### PR TITLE
Nilaway backprop with postorder traversal

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -26,12 +26,14 @@ import (
 // to disable the pretty printing used in error reporting.
 var IsTestEnvironment = false
 
-// LoopTolerance is an extra padding on the number of rounds that we request the FullTriggers
-// from Assertion Tree backpropagation to be stable for before declaring that we've reached a fixed
-// point. If this is set to n - then loops of length n CFG blocks are guaranteed to be fully stabilized
-// by the time we terminate but loops of length n+1 are not. In practice, this does not seem to be a major
-// issue - but we can investigate more.
-const LoopTolerance = 5
+// StableRoundLimit is the number of rounds in backpropagation algorithm after which, if there is no change
+// in the collected triggers, the algorithm halts. It is possible to carefully craft known false negative for any value
+// of StableRoundLimit (check test loopflow.go/longRotNilLoop). Setting this value too low may result in false negatives
+// going undetected, while setting it too high may lead to longer analysis times without significant precision gains.
+// In practice, a value of StableRoundLimit >= 2 has shown to provide sound analysis, capturing most false negatives.
+// After experimentation, we observed that using StableRoundLimit = 5 with NilAway yields similar analysis time compared
+// to lower values, making it a good compromise for precise results.
+const StableRoundLimit = 5
 
 // BackpropTimeout is the timeout set for analysis of each function. This ensures build time SLAs.
 // NilAway should report an error if this timeout is ever hit, in order not to silently ignore any

--- a/testdata/src/go.uber.org/loopflow/loopflow.go
+++ b/testdata/src/go.uber.org/loopflow/loopflow.go
@@ -79,3 +79,34 @@ func infiniteAssertion() {
 		a = a.f //want "nilable value passed to a field access"
 	}
 }
+
+// This is a known false negative. The analysis can be sound in this case if config.StableRoundLimit >= 9. However, that
+// would result in degradation of NilAway performance. In practice, we haven't observed a case similar to this, and
+// config.StableRoundLimit >= 2 is mostly sufficient for soundness.
+// Similar large test that is a false negative can be constructed for any value of config.StableRoundLimit, is currently
+// a known limitation of NilAway.
+func longRotNilLoop(i int) struct{} {
+	var j0 *struct{} = nil
+	j1 := new(struct{})
+	j2 := new(struct{})
+	j3 := new(struct{})
+	j4 := new(struct{})
+	j5 := new(struct{})
+	j6 := new(struct{})
+	j7 := new(struct{})
+	j8 := new(struct{})
+	j9 := new(struct{})
+	for dummyBool() {
+		j9 = j8
+		j8 = j7
+		j7 = j6
+		j6 = j5
+		j5 = j4
+		j4 = j3
+		j3 = j2
+		j2 = j1
+		j1 = j0
+	}
+	// j9 is nilable and thus this is a false negative
+	return *j9
+}


### PR DESCRIPTION
The backpropagation algorithm converges faster if the CFG blocks are traversed in postorder, compared to the random order [Kam, Ullman 76'](https://dl.acm.org/doi/10.1145/321921.321938).

`StableRoundLimit` is the number of rounds in backpropagation algorithm after which, if there is no change in the collected triggers, the algorithm halts. In practice, we observed `StableRoundLimit = 2`, is sufficient for sound analysis. However, it is possible to carefully craft known false negative for any value of StableRoundLimit (check test loopflow.go/longRotNilLoop).

