### PR TITLE
Add initial version of Makefile and CI configurations

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,39 @@
+name: Go
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [ "1.19.x", "1.20.x" ]
+        include:
+          - go: 1.20.x
+            latest: true
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go }}
+
+      - name: Load cached dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Build
+        run: make build
+
+      - name: Test and generate coverage report
+        run: make cover

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ go.work
 # IntelliJ files
 .idea/
 
+# Coverage files
+cover.out cover.html
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: build
+build:
+	go build ./...
+
+.PHONY: test
+test:
+	go test -race ./...
+
+.PHONY: cover
+cover:
+	go test -v -race -coverprofile=cover.out -coverpkg=./... -v ./...
+	go tool cover -html=cover.out -o cover.html

--- a/nilaway_test.go
+++ b/nilaway_test.go
@@ -15,6 +15,7 @@
 package nilaway
 
 import (
+	"os"
 	"testing"
 
 	"go.uber.org/nilaway/config"
@@ -209,4 +210,5 @@ func TestGenerics(t *testing.T) {
 
 func TestMain(m *testing.M) {
 	config.IsTestEnvironment = true
+	os.Exit(m.Run())
 }


### PR DESCRIPTION
This PR adds a simple Makefile for building, testing, and generating coverage report for NilAway. Moreover, initial CI configurations (Github Actions) are added to run tests on each commit and PR.

A simple fix in `nilaway_test.go` is also included which prevented main test suites from running.