### PR TITLE
Parse function contracts

### DIFF
--- a/assertion/function/analyzer_test.go
+++ b/assertion/function/analyzer_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/nilaway/assertion/anonymousfunc"
 	"go.uber.org/nilaway/assertion/function/assertiontree"
+	"go.uber.org/nilaway/assertion/function/functioncontracts"
 	"go.uber.org/nilaway/config"
 	"golang.org/x/tools/go/analysis/analysistest"
 	"golang.org/x/tools/go/analysis/passes/ctrlflow"
@@ -64,7 +65,9 @@ func TestTimeout(t *testing.T) {
 	// effect.
 	emptyFuncLitMap := make(map[*ast.FuncLit]*anonymousfunc.FuncLitInfo)
 	emptyPkgFakeIdentMap := make(map[*ast.Ident]types.Object)
-	funcContext := assertiontree.NewFunctionContext(pass, funcDecl, nil /* funcLit */, funcConfig, emptyFuncLitMap, emptyPkgFakeIdentMap)
+	emptyFuncContracts := make(functioncontracts.Map)
+	funcContext := assertiontree.NewFunctionContext(pass, funcDecl, nil, /* funcLit */
+		funcConfig, emptyFuncLitMap, emptyPkgFakeIdentMap, emptyFuncContracts)
 	// (3) Set up synchronization and communication for the goroutine we are going to spawn.
 	resultChan := make(chan functionResult)
 	wg := new(sync.WaitGroup)

--- a/assertion/function/assertiontree/backprop.go
+++ b/assertion/function/assertiontree/backprop.go
@@ -742,7 +742,8 @@ func computePostOrder(blocks []*cfg.Block) []int {
 // BackpropAcrossFunc is the main driver of the backpropagation, it takes a function declaration
 // with accompanying CFG, and back-propagates a tree of assertions across it to generate, at entry
 // to the function, the set of assertions that must hold to avoid possible nil flow errors.
-func BackpropAcrossFunc(ctx context.Context, pass *analysis.Pass, decl *ast.FuncDecl, functionContext FunctionContext, graph *cfg.CFG) ([]annotation.FullTrigger, error) {
+func BackpropAcrossFunc(ctx context.Context, pass *analysis.Pass, decl *ast.FuncDecl,
+	functionContext FunctionContext, graph *cfg.CFG) ([]annotation.FullTrigger, error) {
 	// We transform the CFG to have it reflect the implicit control flow that happens
 	// inside short-circuiting boolean expressions.
 	graph, richCheckBlocks, exprNonceMap := preprocess(graph, functionContext)

--- a/assertion/function/assertiontree/function_context.go
+++ b/assertion/function/assertiontree/function_context.go
@@ -19,7 +19,7 @@ import (
 	"go/types"
 
 	"go.uber.org/nilaway/assertion/anonymousfunc"
-
+	"go.uber.org/nilaway/assertion/function/functioncontracts"
 	"go.uber.org/nilaway/config"
 	"golang.org/x/tools/go/analysis"
 )
@@ -61,6 +61,9 @@ type FunctionContext struct {
 
 	// functionConfig contains the user set configuration for analyzing a function
 	functionConfig FunctionConfig
+
+	// funcContracts stores the function contracts of all the functions.
+	funcContracts functioncontracts.Map
 }
 
 // FunctionConfig is meant to hold all the user set configuration for analyzing a function
@@ -79,6 +82,7 @@ func NewFunctionContext(
 	functionConfig FunctionConfig,
 	funcLitMap map[*ast.FuncLit]*anonymousfunc.FuncLitInfo,
 	pkgFakeIdentMap map[*ast.Ident]types.Object,
+	funcContracts functioncontracts.Map,
 ) FunctionContext {
 	return FunctionContext{
 		pass:                    pass,
@@ -89,6 +93,7 @@ func NewFunctionContext(
 		functionConfig:          functionConfig,
 		funcLitMap:              funcLitMap,
 		pkgFakeIdentMap:         pkgFakeIdentMap,
+		funcContracts:           funcContracts,
 	}
 }
 

--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -49,6 +49,12 @@ type RootAssertionNode struct {
 	functionContext FunctionContext
 }
 
+// HasContract returns if the given function has any contracts.
+func (r *RootAssertionNode) HasContract(funcObj *types.Func) bool {
+	_, ok := r.functionContext.funcContracts[funcObj]
+	return ok
+}
+
 // MinimalString for a RootAssertionNode returns a minimal string representation of that root node
 func (r *RootAssertionNode) MinimalString() string {
 	return fmt.Sprintf("root<func: %s>", r.functionContext.funcDecl.Name)

--- a/assertion/function/assertiontree/util.go
+++ b/assertion/function/assertiontree/util.go
@@ -371,7 +371,8 @@ func CopyNode(node AssertionNode) AssertionNode {
 		fresh = &RootAssertionNode{
 			triggers:        append(make([]annotation.FullTrigger, 0), node.triggers...),
 			exprNonceMap:    node.exprNonceMap,
-			functionContext: node.functionContext}
+			functionContext: node.functionContext,
+		}
 	case *varAssertionNode:
 		fresh = &varAssertionNode{decl: node.decl}
 	case *fldAssertionNode:

--- a/assertion/function/functioncontracts/analyzer.go
+++ b/assertion/function/functioncontracts/analyzer.go
@@ -1,0 +1,71 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the
+// License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package functioncontracts implements a sub-analyzer to analyze function contracts in a package,
+// i.e., parsing specified function contracts written as special comments before function
+// declarations, or automatically inferring function contracts from the function body.
+package functioncontracts
+
+import (
+	"fmt"
+	"reflect"
+	"runtime/debug"
+
+	"go.uber.org/nilaway/config"
+	"golang.org/x/tools/go/analysis"
+)
+
+const _doc = "Read the contracts of each function in this package, returning the results."
+
+// Result is the result struct for the Analyzer.
+type Result struct {
+	// FunctionContractsMap is the map generated from reading the function contracts in the source
+	// code.
+	FunctionContracts Map
+	// Errors is the slice of errors if errors happened during analysis. We put the errors here as
+	// part of the result of this sub-analyzer so that the upper-level analyzers can decide what
+	// to do with them.
+	Errors []error
+}
+
+// Analyzer here is the analyzer than reads function contracts
+var Analyzer = &analysis.Analyzer{
+	Name:       "nilaway_function_contracts_analyzer",
+	Doc:        _doc,
+	Run:        run,
+	ResultType: reflect.TypeOf((*Result)(nil)).Elem(),
+}
+
+func run(pass *analysis.Pass) (result interface{}, _ error) {
+	// As a last resort, we recover from a panic when running the analyzer, convert the panic to
+	// an error and return.
+	defer func() {
+		if r := recover(); r != nil {
+			// Deferred functions are executed after a result is generated, so here we modify the
+			// return value `result` in-place.
+			e := fmt.Errorf("INTERNAL PANIC: %s\n%s", r, string(debug.Stack()))
+			if retResult, ok := result.(Result); ok {
+				retResult.FunctionContracts = Map{}
+				retResult.Errors = append(retResult.Errors, e)
+			} else {
+				result = Result{FunctionContracts: Map{}, Errors: []error{e}}
+			}
+		}
+	}()
+
+	if !config.PackageIsInScope(pass.Pkg) {
+		return Result{FunctionContracts: Map{}}, nil
+	}
+
+	return Result{FunctionContracts: collectFunctionContracts(pass)}, nil
+}

--- a/assertion/function/functioncontracts/analyzer_test.go
+++ b/assertion/function/functioncontracts/analyzer_test.go
@@ -1,0 +1,58 @@
+package functioncontracts
+
+import (
+	"fmt"
+	"go/types"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestAnalyzer(t *testing.T) {
+	t.Parallel()
+
+	testdata := analysistest.TestData()
+
+	r := analysistest.Run(t, testdata, Analyzer, "go.uber.org/functioncontracts")
+	require.Equal(t, 1, len(r))
+	require.NotNil(t, r[0])
+
+	pass, result := r[0].Pass, r[0].Result
+	require.IsType(t, Result{}, result)
+	funcContractsMap := result.(Result).FunctionContracts
+
+	require.NotNil(t, funcContractsMap)
+
+	actualNameToContracts := map[*types.Func][]*FunctionContract{}
+	for funcObj, contracts := range funcContractsMap {
+		actualNameToContracts[funcObj] = contracts
+	}
+
+	var getFuncObj = func(name string) *types.Func {
+		return pass.Pkg.Scope().Lookup(name).(*types.Func)
+	}
+	expectedNameToContracts := map[*types.Func][]*FunctionContract{
+		getFuncObj("f1"): {
+			&FunctionContract{Ins: []ContractVal{NonNil}, Outs: []ContractVal{NonNil}},
+		},
+		getFuncObj("f2"): {
+			&FunctionContract{Ins: []ContractVal{NonNil}, Outs: []ContractVal{True}},
+		},
+		getFuncObj("f3"): {
+			&FunctionContract{Ins: []ContractVal{NonNil}, Outs: []ContractVal{False}},
+		},
+		getFuncObj("multipleValues"): {
+			&FunctionContract{Ins: []ContractVal{Any, NonNil}, Outs: []ContractVal{NonNil, True}},
+		},
+		getFuncObj("multipleContracts"): {
+			&FunctionContract{Ins: []ContractVal{Any, NonNil}, Outs: []ContractVal{NonNil, True}},
+			&FunctionContract{Ins: []ContractVal{NonNil, Any}, Outs: []ContractVal{NonNil, True}},
+		},
+		// function contractCommentInOtherLine should not exist in the map as it has no contract.
+	}
+	if diff := cmp.Diff(expectedNameToContracts, actualNameToContracts); diff != "" {
+		require.Fail(t, fmt.Sprintf("parsed contracts mismatch (-want +got):\n%s", diff))
+	}
+}

--- a/assertion/function/functioncontracts/function_contracts_map.go
+++ b/assertion/function/functioncontracts/function_contracts_map.go
@@ -1,0 +1,128 @@
+package functioncontracts
+
+import (
+	"fmt"
+	"go/ast"
+	"go/types"
+	"regexp"
+	"strings"
+
+	"go.uber.org/nilaway/config"
+	"golang.org/x/tools/go/analysis"
+)
+
+// ContractVal represents the possible value appearing in a function contract.
+type ContractVal string
+
+const (
+	// NonNil has keyword "nonnil".
+	NonNil ContractVal = "nonnil"
+	// False has keyword "false".
+	False ContractVal = "false"
+	// True has keyword "true".
+	True ContractVal = "true"
+	// Any has keyword "_".
+	Any ContractVal = "_"
+)
+
+// stringToContractVal converts a keyword string into the corresponding function ContractVal.
+func stringToContractVal(keyword string) ContractVal {
+	switch keyword {
+	case "nonnil":
+		return NonNil
+	case "false":
+		return False
+	case "true":
+		return True
+	case "_":
+		return Any
+	default:
+		// TODO: The ideal way to handle this is to keep track of this contract parsing error and
+		//  move on to the other contracts. But this may also require some refactoring of other
+		//  parts (we do not currently handle partial recoveries anyways)
+		panic("Unexpected keyword for ContractVal: " + keyword)
+	}
+}
+
+const _sep = ","
+const _contractKeyword = "contract"
+const _contractValKeyword = NonNil + "|" + False + "|" + True + "|" + Any
+
+// _contractRE matches multiple function contracts in the same line. Each contract looks like
+// `contract(VALUE(,VALUE)+ -> VALUE(,VALUE)+)`. The RE also captures two lists of VALUEs,
+// i.e., the part before and after `->` for each contract.
+// Note that we match start and end of the line here and add a non-capturing group for the entire
+// contract, and we disallow anything else except whitespace to appear between contracts, so we
+// acknowledge only the contracts written in their own line.
+var _contractRE = regexp.MustCompile(
+	fmt.Sprintf("^\\s*//\\s*(?:\\s*%s\\s*\\(\\s*((?:%s)(?:\\s*,\\s*(?:%s))*)\\s*->\\s*((?:%s)(?:\\s*,\\s*(?:%s))*)\\s*\\)\\s*)+$",
+		_contractKeyword, _contractValKeyword, _contractValKeyword, _contractValKeyword, _contractValKeyword))
+
+// FunctionContract represents a function contract.
+type FunctionContract struct {
+	Ins  []ContractVal
+	Outs []ContractVal
+}
+
+// Map stores the mappings from *types.Func to associated function contracts.
+type Map map[*types.Func][]*FunctionContract
+
+// collectFunctionContracts collects all the function contracts and returns a map that associates
+// every function with its contracts if it has any. One function can have multiple contracts.
+func collectFunctionContracts(pass *analysis.Pass) Map {
+	m := Map{}
+	for _, file := range pass.Files {
+		if !config.FileIsInScope(file) {
+			continue
+		}
+		for _, decl := range file.Decls {
+			funcDecl, ok := decl.(*ast.FuncDecl)
+			if !ok || funcDecl.Doc == nil {
+				// Ignore any non-function declaration or the function has no comment
+				// TODO: If we want to support contracts for anonymous function (function
+				//  literals) in the future, then we need to handle more types here.
+				continue
+			}
+			funcObj := pass.TypesInfo.ObjectOf(funcDecl.Name).(*types.Func)
+			if funcContracts := parseContractsForSingleFunction(funcDecl.Doc); len(funcContracts) != 0 {
+				m[funcObj] = funcContracts
+			}
+		}
+	}
+	return m
+}
+
+// parseContractsForSingleFunction parses a slice of function contracts from a singe comment group.
+// If no contract is found from the comment group, an empty slice is returned.
+func parseContractsForSingleFunction(doc *ast.CommentGroup) []*FunctionContract {
+	contracts := make([]*FunctionContract, 0)
+	for _, lineComment := range doc.List {
+		res := _contractRE.FindAllStringSubmatch(lineComment.Text, -1)
+		if res == nil {
+			continue
+		}
+		for _, matching := range res {
+			// matching is a slice of three elements; the first is the whole matched string and the
+			// next two are the captured groups of contract values before and after `->`.
+			ins := parseListOfContractValues(matching[1])
+			outs := parseListOfContractValues(matching[2])
+			ctrt := &FunctionContract{
+				Ins:  ins,
+				Outs: outs,
+			}
+			contracts = append(contracts, ctrt)
+		}
+	}
+	return contracts
+}
+
+// parseListOfContractValues splits a string of comma separated contract value keywords and returns
+// a slice of ContractVal.
+func parseListOfContractValues(wholeStr string) []ContractVal {
+	valKeywords := strings.Split(wholeStr, _sep)
+	contractVals := make([]ContractVal, len(valKeywords))
+	for i, v := range valKeywords {
+		contractVals[i] = stringToContractVal(strings.TrimSpace(v))
+	}
+	return contractVals
+}

--- a/assertion/function/functioncontracts/testdata/src/go.uber.org/functioncontracts/main.go
+++ b/assertion/function/functioncontracts/testdata/src/go.uber.org/functioncontracts/main.go
@@ -1,0 +1,55 @@
+/*
+Test functionality of parsing function contracts.
+*/
+package functioncontracts
+
+// contract(nonnil -> nonnil)
+func f1(x *int) *int {
+	if x == nil {
+		return x
+	}
+	return new(int)
+}
+
+// contract(nonnil -> true)
+func f2(x *int) bool {
+	if x == nil {
+		return false
+	}
+	return true
+}
+
+// contract(nonnil -> false)
+func f3(x *int) bool {
+	if x == nil {
+		return true
+	}
+	return false
+}
+
+// contract(_, nonnil -> nonnil, true)
+func multipleValues(key string, deft *int) (*int, bool) {
+	m := map[string]*int{}
+	x, _ := m[key]
+	if x != nil {
+		return x, true
+	}
+	if deft != nil {
+		return deft, true
+	}
+	return nil, false
+}
+
+// contract(_, nonnil -> nonnil, true)
+// contract(nonnil, _ -> nonnil, true)
+func multipleContracts(x *int, y *int) (*int, bool) {
+	if x == nil && y == nil {
+		return nil, false
+	}
+	return new(int), true
+}
+
+// This contract `// contract(nonnil -> nonnil)` does not hold for the function because the
+// function has no param or return. Only a contract in its own line should be parsed, not even `//
+// contract(nonnil -> nonnil)`.
+func contractCommentInOtherLine() {}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module go.uber.org/nilaway
 go 1.20
 
 require (
+	github.com/google/go-cmp v0.5.9
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1
 	golang.org/x/tools v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=


### PR DESCRIPTION
This PR supports parsing line comments before function declarations as contracts.

### Design

The line comment must contain one or more contracts but nothing else. The following two comments are not parsed as function contracts.
```go
// if we have `// contract(nonnil->nonnil)`
foo(...)...
```
```go
// ...when we have `//
// contract(nonnil->nonnil)`.
foo(...)...
```
A single contract must follow synatx as follows:
```
contract(VALUE[,VALUE]+ -> VALUE[,VALUE]+)
```
`VALUE` must be one of `nonnil`, `true`, `false`, `_`, and whitespaces are allowed between any two tokens.

### Implementation

Create a new analyzer that is a prerequisite of the existing function analyzer.

### Test Plan
Functional:
- A new analyzer_test is added.
- Sanity checking CI job should pass.

Performance:
- Tested in the last pull request of the stack, i.e., nonnil->nonnil no infer mode.