### PR TITLE
Add logic for error suppression and passing configs in the standalone driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ cover.html
 
 # Local binary folder
 bin/
+
+# Local build folder for storing build artifacts
+build/
+

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ cover:
 	go tool cover -html=cover.out -o cover.html
 
 .PHONY: lint
-lint: golangci-lint tidy-lint
+lint: golangci-lint nilaway-lint tidy-lint
 
 .PHONY: golangci-lint
 golangci-lint:
@@ -39,3 +39,8 @@ tidy-lint:
 	@go mod tidy && \
 		git diff --exit-code -- go.mod go.sum || \
 		(echo "'go mod tidy' changed files" && false)
+
+.PHONY: nilaway-lint
+nilaway-lint: build
+	@echo "[lint] nilaway linting itself"
+	@$(GOBIN)/nilaway -include-pkgs="go.uber.org/nilaway" ./...

--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ Note that in the above example, `foo` does not necessarily have to reside in the
 to track nil flows across packages as well. Moreover, NilAway handles Go-specific language constructs such as receivers,
 interfaces, type assertions, type switches, and more. For more detailed discussion, please check our paper.
 
+## Configurations
+
+We expose a set of flags via the standard flag passing mechanism in [go/analysis](https://pkg.go.dev/golang.org/x/tools/go/analysis).
+Please check [wiki/Configuration](https://github.com/uber-go/nilaway/wiki/Configuration) to see the available flags and
+how to pass them using different linter drivers.
+
 ## Support 
 
 Please feel free to [open a GitHub issue](https://github.com/uber-go/nilaway/issues) if you have any questions, bug 

--- a/assertion/anonymousfunc/analyzer.go
+++ b/assertion/anonymousfunc/analyzer.go
@@ -106,8 +106,7 @@ func run(pass *analysis.Pass) (result interface{}, _ error) {
 	funcLitMap := make(map[*ast.FuncLit]*FuncLitInfo)
 
 	for _, file := range pass.Files {
-		if util.DocContainsIgnore(file.Doc) || !conf.IsFileInScope(file) ||
-			!util.DocContainsAnonymousFuncCheck(file.Doc) {
+		if !conf.IsFileInScope(file) || !util.DocContainsAnonymousFuncCheck(file.Doc) {
 			continue
 		}
 

--- a/assertion/function/analyzer.go
+++ b/assertion/function/analyzer.go
@@ -130,7 +130,7 @@ func run(pass *analysis.Pass) (result interface{}, _ error) {
 	var funcIndex int
 	for _, file := range pass.Files {
 		// Skip if a file is marked to be ignored, or it is not in scope of our analysis.
-		if util.DocContainsIgnore(file.Doc) || !conf.IsFileInScope(file) {
+		if !conf.IsFileInScope(file) {
 			continue
 		}
 
@@ -189,8 +189,8 @@ func run(pass *analysis.Pass) (result interface{}, _ error) {
 				panic(fmt.Sprintf("unrecognized function type %T", f))
 			}
 
-			// Skip if function declaration has an empty body, or it is marked to be ignored.
-			if funcDecl.Body == nil || util.DocContainsIgnore(funcDecl.Doc) {
+			// Skip if function declaration has an empty body.
+			if funcDecl.Body == nil {
 				continue
 			}
 			// Skip if the function is too large.

--- a/assertion/function/analyzer.go
+++ b/assertion/function/analyzer.go
@@ -138,7 +138,7 @@ func run(pass *analysis.Pass) (result interface{}, _ error) {
 		// on NilAway itself.
 		functionConfig := assertiontree.FunctionConfig{}
 		if strings.HasPrefix(pass.Pkg.Path(), config.NilAwayPkgPathPrefix) { //nolint:revive
-			// TODO: enable struct initialization flag.
+			// TODO: enable struct initialization flag (tracked in Issue #23).
 			// TODO: enable anonymous function flag.
 		} else {
 			functionConfig.StructInitCheckType = util.DocContainsStructInitCheck(file.Doc)

--- a/assertion/function/analyzer.go
+++ b/assertion/function/analyzer.go
@@ -137,9 +137,9 @@ func run(pass *analysis.Pass) (result interface{}, _ error) {
 		// Construct config for analyzing the functions in this file. By default, enable all checks
 		// on NilAway itself.
 		functionConfig := assertiontree.FunctionConfig{}
-		if strings.HasPrefix(pass.Pkg.Path(), config.NilAwayPkgPathPrefix) {
-			functionConfig.StructInitCheckType = config.DepthOneFieldCheck
-			// TODO: enable anonymous function flag here when  is done
+		if strings.HasPrefix(pass.Pkg.Path(), config.NilAwayPkgPathPrefix) { //nolint:revive
+			// TODO: enable struct initialization flag.
+			// TODO: enable anonymous function flag.
 		} else {
 			functionConfig.StructInitCheckType = util.DocContainsStructInitCheck(file.Doc)
 			functionConfig.EnableAnonymousFunc = util.DocContainsAnonymousFuncCheck(file.Doc)

--- a/assertion/global/analyzer.go
+++ b/assertion/global/analyzer.go
@@ -24,7 +24,6 @@ import (
 
 	"go.uber.org/nilaway/annotation"
 	"go.uber.org/nilaway/config"
-	"go.uber.org/nilaway/util"
 	"golang.org/x/tools/go/analysis"
 )
 
@@ -73,7 +72,7 @@ func run(pass *analysis.Pass) (result interface{}, _ error) {
 
 	var fullTriggers []annotation.FullTrigger
 	for _, file := range pass.Files {
-		if util.DocContainsIgnore(file.Doc) || !conf.IsFileInScope(file) {
+		if !conf.IsFileInScope(file) {
 			continue
 		}
 

--- a/assertion/structfield/analyzer.go
+++ b/assertion/structfield/analyzer.go
@@ -23,7 +23,6 @@ import (
 	"runtime/debug"
 
 	"go.uber.org/nilaway/config"
-	"go.uber.org/nilaway/util"
 	"golang.org/x/tools/go/analysis"
 )
 
@@ -73,7 +72,7 @@ func run(pass *analysis.Pass) (result interface{}, _ error) {
 	}
 
 	for _, file := range pass.Files {
-		if util.DocContainsIgnore(file.Doc) || !conf.IsFileInScope(file) {
+		if !conf.IsFileInScope(file) {
 			continue
 		}
 

--- a/cmd/nilaway/main.go
+++ b/cmd/nilaway/main.go
@@ -18,10 +18,105 @@
 package main
 
 import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"go.uber.org/nilaway"
+	"go.uber.org/nilaway/config"
+	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/singlechecker"
 )
 
+// Analyzer is identical to the one in nilaway.go, except that it overrides the run function for
+// extra filtering of errors, since the singlechecker does not support error suppression like other
+// popular linter drivers.
+var Analyzer = &analysis.Analyzer{
+	Name:       nilaway.Analyzer.Name,
+	Doc:        nilaway.Analyzer.Doc,
+	Run:        run,
+	FactTypes:  nilaway.Analyzer.FactTypes,
+	ResultType: nilaway.Analyzer.ResultType,
+	Requires:   nilaway.Analyzer.Requires,
+}
+
+var (
+	// _includeErrorsInFiles is a driver flag for specifying the list of file prefixes to only report errors.
+	_includeErrorsInFiles string
+	// _excludeErrorsInFiles is a driver flag for specifying the list of file prefixes to not report errors.
+	_excludeErrorsInFiles string
+)
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	// NilAway by default analyzes all packages, including dependencies. Even if specified to
+	// exclude packages from analysis via configurations, NilAway can still report errors on
+	// packages that are not analyzed if the nilness flow happens within the analyzed package, but
+	// the flow concerns a struct that is in an excluded package. The usual way to handle them is
+	// to suppress them at the driver level, but singlechecker does not support that yet. Therefore,
+	// here we add extra logic to filter the errors.
+
+	// Properly parse the error suppression flags.
+	var files [2][]string
+	for i, flagVal := range [...]string{_includeErrorsInFiles, _excludeErrorsInFiles} {
+		if flagVal == "" {
+			files[i] = nil
+			continue
+		}
+
+		// Convert the file paths to absolute paths.
+		list := strings.Split(flagVal, ",")
+		for i := range list {
+			p, err := filepath.Abs(list[i])
+			if err != nil {
+				return nil, fmt.Errorf("incorrect file path: %s", list[i])
+			}
+			list[i] = p
+		}
+		files[i] = list
+	}
+	includes, excludes := files[0], files[1]
+
+	// Override the report function to add error filtering logic.
+	report := pass.Report
+	pass.Report = func(d analysis.Diagnostic) {
+		p := pass.Fset.File(d.Pos).Name()
+		for _, e := range excludes {
+			if strings.HasPrefix(p, e) {
+				return
+			}
+		}
+
+		for _, i := range includes {
+			if strings.HasPrefix(p, i) {
+				report(d)
+				return
+			}
+		}
+	}
+
+	// Delegate the real analysis run to the original nilaway analyzer.
+	return nilaway.Analyzer.Run(pass)
+}
+
 func main() {
-	singlechecker.Main(nilaway.Analyzer)
+	// For better UX, we lift the flags from config.Analyzer to the top level so that users can
+	// specify them without having to specify the analyzer name ("nilaway_config").
+	config.Analyzer.Flags.VisitAll(func(f *flag.Flag) {
+		flag.Func(f.Name, f.Usage, func(s string) error {
+			return f.Value.Set(s)
+		})
+	})
+
+	// Add two more flags to the driver for error suppression since singlechecker does not support it.
+	wd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to get working directory: %v\n", err)
+		os.Exit(1)
+	}
+	flag.StringVar(&_includeErrorsInFiles, "include-errors-in-files", wd, "A comma-separated list of file prefixes to report errors, default is current working directory.")
+	flag.StringVar(&_excludeErrorsInFiles, "exclude-errors-in-files", "", "A comma-separated list of file prefixes to exclude from error reporting. This takes precedence over include-errors-in-files.")
+
+	singlechecker.Main(Analyzer)
 }

--- a/config/const.go
+++ b/config/const.go
@@ -26,10 +26,6 @@ const BackpropTimeout = 10 * time.Second
 // considered undesirable behavior and worth catching in the future.
 const ErrorOnNilableMapRead = false
 
-// NilAwayIgnoreString is the string that may be inserted into the docstring for a file (resp. function)
-// to prevent NilAway from generating assertions from that file (resp. function)
-const NilAwayIgnoreString = "nolint:nilaway"
-
 // NilAwayNoInferString is the string that may be inserted into the docstring for a package to prevent
 // NilAway from inferring the annotations for that package - this is useful for unit tests
 const NilAwayNoInferString = "<nilaway no inference>"

--- a/util/util.go
+++ b/util/util.go
@@ -403,11 +403,6 @@ func GetSelectorExprHeadIdent(selExpr *ast.SelectorExpr) *ast.Ident {
 	return nil
 }
 
-// DocContainsIgnore is used by analyzers to check if the file should be ignored by the analyzer.
-func DocContainsIgnore(group *ast.CommentGroup) bool {
-	return docContainsString(config.NilAwayIgnoreString)(group)
-}
-
 // DocContainsStructInitCheck is used by analyzers to check if the struct initialization check enabling string is present
 // in the comments.
 func DocContainsStructInitCheck(group *ast.CommentGroup) config.StructInitCheckType {


### PR DESCRIPTION
This PR adds error suppression logic (since `singlechecker` does not support it) and passing configs (by lifting flags from `config.Analyzer` for better UX) to the standalone checker.

Now it is possible to specify flags for NilAway via

```
nilaway -include-pkgs=go.uber.org -include-errors-in-files=./ ./...
```
such that only packages starting with `go.uber.org` is _analyzed_, and only errors reported in the files within the current directory is _reported_.

Please note the differences between _analyzed_ and _reported_: even if a package is excluded from analysis, errors might still be reported on them if the nilness flows happens within the analyzed package, but it includes using a struct from the excluded package. For example, if the analyzed package constructs a struct from the excluded package, assigns a nil to a field, and then immediately dereferences the field. In this case, NilAway will report an error for this flow, but the location will be on the field (that resides in the excluded package).

By default, the standalone checker sets `-include-errors-in-files` to the current working directory, so NilAway won't report any errors on other packages. For other linter drivers, uses will have to set this through the drivers instead.

The [wiki/Configuration](https://github.com/uber-go/nilaway/wiki/Configuration) is also updated to reflect this change, and a link to the configuration page is added to the top-level README.

This PR also adds another linting task to run NilAway on itself.

Fixes #16.