### PR TITLE
Add golangci-lint as a linting task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,14 +7,33 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        name: Check out repository
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.20.x
+          cache: false
+
+      - uses: golangci/golangci-lint-action@v3
+        name: Install golangci-lint
+        with:
+          version: latest
+          args: --version
+
+      - run: make lint
+        name: Lint
+
+  test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         go: [ "1.19.x", "1.20.x" ]
-        include:
-          - go: 1.20.x
-            latest: true
     steps:
       - uses: actions/checkout@v3
 
@@ -22,6 +41,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go }}
+          cache: true
 
       - name: Load cached dependencies
         uses: actions/cache@v3

--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,8 @@ go.work
 .idea/
 
 # Coverage files
-cover.out cover.html
+cover.out
+cover.html
 
+# Local binary folder
+bin/

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,16 @@
+issues:
+  # Print all issues reported by all linters.
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+  # Don't ignore some of the issues that golangci-lint considers okay.
+  exclude-use-default: false
+
+linters:
+  enable:
+    - gofmt
+    - goimports
+    - nolintlint
+    - paralleltest
+    - revive
+    - staticcheck

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,41 @@
+# Set up GOBIN so that our binaries are installed to ./bin instead of $GOPATH/bin.
+PROJECT_ROOT = $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+export GOBIN = $(PROJECT_ROOT)/bin
+
+GOLANGCI_LINT_VERSION := $(shell golangci-lint --version 2>/dev/null)
+
+.PHONY: all
+all: build lint test
+
 .PHONY: build
 build:
-	go build ./...
+	go install go.uber.org/nilaway/cmd/nilaway
 
 .PHONY: test
 test:
-	go test -race ./...
+	go test -v -race ./...
 
 .PHONY: cover
 cover:
 	go test -v -race -coverprofile=cover.out -coverpkg=./... -v ./...
 	go tool cover -html=cover.out -o cover.html
+
+.PHONY: lint
+lint: golangci-lint tidy-lint
+
+.PHONY: golangci-lint
+golangci-lint:
+ifdef GOLANGCI_LINT_VERSION
+	@echo "[lint] $(GOLANGCI_LINT_VERSION)"
+else
+	$(error "golangci-lint not found, please install it from https://golangci-lint.run/usage/install/#local-installation")
+endif
+	@echo "[lint] golangci-lint run"
+	@golangci-lint run
+
+.PHONY: tidy-lint
+tidy-lint:
+	@echo "[lint] go mod tidy"
+	@go mod tidy && \
+		git diff --exit-code -- go.mod go.sum || \
+		(echo "'go mod tidy' changed files" && false)

--- a/accumulation/analyzer.go
+++ b/accumulation/analyzer.go
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package accumulation coordinates the entire workflow and collects the annotations, full triggers,
+// and then runs inference to generate and return all potential diagnostics for upper-level
+// analyzers to report.
 package accumulation
 
 import (

--- a/annotation/doc.go
+++ b/annotation/doc.go
@@ -1,0 +1,17 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package annotation implements annotation-related structs (site, maps, triggers) and methods. It
+// also implements the annotation analyzer that reads the manually-provided annotations.
+package annotation

--- a/annotation/key.go
+++ b/annotation/key.go
@@ -147,7 +147,7 @@ func (pk ParamAnnotationKey) MinimalString() string {
 // ParamNameString returns the name of theis parameter, if named, or a placeholder string otherwise
 func (pk ParamAnnotationKey) ParamNameString() string {
 	if pk.ParamName() != nil {
-		return fmt.Sprintf("%s", pk.ParamName().Name())
+		return pk.ParamName().Name()
 	}
 	return fmt.Sprintf("<unnamed param %d>", pk.ParamNum)
 }
@@ -242,8 +242,8 @@ type RetFieldAnnotationKey struct {
 	FieldDecl *types.Var
 }
 
-// Lookup looks this key up in the passed map, returning a Val
-func (rf RetFieldAnnotationKey) Lookup(annMap Map) (Val, bool) {
+// Lookup looks this key up in the passed map, returning a Val.
+func (rf RetFieldAnnotationKey) Lookup(_ Map) (Val, bool) {
 	return nonAnnotatedDefault, false
 }
 
@@ -286,7 +286,7 @@ type EscapeFieldAnnotationKey struct {
 // Lookup looks this key up in the passed map, returning a Val
 // Currently, the annotation key is used only with inference
 // TODO: This should be updated on supporting no-infer with struct initialization
-func (ek EscapeFieldAnnotationKey) Lookup(annMap Map) (Val, bool) {
+func (ek EscapeFieldAnnotationKey) Lookup(_ Map) (Val, bool) {
 	return nonAnnotatedDefault, false
 }
 
@@ -338,7 +338,7 @@ func (pf ParamFieldAnnotationKey) ParamName() *types.Var {
 // Lookup looks this key up in the passed map, returning a Val
 // Currently, the annotation key is used only with inference
 // TODO: This should be updated on supporting no-infer with struct initialization
-func (pf ParamFieldAnnotationKey) Lookup(annMap Map) (Val, bool) {
+func (pf ParamFieldAnnotationKey) Lookup(_ Map) (Val, bool) {
 	return nonAnnotatedDefault, false
 }
 

--- a/assertion/affiliation/affiliation.go
+++ b/assertion/affiliation/affiliation.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package affiliation implements the affliation analyzer that tries to find the concrete
+// implementation of an interface and create full triggers for them.
 package affiliation
 
 import (
@@ -60,7 +62,7 @@ func (a *Affiliation) extractAffiliations(pass *analysis.Pass) {
 
 	// populate upstreamCache by importing entries passed from upstream packages
 	facts := pass.AllPackageFacts()
-	if facts != nil && len(facts) > 0 {
+	if len(facts) > 0 {
 		for _, f := range facts {
 			switch c := f.Fact.(type) {
 			case *AffliliationCache:
@@ -195,7 +197,7 @@ func (a *Affiliation) computeTriggersForCastingSites(pass *analysis.Pass, upstre
 
 					// If the composite is used for initializing an array or a slice, then check for possible
 					// pseudo-assignments through the initialized values of the elements in arrays/slice
-					var elemType types.Type = nil
+					var elemType types.Type
 
 					if slcType, ok := nodeType.(*types.Slice); ok {
 						elemType = slcType.Elem()

--- a/assertion/analyzer.go
+++ b/assertion/analyzer.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package assertion implements a sub-analyzer that collects full triggers from the sub-analyzers
+// and combine them into a list of full triggers for the entire package.
 package assertion
 
 import (

--- a/assertion/anonymousfunc/analyzer.go
+++ b/assertion/anonymousfunc/analyzer.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package anonymousfunc implements a sub-analyzer to analyze anonymous functions in a package.
 package anonymousfunc
 
 import (
@@ -148,7 +149,7 @@ func createFakeFuncDecl(pass *analysis.Pass, funcLit *ast.FuncLit, fakeParams []
 		},
 	}
 	// The list of formal AST parameter nodes (*ast.Field nodes) is extended.
-	fakeFields := make([]*ast.Field, len(fakeParams), len(fakeParams))
+	fakeFields := make([]*ast.Field, len(fakeParams))
 	for i, p := range fakeParams {
 		fakeFields[i] = &ast.Field{
 			// Note that there is no easy way to retrieve the AST nodes for the type of the
@@ -183,7 +184,7 @@ func createFakeFuncDecl(pass *analysis.Pass, funcLit *ast.FuncLit, fakeParams []
 	}
 
 	// Extend the parameter list for the types as well.
-	paramTypes := make([]*types.Var, sig.Params().Len()+len(fakeParams), sig.Params().Len()+len(fakeParams))
+	paramTypes := make([]*types.Var, sig.Params().Len()+len(fakeParams))
 	for i := 0; i < sig.Params().Len(); i++ {
 		paramTypes[i] = sig.Params().At(i)
 	}

--- a/assertion/function/analyzer.go
+++ b/assertion/function/analyzer.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package function implements a sub-analyzer to create full triggers for each function declaration.
 package function
 
 import (

--- a/assertion/function/assertiontree/backprop_util.go
+++ b/assertion/function/assertiontree/backprop_util.go
@@ -745,13 +745,3 @@ func CheckGuardOnFullTrigger(trigger annotation.FullTrigger) annotation.FullTrig
 	}
 	return trigger
 }
-
-func countLiveBlocks(graph *cfg.CFG) int {
-	i := 0
-	for _, block := range graph.Blocks {
-		if block.Live {
-			i++
-		}
-	}
-	return i
-}

--- a/assertion/function/assertiontree/contract.go
+++ b/assertion/function/assertiontree/contract.go
@@ -249,8 +249,9 @@ func RichCheckFromNode(rootNode *RootAssertionNode, nonceGenerator *util.GuardNo
 //     analysis pass before we call ParseExprAsProducer below)
 func parseExpr(rootNode *RootAssertionNode, expr ast.Expr) TrackableExpr {
 	defer func() {
-		// this handles unexpected panics during parsing
-		recover()
+		// This handles unexpected panics during parsing.
+		// TODO: consider removing this hack.
+		_ = recover()
 	}()
 	// this handles being passed the empty expression
 	if util.IsEmptyExpr(expr) {

--- a/assertion/function/assertiontree/fld_assertion_node.go
+++ b/assertion/function/assertiontree/fld_assertion_node.go
@@ -74,7 +74,7 @@ func (f *fldAssertionNode) DefaultTrigger() annotation.ProducingAnnotationTrigge
 }
 
 // BuildExpr for a field node adds that field access to the expression `expr`
-func (f *fldAssertionNode) BuildExpr(pass *analysis.Pass, expr ast.Expr) ast.Expr {
+func (f *fldAssertionNode) BuildExpr(_ *analysis.Pass, expr ast.Expr) ast.Expr {
 	if f.Root() == nil {
 		panic("f.BuildExpr should only be called on nodes present in a valid assertion tree")
 	}

--- a/assertion/function/assertiontree/func_assertion_node.go
+++ b/assertion/function/assertiontree/func_assertion_node.go
@@ -47,7 +47,7 @@ func (f *funcAssertionNode) DefaultTrigger() annotation.ProducingAnnotationTrigg
 }
 
 // BuildExpr for a function node adds that function to `expr` as a method call
-func (f *funcAssertionNode) BuildExpr(pass *analysis.Pass, expr ast.Expr) ast.Expr {
+func (f *funcAssertionNode) BuildExpr(_ *analysis.Pass, expr ast.Expr) ast.Expr {
 	if f.Root() == nil {
 		panic("f.BuildExpr should only be called on nodes present in a valid assertion tree")
 	}

--- a/assertion/function/assertiontree/index_assertion_node.go
+++ b/assertion/function/assertiontree/index_assertion_node.go
@@ -15,7 +15,6 @@
 package assertiontree
 
 import (
-	"fmt"
 	"go/ast"
 	"go/types"
 
@@ -37,7 +36,7 @@ type indexAssertionNode struct {
 }
 
 func (i *indexAssertionNode) MinimalString() string {
-	return fmt.Sprintf("index")
+	return "index"
 }
 
 // DefaultTrigger for an index node is the deep nilability annotation of its parent type
@@ -46,7 +45,7 @@ func (i *indexAssertionNode) DefaultTrigger() annotation.ProducingAnnotationTrig
 }
 
 // BuildExpr for an index node adds that index to `expr`
-func (i *indexAssertionNode) BuildExpr(pass *analysis.Pass, expr ast.Expr) ast.Expr {
+func (i *indexAssertionNode) BuildExpr(_ *analysis.Pass, expr ast.Expr) ast.Expr {
 	return &ast.IndexExpr{
 		X:      expr,
 		Lbrack: 0,

--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -1249,12 +1249,3 @@ rchildloop:
 		left.SetChildren(append(left.Children(), freshrchild))
 	}
 }
-
-// returns a fresh node that's the merge of the two passed nodes
-func (r *RootAssertionNode) mergeNodes(left, right *RootAssertionNode) *RootAssertionNode {
-	fresh := CopyNode(left)
-	r.mergeInto(fresh, right)
-	freshRootAssertionNode := fresh.(*RootAssertionNode)
-
-	return freshRootAssertionNode
-}

--- a/assertion/function/assertiontree/var_assertion_node.go
+++ b/assertion/function/assertiontree/var_assertion_node.go
@@ -78,7 +78,7 @@ func (v *varAssertionNode) DefaultTrigger() annotation.ProducingAnnotationTrigge
 }
 
 // BuildExpr for a varAssertionNode returns the underlying variable's AST node
-func (v *varAssertionNode) BuildExpr(pass *analysis.Pass, expr ast.Expr) ast.Expr {
+func (v *varAssertionNode) BuildExpr(_ *analysis.Pass, _ ast.Expr) ast.Expr {
 	if v.Root() == nil {
 		panic("v.BuildExpr should only be called on nodes present in a valid assertion tree")
 	}

--- a/assertion/function/producer/parsed_producer.go
+++ b/assertion/function/producer/parsed_producer.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package producer contains definitions for parsed producers, which are the result of ParseExprAsProducer.
 package producer
 
 import "go.uber.org/nilaway/annotation"

--- a/assertion/global/analyzer.go
+++ b/assertion/global/analyzer.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package global implements a sub-analyzer to create full triggers for global variables.
 package global
 
 import (

--- a/assertion/global/globalvarinit.go
+++ b/assertion/global/globalvarinit.go
@@ -95,12 +95,12 @@ func getGlobalProducer(pass *analysis.Pass, valspec *ast.ValueSpec, lid int, rid
 			if _, ok := pass.TypesInfo.ObjectOf(ident).(*types.Builtin); ok {
 				return nil
 			}
-			prod = getProducerForFuncCall(pass, ident, lid, rid, prod, rhs)
+			prod = getProducerForFuncCall(pass, ident, lid, rid, rhs)
 		}
 		// Method call
 		if methCall, ok := rhs.Fun.(*ast.SelectorExpr); ok {
 			methName := methCall.Sel
-			prod = getProducerForMethodCall(pass, methName, lid, rid, prod, rhs)
+			prod = getProducerForMethodCall(pass, methName, lid, rid, rhs)
 		}
 	case *ast.Ident:
 		// if rhs is literal nil
@@ -115,7 +115,7 @@ func getGlobalProducer(pass *analysis.Pass, valspec *ast.ValueSpec, lid int, rid
 		}
 	case *ast.SelectorExpr:
 		// Struct field access
-		prod = getProducerForField(pass, rhs.Sel, prod)
+		prod = getProducerForField(pass, rhs.Sel)
 	}
 	return prod
 }
@@ -135,9 +135,9 @@ func getProducerForVar(pass *analysis.Pass, rhs *ast.Ident, prod *annotation.Pro
 	return prod
 }
 
-func getProducerForField(pass *analysis.Pass, rhs *ast.Ident, prod *annotation.ProduceTrigger) *annotation.ProduceTrigger {
+func getProducerForField(pass *analysis.Pass, rhs *ast.Ident) *annotation.ProduceTrigger {
 	rhsVar := pass.TypesInfo.ObjectOf(rhs).(*types.Var)
-	prod = &annotation.ProduceTrigger{
+	prod := &annotation.ProduceTrigger{
 		Annotation: annotation.FldRead{
 			TriggerIfNilable: annotation.TriggerIfNilable{
 				Ann: annotation.FieldAnnotationKey{
@@ -148,7 +148,7 @@ func getProducerForField(pass *analysis.Pass, rhs *ast.Ident, prod *annotation.P
 	return prod
 }
 
-func getProducerForFuncCall(pass *analysis.Pass, methName *ast.Ident, lid int, rid int, prod *annotation.ProduceTrigger, rhs ast.Expr) *annotation.ProduceTrigger {
+func getProducerForFuncCall(pass *analysis.Pass, methName *ast.Ident, lid int, rid int, rhs ast.Expr) *annotation.ProduceTrigger {
 	fdecl, ok := pass.TypesInfo.ObjectOf(methName).(*types.Func)
 
 	// We ignore if the method is anonymous
@@ -160,7 +160,7 @@ func getProducerForFuncCall(pass *analysis.Pass, methName *ast.Ident, lid int, r
 	// In single return function this is `0` and in multiple return function it is `lid`
 	retKey := annotation.RetKeyFromRetNum(fdecl, lid-rid)
 
-	prod = &annotation.ProduceTrigger{
+	prod := &annotation.ProduceTrigger{
 		Annotation: annotation.FuncReturn{
 			TriggerIfNilable: annotation.TriggerIfNilable{Ann: retKey},
 			Guarded:          false,
@@ -170,7 +170,7 @@ func getProducerForFuncCall(pass *analysis.Pass, methName *ast.Ident, lid int, r
 	return prod
 }
 
-func getProducerForMethodCall(pass *analysis.Pass, methName *ast.Ident, lid int, rid int, prod *annotation.ProduceTrigger, rhs ast.Expr) *annotation.ProduceTrigger {
+func getProducerForMethodCall(pass *analysis.Pass, methName *ast.Ident, lid int, rid int, rhs ast.Expr) *annotation.ProduceTrigger {
 	mdecl, ok := pass.TypesInfo.ObjectOf(methName).(*types.Func)
 
 	// We ignore if the method is anonymous
@@ -182,7 +182,7 @@ func getProducerForMethodCall(pass *analysis.Pass, methName *ast.Ident, lid int,
 	// In single return function this is `0` and in multiple return function it is `lid`
 	retKey := annotation.RetKeyFromRetNum(mdecl, lid-rid)
 
-	prod = &annotation.ProduceTrigger{
+	prod := &annotation.ProduceTrigger{
 		Annotation: annotation.MethodReturn{
 			TriggerIfNilable: annotation.TriggerIfNilable{Ann: retKey},
 		},

--- a/assertion/structfield/analyzer.go
+++ b/assertion/structfield/analyzer.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package structfield implements a sub-analyzer that collects struct fields accessed within a
+// function to aid the analysis of the main function analyzer.
 package structfield
 
 import (

--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package config implements the configurations for NilAway.
 package config
 
 import (

--- a/inference/engine.go
+++ b/inference/engine.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package inference implements the inference algorithm in NilAway to automatically infer the
+// nilability of the annotation sites.
 package inference
 
 import (
@@ -184,9 +186,7 @@ func (e *Engine) ObservePackage(pkgFullTriggers []annotation.FullTrigger) {
 
 	// remove deleted triggers from nonErrRetTriggers
 	for _, t := range delTriggers {
-		if _, ok := nonErrRetTriggers[t]; ok {
-			delete(nonErrRetTriggers, t)
-		}
+		delete(nonErrRetTriggers, t)
 	}
 
 	// Step 3: run the inference building process for only the remaining UseAsNonErrorRetDependentOnErrorRetNilability triggers, and collect assertions
@@ -391,7 +391,7 @@ func (e *Engine) observeImplication(
 // The called function RegisterName maintains an internal mapping to ensure that the
 // association between names and structs is bijective
 func GobRegister() {
-	var curr rune = 0
+	var curr rune
 	nextStr := func() string {
 		out := string(curr)
 		curr++

--- a/inference/explained_bool.go
+++ b/inference/explained_bool.go
@@ -16,7 +16,6 @@ package inference
 
 import (
 	"fmt"
-	"go/types"
 )
 
 // An ExplainedBool is a boolean value, wrapped by a "reason" that we came to the conclusion it should
@@ -154,16 +153,4 @@ type FalseBecauseMyopia struct {
 
 func (f FalseBecauseMyopia) String() string {
 	return fmt.Sprintf("NONNIL because myopic annotation inference for package %s decided so", f.PkgName)
-}
-
-func boolAsMyopia(b bool, pkg *types.Package) ExplainedBool {
-	pkgName := pkg.Name()
-	if b {
-		return TrueBecauseMyopia{
-			PkgName: pkgName,
-		}
-	}
-	return FalseBecauseMyopia{
-		PkgName: pkgName,
-	}
 }

--- a/inference/inferred_map.go
+++ b/inference/inferred_map.go
@@ -90,7 +90,6 @@ func (i *InferredMap) Load(site primitiveSite) (value InferredVal, ok bool) {
 // StoreDetermined sets the inferred value for an annotation site.
 func (i *InferredMap) StoreDetermined(site primitiveSite, value ExplainedBool) {
 	i.mapping[site] = &DeterminedVal{Bool: value}
-	return
 }
 
 // StoreImplication stores an implication edge between the `from` and `to` annotation sites in the
@@ -179,11 +178,8 @@ func (i *InferredMap) GobDecode(input []byte) error {
 	dec := gob.NewDecoder(buf)
 
 	i.mapping, i.upstreamMapping = make(map[primitiveSite]InferredVal), make(map[primitiveSite]InferredVal)
-	if err := dec.Decode(&i.mapping); err != nil {
-		return err
-	}
 
-	return nil
+	return dec.Decode(&i.mapping)
 }
 
 // chooseSitesToExport returns the set of AnnotationSites mapped by this InferredMap that are both

--- a/inference/inferred_value.go
+++ b/inference/inferred_value.go
@@ -115,9 +115,9 @@ func (e *UndeterminedVal) isInferredVal() {}
 // Summarizing output behavior: if `new` does not supersede `old`, the function panics
 // if `new` strictly supersedes `old`, (diff, true) is returned
 // if `new` offers the same information as `old`, (garbage, false) is returned.
-func inferredValDiff(new, old InferredVal) (InferredVal, bool) {
+func inferredValDiff(newVal, oldVal InferredVal) (InferredVal, bool) {
 	noSupersede := func() {
-		panic(fmt.Sprintf("ERROR: new value %s does not supersede old value %s", new, old))
+		panic(fmt.Sprintf("ERROR: new value %s does not supersede old value %s", newVal, oldVal))
 	}
 
 	sitesWithAssertionsDiff := func(new, old SitesWithAssertions) (SitesWithAssertions, bool) {
@@ -132,29 +132,29 @@ func inferredValDiff(new, old InferredVal) (InferredVal, bool) {
 		return diff, diffNonempty
 	}
 
-	switch new := new.(type) {
+	switch val := newVal.(type) {
 	case *DeterminedVal:
-		switch old := old.(type) {
+		switch old := oldVal.(type) {
 		case *DeterminedVal:
-			if new.Bool.Val() != old.Bool.Val() {
+			if val.Bool.Val() != old.Bool.Val() {
 				noSupersede()
 			}
 			return nil, false
 		case *UndeterminedVal:
-			return new, true
+			return val, true
 		}
 	case *UndeterminedVal:
-		switch old := old.(type) {
+		switch old := oldVal.(type) {
 		case *DeterminedVal:
 			noSupersede()
 		case *UndeterminedVal:
-			implicants, implicantsDiffs := sitesWithAssertionsDiff(new.Implicants, old.Implicants)
-			implicates, implicatesDiffs := sitesWithAssertionsDiff(new.Implicates, old.Implicates)
+			implicants, implicantsDiffs := sitesWithAssertionsDiff(val.Implicants, old.Implicants)
+			implicates, implicatesDiffs := sitesWithAssertionsDiff(val.Implicates, old.Implicates)
 			return &UndeterminedVal{
 				Implicants: implicants,
 				Implicates: implicates,
 			}, implicantsDiffs || implicatesDiffs
 		}
 	}
-	panic(fmt.Sprintf("ERROR: unrecognized InferredAnnotationVals: %T, %T", new, old))
+	panic(fmt.Sprintf("ERROR: unrecognized InferredAnnotationVals: %T, %T", newVal, oldVal))
 }

--- a/nilaway.go
+++ b/nilaway.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package nilaway implements the top-level analyzer that simply retrieves the diagnostics from
+// the accumulation analyzer and reports them.
 package nilaway
 
 import (

--- a/util/util.go
+++ b/util/util.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package util implements utility functions for AST and types.
 package util
 
 import (


### PR DESCRIPTION
This PR adds `golangci-lint` as a linting task in makefile, as well as adding a separate parallel linting step in the Github Actions.

As a result of this, this PR adds a lot of functionally-equivalent fixes to the codebase (dead code removals, better handlings, removals of unnecessary guardings etc.).