### PR TITLE
[Follow-up of PR #8 ] Support function contract nonnil->nonnil for full infer mode

### DIFF
--- a/annotation/consume_trigger.go
+++ b/annotation/consume_trigger.go
@@ -500,8 +500,8 @@ func (m MethodParamFromInterfacePrestring) String() string {
 		m.ParamName, m.ImplName, m.IntName)
 }
 
-// DuplicateReturnConsumer duplicates a given consumer trigger, assuming the given consumer trigger
-// is of UseAsReturn.
+// DuplicateReturnConsumer duplicates a given consume trigger, assuming the given consumer trigger
+// is for a UseAsReturn annotation.
 func DuplicateReturnConsumer(t *ConsumeTrigger, location token.Position) *ConsumeTrigger {
 	ann := t.Annotation.(UseAsReturn)
 	key := ann.TriggerIfNonNil.Ann.(RetAnnotationKey)

--- a/annotation/full_trigger.go
+++ b/annotation/full_trigger.go
@@ -37,7 +37,7 @@ type FullTrigger struct {
 	// otherwise the full trigger is deactivated in the inference engine.
 	// If this field is nil, it means the trigger is not a controlled trigger and the trigger will
 	// be activated all the time.
-	Controller *ArgAnnotationKey
+	Controller *CallSiteParamAnnotationKey
 }
 
 // Controlled returns true if this full trigger is controlled by a controller site; otherwise

--- a/annotation/key.go
+++ b/annotation/key.go
@@ -113,7 +113,7 @@ func (ak ArgAnnotationKey) MinimalString() string {
 // ParamNameString returns the name of this parameter, if named, or a placeholder string otherwise
 func (ak ArgAnnotationKey) ParamNameString() string {
 	if ak.ParamName() != nil {
-		return fmt.Sprintf("%s", ak.ParamName().Name())
+		return ak.ParamName().Name()
 	}
 	return fmt.Sprintf("<unnamed param %d>", ak.ParamNum)
 }

--- a/annotation/produce_trigger.go
+++ b/annotation/produce_trigger.go
@@ -373,16 +373,17 @@ func DuplicateParamProducer(t *ProduceTrigger, location token.Position) *Produce
 	return &ProduceTrigger{
 		Annotation: FuncParam{
 			TriggerIfNilable: TriggerIfNilable{
-				Ann: NewArgKey(key.FuncDecl, key.ParamNum, location)}},
+				Ann: NewCallSiteParamKey(key.FuncDecl, key.ParamNum, location)}},
 		Expr: t.Expr,
 	}
 }
 
-// FuncParam is used when a value is determined to flow from a function parameter.
-// This consumer trigger can be used on top of two different sites: ParamAnnotationKey &
-// ArgAnnotationKey. ParamAnnotationKey is the parameter site in the function declaration;
-// ArgAnnotationKey is the argument site in the call expression. ArgAnnotationKey is specifically
-// used for functions with contracts since we need to duplicate the sites for context sensitivity.
+// FuncParam is used when a value is determined to flow from a function parameter. This consumer
+// trigger can be used on top of two different sites: ParamAnnotationKey &
+// CallSiteParamAnnotationKey. ParamAnnotationKey is the parameter site in the function
+// declaration; CallSiteParamAnnotationKey is the argument site in the call expression.
+// CallSiteParamAnnotationKey is specifically used for functions with contracts since we need to
+// duplicate the sites for context sensitivity.
 type FuncParam struct {
 	TriggerIfNilable
 }
@@ -396,10 +397,10 @@ func (f FuncParam) Prestring() Prestring {
 	switch key := f.Ann.(type) {
 	case ParamAnnotationKey:
 		return FuncParamPrestring{key.ParamNameString(), key.FuncDecl.Name(), ""}
-	case ArgAnnotationKey:
+	case CallSiteParamAnnotationKey:
 		return FuncParamPrestring{key.ParamNameString(), key.FuncDecl.Name(), key.Location.String()}
 	default:
-		panic(fmt.Sprintf("Expected ParamAnnotationKey or ArgAnnotationKey but see: %T", key))
+		panic(fmt.Sprintf("Expected ParamAnnotationKey or CallSiteParamAnnotationKey but got: %T", key))
 	}
 }
 
@@ -408,7 +409,7 @@ type FuncParamPrestring struct {
 	ParamName string
 	FuncName  string
 	// Location is empty for a FuncParam enclosing ParamAnnotationKey. Location points to the
-	// location of the argument pass at the call site for a FuncParam enclosing ArgAnnotationKey.
+	// location of the argument pass at the call site for a FuncParam enclosing CallSiteParamAnnotationKey.
 	Location string
 }
 
@@ -602,11 +603,12 @@ func (f ParamFldReadPrestring) String() string {
 	return fmt.Sprintf("of the field `%s` of param %d of `%s`", f.FieldName, f.ParamNum, f.FuncName)
 }
 
-// FuncReturn is used when a value is determined to flow from the return of a function.
-// This consumer trigger can be used on top of two different sites: RetAnnotationKey &
-// ResAnnotationKey. RetAnnotationKey is the parameter site in the function declaration;
-// ResAnnotationKey is the argument site in the call expression. ResAnnotationKey is specifically
-// used for functions with contracts since we need to duplicate the sites for context sensitivity.
+// FuncReturn is used when a value is determined to flow from the return of a function. This
+// consumer trigger can be used on top of two different sites: RetAnnotationKey &
+// CallSiteRetAnnotationKey. RetAnnotationKey is the parameter site in the function declaration;
+// CallSiteRetAnnotationKey is the argument site in the call expression. CallSiteRetAnnotationKey
+// is specifically used for functions with contracts since we need to duplicate the sites for
+// context sensitivity.
 type FuncReturn struct {
 	TriggerIfNilable
 	Guarded bool
@@ -621,10 +623,10 @@ func (f FuncReturn) Prestring() Prestring {
 	switch key := f.Ann.(type) {
 	case RetAnnotationKey:
 		return FuncReturnPrestring{key.RetNum, key.FuncDecl.Name(), ""}
-	case ResAnnotationKey:
+	case CallSiteRetAnnotationKey:
 		return FuncReturnPrestring{key.RetNum, key.FuncDecl.Name(), key.Location.String()}
 	default:
-		panic(fmt.Sprintf("Expected RetAnnotationKey or ResAnnotationKey but see: %T", key))
+		panic(fmt.Sprintf("Expected RetAnnotationKey or CallSiteRetAnnotationKey but got: %T", key))
 	}
 }
 
@@ -633,7 +635,7 @@ type FuncReturnPrestring struct {
 	RetNum   int
 	FuncName string
 	// Location is empty for a FuncReturn enclosing RetAnnotationKey. Location points to the
-	// location of the result return at the call site for a FuncReturn enclosing ResAnnotationKey.
+	// location of the result return at the call site for a FuncReturn enclosing CallSiteRetAnnotationKey.
 	Location string
 }
 

--- a/annotation/produce_trigger.go
+++ b/annotation/produce_trigger.go
@@ -17,7 +17,9 @@ package annotation
 import (
 	"fmt"
 	"go/ast"
+	"go/token"
 	"go/types"
+	"strings"
 
 	"go.uber.org/nilaway/util"
 )
@@ -364,7 +366,23 @@ func (BlankVarReturn) String() string {
 	return "read from a blank variable that can never be assigned to"
 }
 
-// FuncParam is used when a value is determined to flow from a function parameter
+// DuplicateParamProducer duplicates a given consumer trigger, assuming the given produce trigger
+// is of FuncParam.
+func DuplicateParamProducer(t *ProduceTrigger, location token.Position) *ProduceTrigger {
+	key := t.Annotation.(FuncParam).TriggerIfNilable.Ann.(ParamAnnotationKey)
+	return &ProduceTrigger{
+		Annotation: FuncParam{
+			TriggerIfNilable: TriggerIfNilable{
+				Ann: NewArgKey(key.FuncDecl, key.ParamNum, location)}},
+		Expr: t.Expr,
+	}
+}
+
+// FuncParam is used when a value is determined to flow from a function parameter.
+// This consumer trigger can be used on top of two different sites: ParamAnnotationKey &
+// ArgAnnotationKey. ParamAnnotationKey is the parameter site in the function declaration;
+// ArgAnnotationKey is the argument site in the call expression. ArgAnnotationKey is specifically
+// used for functions with contracts since we need to duplicate the sites for context sensitivity.
 type FuncParam struct {
 	TriggerIfNilable
 }
@@ -375,18 +393,33 @@ func (f FuncParam) String() string {
 
 // Prestring returns this FuncParam as a Prestring
 func (f FuncParam) Prestring() Prestring {
-	key := f.Ann.(ParamAnnotationKey)
-	return FuncParamPrestring{key.ParamNameString(), key.FuncDecl.Name()}
+	switch key := f.Ann.(type) {
+	case ParamAnnotationKey:
+		return FuncParamPrestring{key.ParamNameString(), key.FuncDecl.Name(), ""}
+	case ArgAnnotationKey:
+		return FuncParamPrestring{key.ParamNameString(), key.FuncDecl.Name(), key.Location.String()}
+	default:
+		panic(fmt.Sprintf("Expected ParamAnnotationKey or ArgAnnotationKey but see: %T", key))
+	}
 }
 
 // FuncParamPrestring is a Prestring storing the needed information to compactly encode a FuncParam
 type FuncParamPrestring struct {
 	ParamName string
 	FuncName  string
+	// Location is empty for a FuncParam enclosing ParamAnnotationKey. Location points to the
+	// location of the argument pass at the call site for a FuncParam enclosing ArgAnnotationKey.
+	Location string
 }
 
 func (f FuncParamPrestring) String() string {
-	return fmt.Sprintf("read from the function parameter `%s` of function `%s`", f.ParamName, f.FuncName)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("read from the function parameter `%s` of function `%s`",
+		f.ParamName, f.FuncName))
+	if f.Location != "" {
+		sb.WriteString(fmt.Sprintf(" at %s", f.Location))
+	}
+	return sb.String()
 }
 
 // MethodRecv is used when a value is determined to flow from a method receiver
@@ -398,13 +431,13 @@ func (m MethodRecv) String() string {
 	return m.Prestring().String()
 }
 
-// Prestring returns this FuncParam as a Prestring
+// Prestring returns this MethodRecv as a Prestring
 func (m MethodRecv) Prestring() Prestring {
 	key := m.Ann.(RecvAnnotationKey)
 	return MethodRecvPrestring{key.FuncDecl.Name()}
 }
 
-// MethodRecvPrestring is a Prestring storing the needed information to compactly encode a FuncParam
+// MethodRecvPrestring is a Prestring storing the needed information to compactly encode a MethodRecv
 type MethodRecvPrestring struct {
 	FuncName string
 }
@@ -422,13 +455,13 @@ func (m MethodRecvDeep) String() string {
 	return m.Prestring().String()
 }
 
-// Prestring returns this FuncParam as a Prestring
+// Prestring returns this MethodRecv as a Prestring
 func (m MethodRecvDeep) Prestring() Prestring {
 	key := m.Ann.(RecvAnnotationKey)
 	return MethodRecvDeepPrestring{key.FuncDecl.Name()}
 }
 
-// MethodRecvDeepPrestring is a Prestring storing the needed information to compactly encode a FuncParam
+// MethodRecvDeepPrestring is a Prestring storing the needed information to compactly encode a MethodRecv
 type MethodRecvDeepPrestring struct {
 	FuncName string
 }
@@ -569,7 +602,11 @@ func (f ParamFldReadPrestring) String() string {
 	return fmt.Sprintf("of the field `%s` of param %d of `%s`", f.FieldName, f.ParamNum, f.FuncName)
 }
 
-// FuncReturn is used when a value is determined to flow from the return of a function
+// FuncReturn is used when a value is determined to flow from the return of a function.
+// This consumer trigger can be used on top of two different sites: RetAnnotationKey &
+// ResAnnotationKey. RetAnnotationKey is the parameter site in the function declaration;
+// ResAnnotationKey is the argument site in the call expression. ResAnnotationKey is specifically
+// used for functions with contracts since we need to duplicate the sites for context sensitivity.
 type FuncReturn struct {
 	TriggerIfNilable
 	Guarded bool
@@ -581,18 +618,33 @@ func (f FuncReturn) String() string {
 
 // Prestring returns this FuncReturn as a Prestring
 func (f FuncReturn) Prestring() Prestring {
-	retKey := f.Ann.(RetAnnotationKey)
-	return FuncReturnPrestring{retKey.RetNum, retKey.FuncDecl.Name()}
+	switch key := f.Ann.(type) {
+	case RetAnnotationKey:
+		return FuncReturnPrestring{key.RetNum, key.FuncDecl.Name(), ""}
+	case ResAnnotationKey:
+		return FuncReturnPrestring{key.RetNum, key.FuncDecl.Name(), key.Location.String()}
+	default:
+		panic(fmt.Sprintf("Expected RetAnnotationKey or ResAnnotationKey but see: %T", key))
+	}
 }
 
 // FuncReturnPrestring is a Prestring storing the needed information to compactly encode a FuncReturn
 type FuncReturnPrestring struct {
 	RetNum   int
 	FuncName string
+	// Location is empty for a FuncReturn enclosing RetAnnotationKey. Location points to the
+	// location of the result return at the call site for a FuncReturn enclosing ResAnnotationKey.
+	Location string
 }
 
 func (f FuncReturnPrestring) String() string {
-	return fmt.Sprintf("returned as result %d from the function `%s`", f.RetNum, f.FuncName)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("returned as result %d from the function `%s`",
+		f.RetNum, f.FuncName))
+	if f.Location != "" {
+		sb.WriteString(fmt.Sprintf(" at %s", f.Location))
+	}
+	return sb.String()
 }
 
 // NeedsGuardMatch for a FuncReturn returns whether this function return is guarded.

--- a/annotation/produce_trigger.go
+++ b/annotation/produce_trigger.go
@@ -366,7 +366,7 @@ func (BlankVarReturn) String() string {
 	return "read from a blank variable that can never be assigned to"
 }
 
-// DuplicateParamProducer duplicates a given consumer trigger, assuming the given produce trigger
+// DuplicateParamProducer duplicates a given produce trigger, assuming the given produce trigger
 // is of FuncParam.
 func DuplicateParamProducer(t *ProduceTrigger, location token.Position) *ProduceTrigger {
 	key := t.Annotation.(FuncParam).TriggerIfNilable.Ann.(ParamAnnotationKey)

--- a/assertion/function/analyzer.go
+++ b/assertion/function/analyzer.go
@@ -86,7 +86,7 @@ type functionResult struct {
 	// declarations can be parallelized.
 	// TODO: remove this.
 	index int
-	// funcDecl is the function declaration in the package.
+	// funcDecl is the function declaration itself.
 	funcDecl *ast.FuncDecl
 }
 
@@ -328,7 +328,7 @@ func duplicateFullTriggersFromContractedFunctionsToCallers(
 		if r == nil {
 			continue
 		}
-		funcTriggers[r.index] = append(r.triggers, triggers...)
+		funcTriggers[r.index] = append(funcTriggers[r.index], triggers...)
 	}
 }
 

--- a/assertion/function/analyzer.go
+++ b/assertion/function/analyzer.go
@@ -369,7 +369,7 @@ func duplicateFullTrigger(
 		retLoc := util.PosToLocation(callExpr.Pos(), pass)
 		dupTrigger.Consumer = annotation.DuplicateReturnConsumer(trigger.Consumer, retLoc)
 		// Set up the site that controls the controlled full trigger to be created
-		c := annotation.NewArgKey(callee, 0, argLoc)
+		c := annotation.NewCallSiteParamKey(callee, 0, argLoc)
 		dupTrigger.Controller = &c
 	}
 

--- a/assertion/function/analyzer.go
+++ b/assertion/function/analyzer.go
@@ -280,9 +280,9 @@ func duplicateFullTriggersFromContractedFunctionsToCallers(
 				// TODO: Ideally, we should do
 				//
 				// if _, ok := callsByCtrtFunc[ctrFunc]; !ok {
-				//  callsByCtrtFunc[ctrFunc] = map[*types.Func]*ast.CallExpr{}
+				//  callsByCtrtFunc[ctrFunc] = map[*types.Func][]*ast.CallExpr{}
 				// }
-				// callsByCtrtFunc[ctrFunc][funcObj] = call
+				// callsByCtrtFunc[ctrFunc][funcObj] = append(callsByCtrtFunc[ctrFunc][funcObj], call)
 				//
 				// However, NilAway complains that callsByCtrtFunc[ctrFunc] can be nil. Thus, we
 				// introduce an intermediate variable v and the following instead.

--- a/assertion/function/analyzer.go
+++ b/assertion/function/analyzer.go
@@ -304,7 +304,7 @@ func duplicateFullTriggersFromContractedFunctionsToCallers(
 		if r == nil {
 			// should not happen since funcResults should contain all the functions including any
 			// contracted functions.
-			continue
+			panic(fmt.Sprintf("Did not find the contracted function %s in funcResults", ctrtFunc.Id()))
 		}
 		for _, trigger := range r.triggers {
 			// If the full trigger has a FuncParam producer or a UseAsReturn consumer, then create
@@ -335,7 +335,7 @@ func duplicateFullTriggersFromContractedFunctionsToCallers(
 		if r == nil {
 			// should not happen since funcResults should contain all the functions including any
 			// contracted functions.
-			continue
+			panic(fmt.Sprintf("Did not find the contracted function %s in funcResults", funcObj.Id()))
 		}
 		funcTriggers[r.index] = append(funcTriggers[r.index], triggers...)
 	}

--- a/assertion/function/analyzer.go
+++ b/assertion/function/analyzer.go
@@ -243,7 +243,7 @@ func run(pass *analysis.Pass) (result interface{}, _ error) {
 	}
 
 	// Duplicate triggers in contracted functions in the callers of the function
-	if config.EnableFunctionContracts {
+	if len(funcContracts) != 0 {
 		duplicateFullTriggersFromContractedFunctionsToCallers(pass, funcContracts, funcTriggers,
 			funcResults)
 	}

--- a/assertion/function/analyzer.go
+++ b/assertion/function/analyzer.go
@@ -272,7 +272,7 @@ func duplicateFullTriggersFromContractedFunctionsToCallers(
 ) {
 
 	// Find all the calls to contracted functions
-	// callsByCtrtFunc is a mapping contracted function -> caller -> call expression
+	// callsByCtrtFunc is a mapping: contracted function -> caller -> all the call expressions
 	callsByCtrtFunc := map[*types.Func]map[*types.Func]*ast.CallExpr{}
 	for funcObj, r := range funcResults {
 		for ctrFunc, calls := range findCallsToContractedFunctions(r.funcDecl, pass, funcContracts) {

--- a/assertion/function/assertiontree/parse_expr_producer.go
+++ b/assertion/function/assertiontree/parse_expr_producer.go
@@ -21,7 +21,6 @@ import (
 
 	"go.uber.org/nilaway/annotation"
 	"go.uber.org/nilaway/assertion/function/producer"
-	"go.uber.org/nilaway/config"
 	"go.uber.org/nilaway/util"
 )
 
@@ -416,7 +415,7 @@ func (r *RootAssertionNode) getFuncReturnProducers(ident *ast.Ident, expr *ast.C
 
 	for i := 0; i < numResults; i++ {
 		var retOrResKey annotation.Key
-		if config.EnableFunctionContracts && r.HasContract(funcObj) {
+		if r.HasContract(funcObj) {
 			// Creates a new result site with location information at every calling of the function
 			// with contracts. The return site is unique at every call site, even with the same
 			// function called.

--- a/assertion/function/assertiontree/parse_expr_producer.go
+++ b/assertion/function/assertiontree/parse_expr_producer.go
@@ -419,7 +419,7 @@ func (r *RootAssertionNode) getFuncReturnProducers(ident *ast.Ident, expr *ast.C
 			// Creates a new result site with location information at every calling of the function
 			// with contracts. The return site is unique at every call site, even with the same
 			// function called.
-			retOrResKey = annotation.NewResKey(funcObj, i, r.LocationOf(expr))
+			retOrResKey = annotation.NewCallSiteRetKey(funcObj, i, r.LocationOf(expr))
 		} else {
 			retOrResKey = annotation.RetKeyFromRetNum(funcObj, i)
 		}

--- a/assertion/function/assertiontree/parse_expr_producer.go
+++ b/assertion/function/assertiontree/parse_expr_producer.go
@@ -414,14 +414,14 @@ func (r *RootAssertionNode) getFuncReturnProducers(ident *ast.Ident, expr *ast.C
 	producers := make([]producer.ParsedProducer, numResults)
 
 	for i := 0; i < numResults; i++ {
-		var retOrResKey annotation.Key
+		var retKey annotation.Key
 		if r.HasContract(funcObj) {
-			// Creates a new result site with location information at every calling of the function
-			// with contracts. The return site is unique at every call site, even with the same
-			// function called.
-			retOrResKey = annotation.NewCallSiteRetKey(funcObj, i, r.LocationOf(expr))
+			// Creates a new return site with location information at every call site for a
+			// function with contracts. The return site is unique at every call site, even with the
+			// same function called.
+			retKey = annotation.NewCallSiteRetKey(funcObj, i, r.LocationOf(expr))
 		} else {
-			retOrResKey = annotation.RetKeyFromRetNum(funcObj, i)
+			retKey = annotation.RetKeyFromRetNum(funcObj, i)
 		}
 
 		var fieldProducers []*annotation.ProduceTrigger
@@ -434,7 +434,7 @@ func (r *RootAssertionNode) getFuncReturnProducers(ident *ast.Ident, expr *ast.C
 			ShallowProducer: &annotation.ProduceTrigger{
 				Annotation: annotation.FuncReturn{
 					TriggerIfNilable: annotation.TriggerIfNilable{
-						Ann: retOrResKey,
+						Ann: retKey,
 					},
 					// for an error-returning function, all but the last result are guarded
 					// TODO: add an annotation that allows more results to escape from guarding

--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -662,7 +662,7 @@ func (r *RootAssertionNode) AddComputation(expr ast.Expr) {
 					})
 				} else {
 					var paramOrArgKey annotation.Key
-					if config.EnableFunctionContracts && r.HasContract(fdecl) {
+					if r.HasContract(fdecl) {
 						// Creates a new argument site with location information at every calling
 						// of the function with contracts. The return site is unique at every call
 						// site, even with the same function called.

--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -666,7 +666,7 @@ func (r *RootAssertionNode) AddComputation(expr ast.Expr) {
 						// Creates a new argument site with location information at every calling
 						// of the function with contracts. The return site is unique at every call
 						// site, even with the same function called.
-						paramOrArgKey = annotation.NewArgKey(fdecl, i, r.LocationOf(arg))
+						paramOrArgKey = annotation.NewCallSiteParamKey(fdecl, i, r.LocationOf(arg))
 					} else {
 						paramOrArgKey = annotation.ParamKeyFromArgNum(fdecl, i)
 					}

--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -661,19 +661,19 @@ func (r *RootAssertionNode) AddComputation(expr ast.Expr) {
 						},
 					})
 				} else {
-					var paramOrArgKey annotation.Key
+					var paramKey annotation.Key
 					if r.HasContract(fdecl) {
-						// Creates a new argument site with location information at every calling
-						// of the function with contracts. The return site is unique at every call
+						// Creates a new param site with location information at every call site
+						// for a function with contracts. The param site is unique at every call
 						// site, even with the same function called.
-						paramOrArgKey = annotation.NewCallSiteParamKey(fdecl, i, r.LocationOf(arg))
+						paramKey = annotation.NewCallSiteParamKey(fdecl, i, r.LocationOf(arg))
 					} else {
-						paramOrArgKey = annotation.ParamKeyFromArgNum(fdecl, i)
+						paramKey = annotation.ParamKeyFromArgNum(fdecl, i)
 					}
 					consumer := annotation.ConsumeTrigger{
 						Annotation: annotation.ArgPass{
 							TriggerIfNonNil: annotation.TriggerIfNonNil{
-								Ann: paramOrArgKey,
+								Ann: paramKey,
 							}},
 						Expr:   arg,
 						Guards: util.NoGuards(),

--- a/assertion/function/functioncontracts/analyzer_test.go
+++ b/assertion/function/functioncontracts/analyzer_test.go
@@ -1,3 +1,17 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package functioncontracts
 
 import (

--- a/assertion/function/functioncontracts/function_contracts_map.go
+++ b/assertion/function/functioncontracts/function_contracts_map.go
@@ -1,3 +1,17 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package functioncontracts
 
 import (

--- a/assertion/function/functioncontracts/function_contracts_map.go
+++ b/assertion/function/functioncontracts/function_contracts_map.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"go.uber.org/nilaway/config"
+	"go.uber.org/nilaway/util"
 	"golang.org/x/tools/go/analysis"
 )
 
@@ -74,7 +75,7 @@ func collectFunctionContracts(pass *analysis.Pass) Map {
 
 	m := Map{}
 	for _, file := range pass.Files {
-		if !conf.IsFileInScope(file) {
+		if !conf.IsFileInScope(file) || !util.DocContainsFunctionContractsCheck(file.Doc) {
 			continue
 		}
 		for _, decl := range file.Decls {

--- a/assertion/function/functioncontracts/testdata/src/go.uber.org/functioncontracts/main.go
+++ b/assertion/function/functioncontracts/testdata/src/go.uber.org/functioncontracts/main.go
@@ -1,6 +1,8 @@
 /*
 Test functionality of parsing function contracts.
 */
+
+// <nilaway contract enable>
 package functioncontracts
 
 // contract(nonnil -> nonnil)

--- a/assertion/function/functioncontracts/testdata/src/go.uber.org/functioncontracts/main.go
+++ b/assertion/function/functioncontracts/testdata/src/go.uber.org/functioncontracts/main.go
@@ -1,6 +1,16 @@
-/*
-Test functionality of parsing function contracts.
-*/
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // <nilaway contract enable>
 package functioncontracts

--- a/config/const.go
+++ b/config/const.go
@@ -7,9 +7,6 @@ import (
 
 // This file hosts non-user-configurable parameters --- these are for development and testing purposes only.
 
-// EnableFunctionContracts turns on the feature of function contracts.
-var EnableFunctionContracts = false
-
 // StableRoundLimit is the number of rounds in backpropagation algorithm after which, if there is no change
 // in the collected triggers, the algorithm halts. It is possible to carefully craft known false negative for any value
 // of StableRoundLimit (check test loopflow.go/longRotNilLoop). Setting this value too low may result in false negatives
@@ -65,6 +62,10 @@ const NilAwayStructInitCheckString = "<nilaway struct enable>"
 // NilAwayAnonymousFuncCheckString is the string that may be inserted into the docstring for a package to
 // force NilAway to enable anonymous func checking
 const NilAwayAnonymousFuncCheckString = "<nilaway anonymous function enable>"
+
+// NilAwayFunctionContractsCheckString is the string that may be inserted into the docstring for a
+// package to force NilAway to enable function contracts.
+const NilAwayFunctionContractsCheckString = "<nilaway contract enable>"
 
 func maxRoundsFromBlocks(numBlocks int) int {
 	return numBlocks * numBlocks * 2

--- a/config/const.go
+++ b/config/const.go
@@ -7,6 +7,9 @@ import (
 
 // This file hosts non-user-configurable parameters --- these are for development and testing purposes only.
 
+// EnableFunctionContracts turns on the feature of function contracts.
+var EnableFunctionContracts = false
+
 // StableRoundLimit is the number of rounds in backpropagation algorithm after which, if there is no change
 // in the collected triggers, the algorithm halts. It is possible to carefully craft known false negative for any value
 // of StableRoundLimit (check test loopflow.go/longRotNilLoop). Setting this value too low may result in false negatives

--- a/inference/engine.go
+++ b/inference/engine.go
@@ -204,8 +204,9 @@ func (e *Engine) buildPkgInferenceMap(triggers []annotation.FullTrigger) {
 		if !trigger.Controlled() {
 			continue
 		}
-		// controller is an ArgAnnotationKey, which must be enclosed in a ArgPass consumer, which
-		// Kind() method returns Conditional which is not deep. Thus, we pass false here.
+		// controller is an CallSiteParamAnnotationKey, which must be enclosed in a ArgPass
+		// consumer, which Kind() method returns Conditional which is not deep. Thus, we pass false
+		// here.
 		site := newPrimitiveSite(*trigger.Controller, false)
 		ts, ok := controlledTgsBySite[site]
 		if !ok {

--- a/inference/engine.go
+++ b/inference/engine.go
@@ -39,7 +39,7 @@ type Engine struct {
 	// converted to diagnostics and returned along with the current inferred map whenever users
 	// request it.
 	conflicts *conflictGrouping
-	// controlledTriggersBySite stores the set of controlled triggers for each site if the site is
+	// controlledTriggersBySite stores the set of controlled triggers for each site if the site
 	// controls any triggers. This field is for internal use in the struct only and should not be
 	// accessed elsewhere.
 	controlledTriggersBySite map[primitiveSite]map[annotation.FullTrigger]bool

--- a/nilaway_test.go
+++ b/nilaway_test.go
@@ -217,6 +217,15 @@ func TestGenerics(t *testing.T) {
 	analysistest.Run(t, testdata, Analyzer, "go.uber.org/generics")
 }
 
+func TestFunctionContracts(t *testing.T) {
+	t.Parallel()
+
+	config.EnableFunctionContracts = true
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, Analyzer, "go.uber.org/functioncontracts/inference")
+	config.EnableFunctionContracts = false
+}
+
 func TestPrettyPrint(t *testing.T) { //nolint:paralleltest
 	// We specifically do not set this test to be parallel such that this test is run separately
 	// from the parallel tests. This makes it possible to set the pretty-print flag to true for

--- a/nilaway_test.go
+++ b/nilaway_test.go
@@ -220,10 +220,8 @@ func TestGenerics(t *testing.T) {
 func TestFunctionContracts(t *testing.T) {
 	t.Parallel()
 
-	config.EnableFunctionContracts = true
 	testdata := analysistest.TestData()
 	analysistest.Run(t, testdata, Analyzer, "go.uber.org/functioncontracts/inference")
-	config.EnableFunctionContracts = false
 }
 
 func TestPrettyPrint(t *testing.T) { //nolint:paralleltest

--- a/testdata/src/go.uber.org/functioncontracts/inference/functioncontracts-with-inference.go
+++ b/testdata/src/go.uber.org/functioncontracts/inference/functioncontracts-with-inference.go
@@ -47,9 +47,16 @@ func barReturn2() {
 
 // Test the contracted function contains a full trigger param 0 -> nonnil.
 // contract(nonnil -> nonnil)
-func fooParam(x *int) *int { // want "^ Annotation on Param 0.*\n.*Must be NILABLE.*\n.*AND.*\n.*Must be NONNIL.*NONNIL$"
-	sink(*x) // "nilable value dereferenced" wanted
-	return new(int)
+func fooParam(x *int) *int { // want "^ Annotation on Param 0.*\n.*Must be NILABLE.*\n.*AND.*\n.*Must be NONNIL.*NONNIL$" "^ Annotation on Result 0.*\n.*Must be NILABLE.*\n.*AND.*\n.*Must be NONNIL.*NONNIL$"
+	if x != nil {
+		return new(int)
+	}
+	if rand.Float64() > 0.5 {
+		return new(int)
+	} else {
+		sink(*x) // "nilable value dereferenced" wanted
+		return nil
+	}
 }
 
 func barParam1() {
@@ -67,25 +74,6 @@ func barParam2() {
 
 func sink(v int) {}
 
-// Test the contracted function contains a full trigger param 0 -> return 0.
-// contract(nonnil -> nonnil)
-func fooParamAndReturn(x *int) *int { // want "^ Annotation on Result 0.*\n.*Must be NILABLE.*\n.*AND.*\n.*Must be NONNIL.*NONNIL$"
-	return x
-}
-
-func barParamAndReturn1() {
-	n := 1
-	a1 := &n
-	b1 := fooParamAndReturn(a1)
-	print(*b1) // No "nilable value dereferenced" wanted
-}
-
-func barParamAndReturn2() {
-	var a2 *int
-	b2 := fooParamAndReturn(a2)
-	print(*b2) // "nilable value dereferenced" wanted
-}
-
 // Test the contracted function contains another contracted function.
 // contract(nonnil -> nonnil)
 func fooNested(x *int) *int {
@@ -94,7 +82,14 @@ func fooNested(x *int) *int {
 
 // contract(nonnil -> nonnil)
 func fooBase(x *int) *int { // want "^ Annotation on Result 0.*\n.*Must be NILABLE.*\n.*AND.*\n.*Must be NONNIL.*NONNIL$"
-	return x
+	if x != nil {
+		return new(int)
+	}
+	if rand.Float64() > 0.5 {
+		return nil
+	} else {
+		return new(int)
+	}
 }
 
 func barNested1() {
@@ -112,14 +107,21 @@ func barNested2() {
 
 // Test the contracted function is called by another function.
 // contract(nonnil -> nonnil)
-func fooParamCalledInAnotherFunction(s *int) *int { // want "^ Annotation on Param 0.*\n.*Must be NILABLE.*\n.*AND.*\n.*Must be NONNIL.*NONNIL$"
-	sink(*s)
-	return new(int)
+func fooParamCalledInAnotherFunction(x *int) *int { // want "^ Annotation on Param 0.*\n.*Must be NILABLE.*\n.*AND.*\n.*Must be NONNIL.*NONNIL$"
+	if x != nil {
+		return new(int)
+	}
+	if rand.Float64() > 0.5 {
+		return new(int)
+	} else {
+		sink(*x) // "nilable value dereferenced" wanted
+		return nil
+	}
 }
 
 func barParamCalledInAnotherFunction() {
-	var s *int
-	call(fooParamCalledInAnotherFunction(s))
+	var x *int
+	call(fooParamCalledInAnotherFunction(x))
 }
 
 func call(x *int) {}

--- a/testdata/src/go.uber.org/functioncontracts/inference/functioncontracts-with-inference.go
+++ b/testdata/src/go.uber.org/functioncontracts/inference/functioncontracts-with-inference.go
@@ -158,3 +158,22 @@ func barReturnCalledMultipleTimesInTheSameFunction() {
 	b4 := fooReturnCalledMultipleTimesInTheSameFunction(a4)
 	print(*b4) // "nilable value dereferenced" wanted
 }
+
+// Contract below isn't useful, since return is always nonnil and argument is ignored, but added to
+// check we don't crash on unnamed parameters.
+// contract(nonnil -> nonnil)
+func fooUnamedParam(_ *int) *int {
+	return new(int)
+}
+
+func barUnamedParam1() {
+	var a1 *int
+	b1 := fooUnamedParam(a1)
+	print(*b1) // No "nilable value dereferenced" wanted
+}
+
+func barUnamedParam2() {
+	var a2 *int
+	b2 := fooUnamedParam(a2)
+	print(*b2) // No "nilable value dereferenced" wanted
+}

--- a/testdata/src/go.uber.org/functioncontracts/inference/functioncontracts-with-inference.go
+++ b/testdata/src/go.uber.org/functioncontracts/inference/functioncontracts-with-inference.go
@@ -1,3 +1,4 @@
+// <nilaway contract enable>
 package inference
 
 import "math/rand"

--- a/testdata/src/go.uber.org/functioncontracts/inference/functioncontracts-with-inference.go
+++ b/testdata/src/go.uber.org/functioncontracts/inference/functioncontracts-with-inference.go
@@ -1,3 +1,17 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // <nilaway contract enable>
 package inference
 

--- a/testdata/src/go.uber.org/functioncontracts/inference/functioncontracts-with-inference.go
+++ b/testdata/src/go.uber.org/functioncontracts/inference/functioncontracts-with-inference.go
@@ -126,7 +126,9 @@ func barParamCalledInAnotherFunction() {
 
 func call(x *int) {}
 
-func fooReturnCalledMultipleTimesInTheSameFunction(x *int) *int { // want "^ Annotation on Result 0.*\n.*Must be NILABLE.*\n.*AND.*\n.*Must be NONNIL.*\n.*AND.*\n.*Must be NONNIL.*NONNIL$"
+// Test a contracted function is called multiple times in another function.
+// contract(nonnil->nonnil)
+func fooReturnCalledMultipleTimesInTheSameFunction(x *int) *int { // want "^ Annotation on Result 0.*\n.*Must be NILABLE.*\n.*AND.*\n.*Must be NONNIL.*NONNIL$"
 	if x != nil {
 		return new(int)
 	}
@@ -140,19 +142,10 @@ func fooReturnCalledMultipleTimesInTheSameFunction(x *int) *int { // want "^ Ann
 func barReturnCalledMultipleTimesInTheSameFunction() {
 	n := 1
 	a1 := &n
-	b1 := fooReturnCalledMultipleTimesInTheSameFunction(a1) // No "nilable value dereferenced" wanted
-	print(*b1)
+	b1 := fooReturnCalledMultipleTimesInTheSameFunction(a1)
+	print(*b1) // No "nilable value dereferenced" wanted
 
 	var a2 *int
-	b2 := fooReturnCalledMultipleTimesInTheSameFunction(a2) // "nilable value dereferenced" wanted
-	print(b2)
-
-	m := 2
-	a3 := &m
-	b3 := fooReturnCalledMultipleTimesInTheSameFunction(a3) // No "nilable value dereferenced" wanted
-	print(*b3)
-
-	var a4 *int
-	b4 := fooReturnCalledMultipleTimesInTheSameFunction(a4) // "nilable value dereferenced" wanted
-	print(b4)
+	b2 := fooReturnCalledMultipleTimesInTheSameFunction(a2)
+	print(*b2) // "nilable value dereferenced" wanted
 }

--- a/testdata/src/go.uber.org/functioncontracts/inference/functioncontracts-with-inference.go
+++ b/testdata/src/go.uber.org/functioncontracts/inference/functioncontracts-with-inference.go
@@ -1,0 +1,110 @@
+package inference
+
+import "math/rand"
+
+// Test the contracted function contains a full trigger nilable -> return 0.
+// contract(nonnil -> nonnil)
+func fooReturn(x *int) *int { // want "^ Annotation on Result 0.*\n.*Must be NILABLE.*\n.*AND.*\n.*Must be NONNIL.*NONNIL$"
+	if x != nil {
+		// Return nonnil
+		return new(int)
+	}
+	// Return nonnil or nil randomly
+	if rand.Float64() > 0.5 {
+		return new(int)
+	} else {
+		return nil
+	}
+}
+
+func barReturn1() {
+	n := 1
+	a1 := &n
+	b1 := fooReturn(a1)
+	print(*b1) // No "nilable value dereferenced" wanted
+}
+
+func barReturn2() {
+	var a2 *int
+	b2 := fooReturn(a2)
+	print(*b2) // "nilable value dereferenced" wanted
+}
+
+// Test the contracted function contains a full trigger param 0 -> nonnil.
+// contract(nonnil -> nonnil)
+func fooParam(x *int) *int { // want "^ Annotation on Param 0.*\n.*Must be NILABLE.*\n.*AND.*\n.*Must be NONNIL.*NONNIL$"
+	sink(*x) // "nilable value dereferenced" wanted
+	return new(int)
+}
+
+func barParam1() {
+	n := 1
+	a1 := &n
+	b1 := fooParam(a1)
+	print(*b1)
+}
+
+func barParam2() {
+	var a2 *int
+	b2 := fooParam(a2)
+	print(*b2)
+}
+
+func sink(v int) {}
+
+// Test the contracted function contains a full trigger param 0 -> return 0.
+// contract(nonnil -> nonnil)
+func fooParamAndReturn(x *int) *int { // want "^ Annotation on Result 0.*\n.*Must be NILABLE.*\n.*AND.*\n.*Must be NONNIL.*NONNIL$"
+	return x
+}
+
+func barParamAndReturn1() {
+	n := 1
+	a1 := &n
+	b1 := fooParamAndReturn(a1)
+	print(*b1) // No "nilable value dereferenced" wanted
+}
+
+func barParamAndReturn2() {
+	var a2 *int
+	b2 := fooParamAndReturn(a2)
+	print(*b2) // "nilable value dereferenced" wanted
+}
+
+// Test the contracted function contains another contracted function.
+// contract(nonnil -> nonnil)
+func fooNested(x *int) *int {
+	return fooBase(x)
+}
+
+// contract(nonnil -> nonnil)
+func fooBase(x *int) *int { // want "^ Annotation on Result 0.*\n.*Must be NILABLE.*\n.*AND.*\n.*Must be NONNIL.*NONNIL$"
+	return x
+}
+
+func barNested1() {
+	n := 1
+	a1 := &n
+	b1 := fooNested(a1)
+	print(*b1) // No "nilable value dereferenced" wanted
+}
+
+func barNested2() {
+	var a2 *int
+	b2 := fooNested(a2)
+	print(*b2) // "nilable value dereferenced" wanted
+}
+
+// Test the contracted function is called by another function.
+// contract(nonnil -> nonnil)
+func fooParamCalledInAnotherFunction(s *int) *int { // want "^ Annotation on Param 0.*\n.*Must be NILABLE.*\n.*AND.*\n.*Must be NONNIL.*NONNIL$"
+	sink(*s)
+	return new(int)
+}
+
+func barParamCalledInAnotherFunction() {
+	var s *int
+	call(fooParamCalledInAnotherFunction(s))
+}
+
+func call(x *int) {}

--- a/testdata/src/go.uber.org/functioncontracts/inference/functioncontracts-with-inference.go
+++ b/testdata/src/go.uber.org/functioncontracts/inference/functioncontracts-with-inference.go
@@ -125,3 +125,34 @@ func barParamCalledInAnotherFunction() {
 }
 
 func call(x *int) {}
+
+func fooReturnCalledMultipleTimesInTheSameFunction(x *int) *int { // want "^ Annotation on Result 0.*\n.*Must be NILABLE.*\n.*AND.*\n.*Must be NONNIL.*\n.*AND.*\n.*Must be NONNIL.*NONNIL$"
+	if x != nil {
+		return new(int)
+	}
+	if rand.Float64() > 0.5 {
+		return new(int)
+	} else {
+		return nil
+	}
+}
+
+func barReturnCalledMultipleTimesInTheSameFunction() {
+	n := 1
+	a1 := &n
+	b1 := fooReturnCalledMultipleTimesInTheSameFunction(a1) // No "nilable value dereferenced" wanted
+	print(*b1)
+
+	var a2 *int
+	b2 := fooReturnCalledMultipleTimesInTheSameFunction(a2) // "nilable value dereferenced" wanted
+	print(b2)
+
+	m := 2
+	a3 := &m
+	b3 := fooReturnCalledMultipleTimesInTheSameFunction(a3) // No "nilable value dereferenced" wanted
+	print(*b3)
+
+	var a4 *int
+	b4 := fooReturnCalledMultipleTimesInTheSameFunction(a4) // "nilable value dereferenced" wanted
+	print(b4)
+}

--- a/testdata/src/go.uber.org/functioncontracts/inference/functioncontracts-with-inference.go
+++ b/testdata/src/go.uber.org/functioncontracts/inference/functioncontracts-with-inference.go
@@ -128,7 +128,7 @@ func call(x *int) {}
 
 // Test a contracted function is called multiple times in another function.
 // contract(nonnil->nonnil)
-func fooReturnCalledMultipleTimesInTheSameFunction(x *int) *int { // want "^ Annotation on Result 0.*\n.*Must be NILABLE.*\n.*AND.*\n.*Must be NONNIL.*NONNIL$"
+func fooReturnCalledMultipleTimesInTheSameFunction(x *int) *int { // want "^ Annotation on Result 0.*\n.*Must be NILABLE.*\n.*AND.*\n.*Must be NONNIL.*NONNIL$" "^ Annotation on Result 0.*\n.*Must be NILABLE.*\n.*AND.*\n.*Must be NONNIL.*NONNIL$"
 	if x != nil {
 		return new(int)
 	}
@@ -148,4 +148,13 @@ func barReturnCalledMultipleTimesInTheSameFunction() {
 	var a2 *int
 	b2 := fooReturnCalledMultipleTimesInTheSameFunction(a2)
 	print(*b2) // "nilable value dereferenced" wanted
+
+	m := 2
+	a3 := &m
+	b3 := fooReturnCalledMultipleTimesInTheSameFunction(a3)
+	print(*b3) // No "nilable value dereferenced" wanted
+
+	var a4 *int
+	b4 := fooReturnCalledMultipleTimesInTheSameFunction(a4)
+	print(*b4) // "nilable value dereferenced" wanted
 }

--- a/util/util.go
+++ b/util/util.go
@@ -419,6 +419,12 @@ func DocContainsAnonymousFuncCheck(group *ast.CommentGroup) bool {
 	return docContainsString(config.NilAwayAnonymousFuncCheckString)(group)
 }
 
+// DocContainsFunctionContractsCheck is used by analyzers to check if the function contracts check
+// enabling string is present.
+func DocContainsFunctionContractsCheck(group *ast.CommentGroup) bool {
+	return docContainsString(config.NilAwayFunctionContractsCheckString)(group)
+}
+
 // docContainsString is used to check if the file comments contain a string s.
 func docContainsString(s string) func(*ast.CommentGroup) bool {
 	return func(group *ast.CommentGroup) bool {

--- a/util/util.go
+++ b/util/util.go
@@ -18,6 +18,7 @@ package util
 import (
 	"fmt"
 	"go/ast"
+	"go/token"
 	"go/types"
 	"regexp"
 	"strings"
@@ -461,4 +462,18 @@ func PrettyPrintErrorMessage(msg string) string {
 	msg = pathPattern.ReplaceAllString(msg, pathStr)
 	msg = errorStr + msg
 	return msg
+}
+
+// truncatePosition removes part of prefix of the full file path, determined by
+// config.DirLevelsToPrintForTriggers.
+func truncatePosition(position token.Position) token.Position {
+	position.Filename = PortionAfterSep(
+		position.Filename, "/",
+		config.DirLevelsToPrintForTriggers)
+	return position
+}
+
+// PosToLocation converts a token.Pos as a real code location, of token.Position.
+func PosToLocation(pos token.Pos, pass *analysis.Pass) token.Position {
+	return truncatePosition(pass.Fset.Position(pos))
 }


### PR DESCRIPTION
Follow up of PR #8 , support function contract(nonnil->nonnil) in full infer mode.

This revision supports contract(nonnil -> nonnil). There are two major steps:

1. Duplicate param and return sites at every call of the function with a contract so a param or return site will have its unique nilability. We duplicate full triggers from the contracted functions as well in order those duplicated param and return sites are involved in those duplicated full triggers.

2. Introduce controlled triggers to allow NilAway to ignore some over-constraints when the contract should work.