### PR TITLE
Add codecov step in CI and add badges to README

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,0 +1,14 @@
+coverage:
+  range: 80..100
+  round: down
+  precision: 2
+
+  status:
+    project:                   # measuring the overall project coverage
+      default:                 # context, you can create multiple ones with custom titles
+        enabled: yes           # must be yes|true to enable this status
+        target: auto           # specify the target coverage for each commit status
+                               #   option: "auto" (must increase from parent commit or pull request base)
+                               #   option: "X%" a static target percentage to hit
+        if_not_found: success  # if parent is not found report status as success, error, or failure
+        if_ci_failed: error    # if ci fails report status as success, error, or failure

--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -8,7 +8,8 @@ coverage:
       default:                 # context, you can create multiple ones with custom titles
         enabled: yes           # must be yes|true to enable this status
         target: auto           # specify the target coverage for each commit status
-                               #   option: "auto" (must increase from parent commit or pull request base)
+                               #   option: "auto" (compare against parent commit or pull request base)
                                #   option: "X%" a static target percentage to hit
+        threshold: 5%          # allow the coverage drop by 5% before marking as failure
         if_not_found: success  # if parent is not found report status as success, error, or failure
         if_ci_failed: error    # if ci fails report status as success, error, or failure

--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -10,6 +10,6 @@ coverage:
         target: auto           # specify the target coverage for each commit status
                                #   option: "auto" (compare against parent commit or pull request base)
                                #   option: "X%" a static target percentage to hit
-        threshold: 5%          # allow the coverage drop by 5% before marking as failure
+        threshold: 1%          # allow the coverage drop by 1% before marking as failure (to allow some flakiness)
         if_not_found: success  # if parent is not found report status as success, error, or failure
         if_ci_failed: error    # if ci fails report status as success, error, or failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,3 +57,6 @@ jobs:
 
       - name: Test and generate coverage report
         run: make cover
+
+      - name: Upload coverage to codecov.io
+        uses: codecov/codecov-action@v3

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # NilAway
 
+[![GoDoc][doc-img]][doc] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov]
+
 > [!WARNING]  
 > NilAway is currently under active development: false positives and breaking changes can happen. 
 > We highly appreciate any feedback and contributions!
@@ -106,3 +108,10 @@ our [Uber Contributor License Agreement](https://cla-assistant.io/uber-go/nilawa
 ## License
 
 This project is copyright 2023 Uber Technologies, Inc., and licensed under Apache 2.0.
+
+[doc-img]: https://pkg.go.dev/badge/go.uber.org/nilaway.svg
+[doc]: https://pkg.go.dev/go.uber.org/nilaway
+[ci-img]: https://github.com/uber-go/nilaway/actions/workflows/ci.yml/badge.svg
+[ci]: https://github.com/uber-go/nilaway/actions/workflows/ci.yml
+[cov-img]: https://codecov.io/gh/uber-go/nilaway/branch/main/graph/badge.svg
+[cov]: https://codecov.io/gh/uber-go/nilaway


### PR DESCRIPTION
This PR adds a codecov step in CI configs and add the corresponding badges to README.

We have also added a config file for codecov to fail PRs if the coverage decreases (experimental, we can revert / disable it if it gets too annoying in the future)