### PR TITLE
Run CI builds on all PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 jobs:
   lint:


### PR DESCRIPTION
This PR changes the CI build configs such that CI is run on all PRs, instead of only on PRs that are against the `main` branch. This will allow us to have early CI feedback for stacked PRs.