### PR TITLE
Store original AST expressions in assertion nodes

### DIFF
--- a/annotation/full_trigger.go
+++ b/annotation/full_trigger.go
@@ -19,7 +19,6 @@ import (
 	"go/ast"
 	"go/token"
 
-	"go.uber.org/nilaway/config"
 	"go.uber.org/nilaway/util"
 	"golang.org/x/tools/go/analysis"
 )
@@ -60,15 +59,8 @@ func (t *FullTrigger) Check(annMap Map) bool {
 		t.Consumer.Annotation.CheckConsume(annMap)
 }
 
-func truncatePosition(position token.Position) token.Position {
-	position.Filename = util.PortionAfterSep(
-		position.Filename, "/",
-		config.DirLevelsToPrintForTriggers)
-	return position
-}
-
 func (t *FullTrigger) truncatedConsumerPos(pass *analysis.Pass) token.Position {
-	return truncatePosition(pass.Fset.Position(t.Consumer.Pos()))
+	return util.TruncatePosition(pass.Fset.Position(t.Consumer.Pos()))
 }
 
 func (t *FullTrigger) truncatedProducerPos(pass *analysis.Pass) token.Position {
@@ -81,7 +73,7 @@ func (t *FullTrigger) truncatedProducerPos(pass *analysis.Pass) token.Position {
 	if t.Producer.Expr == nil {
 		panic(fmt.Sprintf("nil Expr for producer %q", t.Producer))
 	}
-	return truncatePosition(pass.Fset.Position(t.Producer.Expr.Pos()))
+	return util.TruncatePosition(pass.Fset.Position(t.Producer.Expr.Pos()))
 }
 
 // BuildStringRepr returns a string representation of a `FullTrigger` given an `analysis.Pass` to help Lookup its objects

--- a/assertion/function/assertiontree/assertion_node.go
+++ b/assertion/function/assertiontree/assertion_node.go
@@ -73,6 +73,10 @@ type assertionNodeCommon struct {
 	parent          AssertionNode // this should be nil for the root
 	children        []AssertionNode
 	consumeTriggers []*annotation.ConsumeTrigger
+
+	// originalExpr stores the original call expression that prompted the creation of this assertion node
+	originalExpr ast.Expr // this should be nil for the root
+
 }
 
 func (n *assertionNodeCommon) Parent() AssertionNode { return n.parent }
@@ -105,4 +109,8 @@ func (n *assertionNodeCommon) Size() int {
 		size += child.Size()
 	}
 	return size
+}
+
+func (n *assertionNodeCommon) BuildExpr(pass *analysis.Pass, expr ast.Expr) ast.Expr {
+	return n.originalExpr
 }

--- a/assertion/function/assertiontree/fld_assertion_node.go
+++ b/assertion/function/assertiontree/fld_assertion_node.go
@@ -16,11 +16,9 @@ package assertiontree
 
 import (
 	"fmt"
-	"go/ast"
 	"go/types"
 
 	"go.uber.org/nilaway/annotation"
-	"golang.org/x/tools/go/analysis"
 )
 
 type fldAssertionNode struct {
@@ -71,15 +69,4 @@ func (f *fldAssertionNode) DefaultTrigger() annotation.ProducingAnnotationTrigge
 			Ann: annotation.FieldAnnotationKey{
 				FieldDecl: f.decl,
 			}}}
-}
-
-// BuildExpr for a field node adds that field access to the expression `expr`
-func (f *fldAssertionNode) BuildExpr(_ *analysis.Pass, expr ast.Expr) ast.Expr {
-	if f.Root() == nil {
-		panic("f.BuildExpr should only be called on nodes present in a valid assertion tree")
-	}
-	return &ast.SelectorExpr{
-		X:   expr,
-		Sel: f.Root().GetDeclaringIdent(f.decl),
-	}
 }

--- a/assertion/function/assertiontree/func_assertion_node.go
+++ b/assertion/function/assertiontree/func_assertion_node.go
@@ -16,12 +16,10 @@ package assertiontree
 
 import (
 	"fmt"
-	"go/ast"
 	"go/types"
 
 	"go.uber.org/nilaway/annotation"
 	"go.uber.org/nilaway/util"
-	"golang.org/x/tools/go/analysis"
 )
 
 type funcAssertionNode struct {
@@ -29,7 +27,6 @@ type funcAssertionNode struct {
 
 	// declaring identifier for this function
 	decl *types.Func
-	args []ast.Expr
 }
 
 func (f *funcAssertionNode) MinimalString() string {
@@ -44,27 +41,4 @@ func (f *funcAssertionNode) DefaultTrigger() annotation.ProducingAnnotationTrigg
 	return annotation.MethodReturn{
 		TriggerIfNilable: annotation.TriggerIfNilable{
 			Ann: annotation.RetKeyFromRetNum(f.decl, 0)}}
-}
-
-// BuildExpr for a function node adds that function to `expr` as a method call
-func (f *funcAssertionNode) BuildExpr(_ *analysis.Pass, expr ast.Expr) ast.Expr {
-	if f.Root() == nil {
-		panic("f.BuildExpr should only be called on nodes present in a valid assertion tree")
-	}
-	genFunc := func() ast.Expr {
-		if expr == nil {
-			return f.Root().GetDeclaringIdent(f.decl)
-		}
-		return &ast.SelectorExpr{
-			X:   expr,
-			Sel: f.Root().GetDeclaringIdent(f.decl),
-		}
-	}
-	return &ast.CallExpr{
-		Fun:      genFunc(),
-		Lparen:   0,
-		Args:     f.args,
-		Ellipsis: 0,
-		Rparen:   0,
-	}
 }

--- a/assertion/function/assertiontree/index_assertion_node.go
+++ b/assertion/function/assertiontree/index_assertion_node.go
@@ -15,24 +15,17 @@
 package assertiontree
 
 import (
-	"go/ast"
 	"go/types"
 
 	"go.uber.org/nilaway/annotation"
-	"golang.org/x/tools/go/analysis"
 )
 
 type indexAssertionNode struct {
 	assertionNodeCommon
-	index ast.Expr
 
 	// we need to remember the type of the values of this index because there is no other way
 	// to look it up - unlike fields and functions there is no sufficient identifier to store
 	valType types.Type
-
-	// here we store the type of the reciever to this indexAssertionNode -
-	// specifically to determine if it is a map
-	recvType types.Type
 }
 
 func (i *indexAssertionNode) MinimalString() string {
@@ -42,14 +35,4 @@ func (i *indexAssertionNode) MinimalString() string {
 // DefaultTrigger for an index node is the deep nilability annotation of its parent type
 func (i *indexAssertionNode) DefaultTrigger() annotation.ProducingAnnotationTrigger {
 	return deepNilabilityTriggerOf(i.Parent())
-}
-
-// BuildExpr for an index node adds that index to `expr`
-func (i *indexAssertionNode) BuildExpr(_ *analysis.Pass, expr ast.Expr) ast.Expr {
-	return &ast.IndexExpr{
-		X:      expr,
-		Lbrack: 0,
-		Index:  i.index,
-		Rbrack: 0,
-	}
 }

--- a/assertion/function/assertiontree/parse_expr_producer.go
+++ b/assertion/function/assertiontree/parse_expr_producer.go
@@ -221,8 +221,11 @@ func (r *RootAssertionNode) ParseExprAsProducer(expr ast.Expr, doNotTrack bool) 
 
 		if recv, _ := r.ParseExprAsProducer(expr.X, false); recv != nil {
 			// trackable access to a field
-			return append(recv, &fldAssertionNode{decl: r.ObjectOf(expr.Sel).(*types.Var),
-				functionContext: r.functionContext}), nil
+			return append(recv, &fldAssertionNode{
+				decl:                r.ObjectOf(expr.Sel).(*types.Var),
+				functionContext:     r.functionContext,
+				assertionNodeCommon: assertionNodeCommon{originalExpr: expr}},
+			), nil
 		}
 		// non-trackable access to a field - just return a produce trigger for that field
 		return nil, fldReadProduce()
@@ -282,7 +285,9 @@ func (r *RootAssertionNode) ParseExprAsProducer(expr ast.Expr, doNotTrack bool) 
 			// non-builtin funcs
 			if !doNotTrack && litArgs() {
 				return TrackableExpr{&funcAssertionNode{
-					decl: r.ObjectOf(fun).(*types.Func), args: expr.Args}}, nil
+					decl:                r.ObjectOf(fun).(*types.Func),
+					assertionNodeCommon: assertionNodeCommon{originalExpr: expr}},
+				}, nil
 			}
 			// function call has non-literal args, so is not literal, use its return annotation
 			// alternatively, doNotTrack was set
@@ -299,11 +304,15 @@ func (r *RootAssertionNode) ParseExprAsProducer(expr ast.Expr, doNotTrack bool) 
 			if litArgs() {
 				if r.isPkgName(fun.X) {
 					return TrackableExpr{&funcAssertionNode{
-						decl: r.ObjectOf(fun.Sel).(*types.Func), args: expr.Args}}, nil
+						decl:                r.ObjectOf(fun.Sel).(*types.Func),
+						assertionNodeCommon: assertionNodeCommon{originalExpr: expr}},
+					}, nil
 				}
 				if recv, _ := r.ParseExprAsProducer(fun.X, false); recv != nil {
 					return append(recv, &funcAssertionNode{
-						decl: r.ObjectOf(fun.Sel).(*types.Func), args: expr.Args}), nil
+						decl:                r.ObjectOf(fun.Sel).(*types.Func),
+						assertionNodeCommon: assertionNodeCommon{originalExpr: expr}},
+					), nil
 				}
 				// receiver is not trackable, use its return annotation
 				return nil, r.getFuncReturnProducers(fun.Sel, expr)
@@ -329,9 +338,8 @@ func (r *RootAssertionNode) ParseExprAsProducer(expr ast.Expr, doNotTrack bool) 
 			if r.isStable(expr.Index) {
 				// receiver is trackable and index is stable, so return an augmented path
 				return append(recv, &indexAssertionNode{
-					index:    expr.Index,
-					valType:  r.Pass().TypesInfo.Types[expr].Type,
-					recvType: r.Pass().TypesInfo.Types[expr.X].Type,
+					valType:             r.Pass().TypesInfo.Types[expr].Type,
+					assertionNodeCommon: assertionNodeCommon{originalExpr: expr},
 				}), nil
 			}
 			// index is non-literal, so the expression is not trackable, just return nilable for index without check

--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -993,15 +993,20 @@ func (r *RootAssertionNode) shallowEqNodes(left, right AssertionNode) bool {
 		if left.decl != right.decl {
 			return false
 		}
-		if len(left.args) != len(right.args) {
+
+		leftCallExpr, okLeft := left.originalExpr.(*ast.CallExpr)
+		rightCallExpr, okRight := right.originalExpr.(*ast.CallExpr)
+
+		if !okLeft || !okRight || len(leftCallExpr.Args) != len(rightCallExpr.Args) {
 			return false
 		}
-		for i := range left.args {
-			if right.args == nil {
+
+		for i := range leftCallExpr.Args {
+			if rightCallExpr.Args == nil {
 				// TODO: remove this when  is implemented and we can replace it with a real suppression
 				return false
 			}
-			if !r.eqStable(left.args[i], right.args[i]) {
+			if !r.eqStable(leftCallExpr.Args[i], rightCallExpr.Args[i]) {
 				return false
 			}
 		}
@@ -1010,7 +1015,15 @@ func (r *RootAssertionNode) shallowEqNodes(left, right AssertionNode) bool {
 		if !ok {
 			return false
 		}
-		if !r.eqStable(left.index, right.index) {
+
+		leftIndexExpr, okLeft := left.originalExpr.(*ast.IndexExpr)
+		rightIndexExpr, okRight := right.originalExpr.(*ast.IndexExpr)
+
+		if !okLeft || !okRight {
+			return false
+		}
+
+		if !r.eqStable(leftIndexExpr.Index, rightIndexExpr.Index) {
 			return false
 		}
 	default:

--- a/assertion/function/assertiontree/util.go
+++ b/assertion/function/assertiontree/util.go
@@ -376,14 +376,14 @@ func CopyNode(node AssertionNode) AssertionNode {
 	case *varAssertionNode:
 		fresh = &varAssertionNode{decl: node.decl}
 	case *fldAssertionNode:
-		fresh = &fldAssertionNode{decl: node.decl, functionContext: node.functionContext}
+		fresh = &fldAssertionNode{decl: node.decl, functionContext: node.functionContext, assertionNodeCommon: node.assertionNodeCommon}
 	case *funcAssertionNode:
-		fresh = &funcAssertionNode{decl: node.decl, args: node.args}
+		fresh = &funcAssertionNode{decl: node.decl, assertionNodeCommon: node.assertionNodeCommon}
 	case *indexAssertionNode:
 		fresh = &indexAssertionNode{
-			index:    node.index,
-			valType:  node.valType,
-			recvType: node.recvType}
+			valType:             node.valType,
+			assertionNodeCommon: node.assertionNodeCommon,
+		}
 	default:
 		panic("unrecognized node type")
 	}

--- a/inference/conflict.go
+++ b/inference/conflict.go
@@ -19,148 +19,177 @@ import (
 	"go/token"
 
 	"go.uber.org/nilaway/annotation"
+	"go.uber.org/nilaway/util"
 	"golang.org/x/tools/go/analysis"
 )
 
-// For concise error reporting, conflicts are grouped by their nilness root cause, i.e., by their producers. Thus, the producer
-// forms the 'key' to identify a conflict group.
-
-// groupKey stores the type of the key representing a conflict group.
-// (Note that the type is currently set to any since the producer types of singleAssertionConflict and overconstrainedConflict
-// are not the same. Consolidating the two types of conflicts will help solve this problem (tracked in .)
-type groupKey any
-
-// conflictGrouping stores groups of conflicts represented by their keys in a map. It also provides methods to add conflicts
-// to the groups and to generate diagnostics from the groups.
-type conflictGrouping struct {
-	groupMap map[groupKey][]conflict
+type conflict struct {
+	position token.Pos // stores position where the error should be reported
+	expr     string    // stores expression that is overcontrained (i.e., expected to be nonnil, but found nilable)
+	nilFlow  nilFlow   // stores nil flow from source to dereference point
 }
 
-// newConflictGrouping constructs and returns a pointer to conflictGrouping.
-func newConflictGrouping() *conflictGrouping {
-	return &conflictGrouping{
-		groupMap: make(map[groupKey][]conflict),
+type nilFlow struct {
+	nilPath    []node // stores nil path of the flow from nilable source to conflict point
+	nonnilPath []node // stores non-nil path of the flow from conflict point to dereference point
+}
+
+type node struct {
+	position token.Position
+	reason   string
+}
+
+func newNode(p annotation.Prestring) node {
+	nodeObj := node{}
+	if l, ok := p.(annotation.LocatedPrestring); ok {
+		nodeObj.position = l.Location
+		nodeObj.reason = l.Contained.String()
+	} else if p != nil {
+		nodeObj.reason = p.String()
 	}
+	return nodeObj
 }
 
-// addConflict adds a conflict to a conflict group identified by the conflict's key.
-func (t *conflictGrouping) addConflict(conflict conflict) {
-	key := conflict.key()
-	t.groupMap[key] = append(t.groupMap[key], conflict)
+func (n *node) String() string {
+	posStr := "<no pos info>"
+	reasonStr := "<no reason info>"
+	if n.position.IsValid() {
+		posStr = n.position.String()
+	}
+	if len(n.reason) > 0 {
+		reasonStr = n.reason
+	}
+	return fmt.Sprintf("\n\t-> %s: %s", posStr, reasonStr)
 }
 
-// diagnostics converts conflict groups to a list of analysis.Diagnostic for reporting.
-func (t *conflictGrouping) diagnostics() []analysis.Diagnostic {
-	var diagnostics []analysis.Diagnostic
-	for _, conflicts := range t.groupMap {
-		site := conflicts[0].getSiteMessage()
-		producer := conflicts[0].getProducerMessage()
-		consumer := ""
-		for _, c := range conflicts {
-			consumer += c.getConsumerMessage()
+// addNilPathNode adds a new node to the nil path.
+// LocatedPrestring contains accurate information about the position and the reason why NilAway deemed that position
+// to be nilable. We use it if available, else we use the raw string representation available from the Prestring `p`.
+func (n *nilFlow) addNilPathNode(p annotation.Prestring) {
+	nodeObj := newNode(p)
+
+	// Note that we prepend the new node to nilPath because we want to print the flow in the order in which it was discovered.
+	n.nilPath = append([]node{nodeObj}, n.nilPath...)
+}
+
+// addNonNilPathNode adds a new node to the non-nil path
+func (n *nilFlow) addNonNilPathNode(p annotation.Prestring) {
+	nodeObj := newNode(p)
+	n.nonnilPath = append(n.nonnilPath, nodeObj)
+}
+
+// String converts a nilFlow to a string representation, where each entry is the flow of the form: `<pos>: <reason>`
+func (n *nilFlow) String() string {
+	// Augment reason for the first and last node in the flow with nilable and nonnil information, respectively.
+	firstNilNodeIndex := 0
+	n.nilPath[firstNilNodeIndex].reason = fmt.Sprintf("%s (found NILABLE)", n.nilPath[firstNilNodeIndex].reason)
+
+	lastNonnilNodeIndex := len(n.nonnilPath) - 1
+	n.nonnilPath[lastNonnilNodeIndex].reason = fmt.Sprintf("%s (must be NONNIL)", n.nonnilPath[lastNonnilNodeIndex].reason)
+
+	flow := ""
+	for _, nodes := range [...][]node{n.nilPath, n.nonnilPath} {
+		for _, nodeObj := range nodes {
+			flow += nodeObj.String()
+		}
+	}
+	return flow
+}
+
+func (c *conflict) String() string {
+	consumerPos := c.nilFlow.nonnilPath[len(c.nilFlow.nonnilPath)-1].position
+	producerPos := c.nilFlow.nilPath[len(c.nilFlow.nilPath)-1].position
+	return fmt.Sprintf(" Nonnil `%s` expected at \"%s\", but produced as nilable at \"%s\". Observed nil flow from "+
+		"source to dereference: %s", c.expr, consumerPos.String(), producerPos.String(), c.nilFlow.String())
+}
+
+type conflictList struct {
+	conflicts []conflict
+}
+
+func (l *conflictList) addSingleAssertionConflict(pass *analysis.Pass, trigger annotation.FullTrigger) {
+	t := fullTriggerAsPrimitive(pass, trigger)
+	c := conflict{
+		position: t.Pos,
+		expr:     util.ExprToString(trigger.Consumer.Expr, pass),
+		nilFlow:  nilFlow{},
+	}
+
+	c.nilFlow.addNilPathNode(t.ProducerRepr)
+	c.nilFlow.addNonNilPathNode(t.ConsumerRepr)
+
+	l.conflicts = append(l.conflicts, c)
+}
+
+func (l *conflictList) addOverconstraintConflict(nilExplanation ExplainedBool, nonnilExplanation ExplainedBool, pass *analysis.Pass) {
+	c := conflict{}
+
+	// Build nil path by traversing the inference graph from `nilExplanation` part of the overconstraint failure.
+	// (Note that this traversal gives us a backward path from point of conflict to the source of nilability. Hence, we
+	// must take this into consideration while printing the flow.)
+	var queue []ExplainedBool
+	queue = append(queue, nilExplanation)
+
+	for len(queue) > 0 {
+		e := queue[0]
+		queue = queue[1:]
+
+		t := e.getPrimitiveFullTrigger()
+		if t.ConsumerRepr != nil && t.ProducerRepr != nil {
+			c.nilFlow.addNilPathNode(t.ConsumerRepr)
+			c.nilFlow.addNilPathNode(t.ProducerRepr)
+		} else {
+			c.nilFlow.addNilPathNode(annotation.LocatedPrestring{
+				Contained: e,
+				Location:  util.TruncatePosition(pass.Fset.Position(t.Pos)),
+			})
 		}
 
+		if e.getExplainedBool() != nil {
+			queue = append(queue, e.getExplainedBool())
+		}
+	}
+
+	// Build nonnil path by traversing the inference graph from `nonnilExplanation` part of the overconstraint failure.
+	// (Note that this traversal is forward from the point of conflict to dereference. Hence, we don't need to make
+	// any special considerations while printing the flow.)
+	queue = make([]ExplainedBool, 0)
+	queue = append(queue, nonnilExplanation)
+	for len(queue) > 0 {
+		e := queue[0]
+		queue = queue[1:]
+
+		t := e.getPrimitiveFullTrigger()
+		if t.ConsumerRepr != nil && t.ProducerRepr != nil {
+			c.nilFlow.addNonNilPathNode(t.ProducerRepr)
+			c.nilFlow.addNonNilPathNode(t.ConsumerRepr)
+			c.position = t.Pos
+		} else {
+			c.nilFlow.addNonNilPathNode(annotation.LocatedPrestring{
+				Contained: e,
+				Location:  util.TruncatePosition(pass.Fset.Position(t.Pos)),
+			})
+			c.position = t.Pos
+		}
+
+		if e.getExplainedBool() != nil {
+			queue = append(queue, e.getExplainedBool())
+		}
+	}
+
+	// add the expression that was overconstrained
+	c.expr = nonnilExplanation.getPrimitiveFullTrigger().ExprRepr
+
+	l.conflicts = append(l.conflicts, c)
+}
+
+func (l *conflictList) diagnostics() []analysis.Diagnostic {
+	var diagnostics []analysis.Diagnostic
+	for _, c := range l.conflicts {
 		diagnostics = append(diagnostics, analysis.Diagnostic{
-			Pos:     conflicts[0].getPosition(),
-			Message: fmt.Sprintf("%s%s%s", site, producer, consumer),
+			Pos:     c.position,
+			Message: c.String(),
 		})
 	}
 	return diagnostics
-}
-
-// A conflict indicates a conflict in inferred value for an annotation site found by the inference engine.
-type conflict interface {
-	getSiteMessage() string
-	getPosition() token.Pos
-	getProducerMessage() string
-	getConsumerMessage() string
-	key() groupKey
-}
-
-// A singleAssertionConflict represents a conflict of a single assertion because its producer was
-// already fixed to produce nilable, and its consumer was already fixed to consume nonnil.
-// This could happen for some silly code like `var x X = nil; x.f` that does not depend at all on
-// annotations. A more complicated example of such conflict involves flows across different source
-// files in a package: the field `f` of some value of type `T` in one source file written with
-// `nil` and the same field `f` of `T` passed to a deeper field access without nil check in a
-// different source file.
-type singleAssertionConflict struct {
-	trigger         primitiveFullTrigger
-	originalTrigger annotation.FullTrigger
-}
-
-// newSingleAssertionConflict constructs and returns a singleAssertionConflict.
-func newSingleAssertionConflict(pass *analysis.Pass, trigger annotation.FullTrigger) *singleAssertionConflict {
-	return &singleAssertionConflict{
-		trigger:         fullTriggerAsPrimitive(pass, trigger),
-		originalTrigger: trigger,
-	}
-}
-
-// getSiteMessage returns the message for the site of the conflict. For a singleAssertionConflict, this is an empty string.
-func (t *singleAssertionConflict) getSiteMessage() string {
-	return ""
-}
-
-// getPosition returns the source code position of the conflict.
-func (t *singleAssertionConflict) getPosition() token.Pos {
-	return t.trigger.Pos
-}
-
-// getProducerMessage returns the error message to be reported for the producer part of the conflict.
-func (t *singleAssertionConflict) getProducerMessage() string {
-	return fmt.Sprintf(" Value %s (definitely nilable)", t.trigger.ProducerRepr)
-}
-
-// getConsumerMessage returns the error message to be reported for the consumer part of the conflict.
-func (t *singleAssertionConflict) getConsumerMessage() string {
-	return fmt.Sprintf(" and is %s (must be nonnil)", t.trigger.ConsumerRepr)
-}
-
-// key returns the key of the conflict group that this conflict belongs to.
-func (t *singleAssertionConflict) key() groupKey {
-	return t.originalTrigger.Producer
-}
-
-// An overconstrainedConflict represents a local annotation site that was constrained by two different
-// chains of assertions to be both nilable (true) and nonnil (false). It encodes the overconstrained
-// site, and the reason that the site had to be true and had to be false, as ExplainedBools.
-type overconstrainedConflict struct {
-	site             primitiveSite
-	trueExplanation  ExplainedBool
-	falseExplanation ExplainedBool
-}
-
-// newOverconstrainedConflict  constructs and returns an overconstrainedConflict.
-func newOverconstrainedConflict(site primitiveSite, trueExplanation, falseExplanation ExplainedBool) *overconstrainedConflict {
-	return &overconstrainedConflict{
-		site:             site,
-		trueExplanation:  trueExplanation,
-		falseExplanation: falseExplanation,
-	}
-}
-
-// getSiteMessage returns the message for the site of the conflict.
-func (t *overconstrainedConflict) getSiteMessage() string {
-	return fmt.Sprintf(" Annotation on %s overconstrained:", t.site.String())
-}
-
-// getPosition returns the source code position of the conflict.
-func (t *overconstrainedConflict) getPosition() token.Pos {
-	return t.site.Pos
-}
-
-// getProducerMessage returns the error message to be reported for the producer part of the conflict.
-func (t *overconstrainedConflict) getProducerMessage() string {
-	return fmt.Sprintf("\n\tMust be %s", t.trueExplanation.String())
-}
-
-// getConsumerMessage returns the error message to be reported for the consumer part of the conflict.
-func (t *overconstrainedConflict) getConsumerMessage() string {
-	return fmt.Sprintf("\n\t\tAND\n\tMust be %s", t.falseExplanation.String())
-}
-
-// key returns the key of the conflict group that this conflict belongs to.
-func (t *overconstrainedConflict) key() groupKey {
-	return t.trueExplanation
 }

--- a/inference/engine.go
+++ b/inference/engine.go
@@ -35,10 +35,10 @@ type Engine struct {
 	// construction of the engine and populated by the "Observe*" methods of the engine. Users
 	// should use the Engine.InferredMapWithDiagnostics() method to obtain the current inferred map.
 	inferredMap *InferredMap
-	// conflicts stores conflict groups encountered during the observations. It will be
+	// conflicts stores conflicts encountered during the observations. It will be
 	// converted to diagnostics and returned along with the current inferred map whenever users
 	// request it.
-	conflicts *conflictGrouping
+	conflicts *conflictList
 }
 
 // NewEngine constructs an inference engine that is ready to run inference.
@@ -46,7 +46,7 @@ func NewEngine(pass *analysis.Pass) *Engine {
 	return &Engine{
 		pass:        pass,
 		inferredMap: newInferredMap(),
-		conflicts:   newConflictGrouping(),
+		conflicts:   &conflictList{},
 	}
 }
 
@@ -108,9 +108,9 @@ func (e *Engine) ObserveAnnotations(pkgAnnotations *annotation.ObservedMap, mode
 	pkgAnnotations.Range(func(key annotation.Key, isDeep bool, val bool) {
 		site := newPrimitiveSite(key, isDeep)
 		if val {
-			e.observeSiteExplanation(site, TrueBecauseAnnotation{})
+			e.observeSiteExplanation(site, TrueBecauseAnnotation{Pos: site.Pos})
 		} else {
-			e.observeSiteExplanation(site, FalseBecauseAnnotation{})
+			e.observeSiteExplanation(site, FalseBecauseAnnotation{Pos: site.Pos})
 		}
 	}, mode != NoInfer)
 }
@@ -206,7 +206,7 @@ func (e *Engine) buildPkgInferenceMap(triggers []annotation.FullTrigger) {
 		case pKind == annotation.Always && cKind == annotation.Always:
 			// Producer always produces nilable value -> consumer always consumes nonnil value.
 			// We simply generate a failure for this case.
-			e.conflicts.addConflict(newSingleAssertionConflict(e.pass, trigger))
+			e.conflicts.addSingleAssertionConflict(e.pass, trigger)
 
 		case pKind == annotation.Always && (cKind == annotation.Conditional || cKind == annotation.DeepConditional):
 			// Producer always produces nilable value -> consumer unknown.
@@ -291,7 +291,7 @@ func (e *Engine) observeSiteExplanation(site primitiveSite, siteExplained Explai
 		if !v.Bool.Val() {
 			trueExplanation, falseExplanation = falseExplanation, trueExplanation
 		}
-		e.conflicts.addConflict(newOverconstrainedConflict(site, trueExplanation, falseExplanation))
+		e.conflicts.addOverconstraintConflict(trueExplanation, falseExplanation, e.pass)
 
 	case *UndeterminedVal:
 		e.inferredMap.StoreDetermined(site, siteExplained)
@@ -406,11 +406,9 @@ func GobRegister() {
 	gob.RegisterName(nextStr(), FalseBecauseShallowConstraint{})
 	gob.RegisterName(nextStr(), FalseBecauseDeepConstraint{})
 	gob.RegisterName(nextStr(), FalseBecauseAnnotation{})
-	gob.RegisterName(nextStr(), FalseBecauseMyopia{})
 	gob.RegisterName(nextStr(), TrueBecauseShallowConstraint{})
 	gob.RegisterName(nextStr(), TrueBecauseDeepConstraint{})
 	gob.RegisterName(nextStr(), TrueBecauseAnnotation{})
-	gob.RegisterName(nextStr(), TrueBecauseMyopia{})
 
 	gob.RegisterName(nextStr(), annotation.PtrLoadPrestring{})
 	gob.RegisterName(nextStr(), annotation.MapAccessPrestring{})

--- a/inference/explained_bool.go
+++ b/inference/explained_bool.go
@@ -16,6 +16,7 @@ package inference
 
 import (
 	"fmt"
+	"go/token"
 )
 
 // An ExplainedBool is a boolean value, wrapped by a "reason" that we came to the conclusion it should
@@ -29,6 +30,8 @@ import (
 type ExplainedBool interface {
 	Val() bool
 	String() string
+	getPrimitiveFullTrigger() primitiveFullTrigger
+	getExplainedBool() ExplainedBool
 }
 
 // ExplainedTrue is a common embedding in all instances of ExplainedBool that wrap the value `true`
@@ -64,6 +67,14 @@ func (t TrueBecauseShallowConstraint) String() string {
 		t.ExternalAssertion.ConsumerRepr, t.ExternalAssertion.ProducerRepr)
 }
 
+func (t TrueBecauseShallowConstraint) getPrimitiveFullTrigger() primitiveFullTrigger {
+	return t.ExternalAssertion
+}
+
+func (t TrueBecauseShallowConstraint) getExplainedBool() ExplainedBool {
+	return nil
+}
+
 // FalseBecauseShallowConstraint is used as the label for site X when an assertion of the form
 // `nilable X -> nilable Y` is discovered and the trigger for `nilable Y` always fires (i.e. yields
 // nonnil) - for example because it is the dereferenced as a pointer or passed to a field access. In
@@ -79,6 +90,14 @@ func (f FalseBecauseShallowConstraint) String() string {
 	return fmt.Sprintf(
 		"NONNIL because it describes the value %s, and that value is %s, where it must be NONNIL",
 		f.ExternalAssertion.ProducerRepr, f.ExternalAssertion.ConsumerRepr)
+}
+
+func (f FalseBecauseShallowConstraint) getPrimitiveFullTrigger() primitiveFullTrigger {
+	return f.ExternalAssertion
+}
+
+func (f FalseBecauseShallowConstraint) getExplainedBool() ExplainedBool {
+	return nil
 }
 
 // TrueBecauseDeepConstraint is used as the label for a site Y when an assertion of the form
@@ -97,6 +116,14 @@ func (t TrueBecauseDeepConstraint) String() string {
 		t.InternalAssertion.ConsumerRepr, t.InternalAssertion.ProducerRepr, t.DeeperExplanation.String())
 }
 
+func (t TrueBecauseDeepConstraint) getPrimitiveFullTrigger() primitiveFullTrigger {
+	return t.InternalAssertion
+}
+
+func (t TrueBecauseDeepConstraint) getExplainedBool() ExplainedBool {
+	return t.DeeperExplanation
+}
+
 // FalseBecauseDeepConstraint is used as the label for a site X when an assertion of the form
 // `nilable X -> nilable Y` is discovered along with some reason for Y to be nonnil, besides it
 // necessarily being so because it always fires. This reason could be any ExplainedFalse - such as
@@ -113,44 +140,48 @@ func (f FalseBecauseDeepConstraint) String() string {
 		f.InternalAssertion.ProducerRepr, f.InternalAssertion.ConsumerRepr, f.DeeperExplanation.String())
 }
 
+func (f FalseBecauseDeepConstraint) getPrimitiveFullTrigger() primitiveFullTrigger {
+	return f.InternalAssertion
+}
+
+func (f FalseBecauseDeepConstraint) getExplainedBool() ExplainedBool {
+	return f.DeeperExplanation
+}
+
 // TrueBecauseAnnotation is used as the label for a site X on which a literal annotation "//nilable(x)"
 // has been discovered - forcing that site to be nilable.
 type TrueBecauseAnnotation struct {
 	ExplainedTrue
+	Pos token.Pos
 }
 
 func (TrueBecauseAnnotation) String() string {
 	return "NILABLE because it is annotated as so"
 }
 
+func (t TrueBecauseAnnotation) getPrimitiveFullTrigger() primitiveFullTrigger {
+	return primitiveFullTrigger{Pos: t.Pos}
+}
+
+func (t TrueBecauseAnnotation) getExplainedBool() ExplainedBool {
+	return nil
+}
+
 // FalseBecauseAnnotation is used as the label for a site X on which a literal annotation "//nonnil(x)"
 // has been discovered - forcing that site to be nonnil.
 type FalseBecauseAnnotation struct {
 	ExplainedFalse
+	Pos token.Pos
 }
 
 func (FalseBecauseAnnotation) String() string {
 	return "NONNIL because it is annotated as so"
 }
 
-// TrueBecauseMyopia is used as the label for a site X that a myopic inference procedure decided should
-// be nilable
-type TrueBecauseMyopia struct {
-	ExplainedTrue
-	PkgName string
+func (f FalseBecauseAnnotation) getPrimitiveFullTrigger() primitiveFullTrigger {
+	return primitiveFullTrigger{Pos: f.Pos}
 }
 
-func (t TrueBecauseMyopia) String() string {
-	return fmt.Sprintf("NILABLE because myopic annotation inference for package %s decided so", t.PkgName)
-}
-
-// FalseBecauseMyopia is used as the label for a site X that a myopic inference procedure decided should
-// be nonnil
-type FalseBecauseMyopia struct {
-	ExplainedFalse
-	PkgName string
-}
-
-func (f FalseBecauseMyopia) String() string {
-	return fmt.Sprintf("NONNIL because myopic annotation inference for package %s decided so", f.PkgName)
+func (f FalseBecauseAnnotation) getExplainedBool() ExplainedBool {
+	return nil
 }

--- a/inference/primitive.go
+++ b/inference/primitive.go
@@ -18,6 +18,7 @@ import (
 	"go/token"
 
 	"go.uber.org/nilaway/annotation"
+	"go.uber.org/nilaway/util"
 	"golang.org/x/tools/go/analysis"
 )
 
@@ -36,6 +37,7 @@ type primitiveFullTrigger struct {
 	ProducerRepr annotation.Prestring
 	ConsumerRepr annotation.Prestring
 	Pos          token.Pos
+	ExprRepr     string
 }
 
 func fullTriggerAsPrimitive(pass *analysis.Pass, trigger annotation.FullTrigger) primitiveFullTrigger {
@@ -44,6 +46,7 @@ func fullTriggerAsPrimitive(pass *analysis.Pass, trigger annotation.FullTrigger)
 		ProducerRepr: producer,
 		ConsumerRepr: consumer,
 		Pos:          trigger.Consumer.Expr.Pos(),
+		ExprRepr:     util.ExprToString(trigger.Consumer.Expr, pass),
 	}
 }
 

--- a/testdata/src/go.uber.org/anonymousfunction/anonymous_functions_assignment.go
+++ b/testdata/src/go.uber.org/anonymousfunction/anonymous_functions_assignment.go
@@ -18,15 +18,15 @@ package anonymousfunction
 
 func testSimpleAssignment() {
 	var t1 *int
-	a := func() { // want "value is read from a variable that was never assigned to"
-		print(*t1)
+	a := func() {
+		print(*t1) //want "read from a variable that was never assigned to"
 	}
 	a() // at this call t1 is nil
 
 	var t2 *int
-	b := func() { // want "Annotation on Param 1: 't2'"
+	b := func() {
 		print(*t1)
-		print(*t2)
+		print(*t2) //want "read from the function parameter `t2`"
 	}
 
 	i := 1
@@ -38,10 +38,10 @@ func testSimpleAssignment() {
 
 func testAssignOneToOneAssingments() {
 	var t1 *int
-	a, b := func(t *int) { // want "value is read from a variable that was never assigned to"
-		print(*t)
-	}, func(t2 *int) { // want "value is read from a variable that was never assigned to"
-		print(*t2)
+	a, b := func(t *int) {
+		print(*t) //want "read from a variable that was never assigned to"
+	}, func(t2 *int) {
+		print(*t2) //want "read from a variable that was never assigned to"
 	}
 	a(t1)
 	b(t1)
@@ -51,13 +51,13 @@ func testAssignOneToOneAssingments() {
 func testNestedAnonymousFuncAssignment() {
 	var t1 *int
 	var t2 *int
-	a := func() { // want "Annotation on Param 0: 't1'"
-		print(*t1)
+	a := func() {
+		print(*t1) //want "read from a variable that was never assigned to"
 		var t2 *int
-		print(*t2)    // want "Value read from a variable that was never assigned to "
-		b := func() { // want "Annotation on Param 0: 't1'" "Annotation on Param 1: 't2'"
-			print(*t1) // this is not ok
-			print(*t2) // this is not ok
+		print(*t2) //want "read from a variable that was never assigned to"
+		b := func() {
+			print(*t1) //want "read from a variable that was never assigned to"
+			print(*t2) //want "read from a variable that was never assigned to"
 			if t2 != nil {
 				print(*t2) // this is ok
 			}
@@ -73,13 +73,13 @@ func testNestedAnonymousFuncAssignment() {
 func testImplicitAndExplicitArguments() {
 	var t1 *int
 	var t2 *int
-	f := func(t *int) { // want "Annotation on Param 0: 't' "
-		print(*t) // this is not ok
+	f := func(t *int) {
+		print(*t) //want "read from a variable that was never assigned to"
 		// the following erros are for t3 and p2
-		g := func(p *int) { // want "Annotation on Param 0: 'p'" "Annotation on Param 2: 't2'"
+		g := func(p *int) {
 			print(*t)
-			print(*p)
-			print(*t2)
+			print(*p)  //want "read from a variable that was never assigned to"
+			print(*t2) //want "read from a variable that was never assigned to"
 		}
 		i := 1
 		t = &i
@@ -94,8 +94,8 @@ func testShadowedClosureVariable() {
 	i := 1
 	b := &i
 
-	func() { // want "Annotation on Param 0: 'a'"
-		print(*a)
+	func() {
+		print(*a) //want "read from a variable that was never assigned to"
 		func(a *int) {
 			print(*a) // this is actually ok since `a` is shadowed and we are passing a nonnil argument at the call site.
 		}(b)

--- a/testdata/src/go.uber.org/anonymousfunction/argument_passing_explicitly.go
+++ b/testdata/src/go.uber.org/anonymousfunction/argument_passing_explicitly.go
@@ -22,8 +22,8 @@ func testPassingArgsExplicityToAnonFuncs() {
 
 	// Passing nilable variables as parameters.
 	var t1 *int
-	func(t *int) { // want "value is read from a variable that was never assigned to"
-		print(*t)
+	func(t *int) {
+		print(*t) //want "read from a variable that was never assigned to"
 	}(t1)
 
 	func(t *int) {
@@ -40,8 +40,8 @@ func testPassingArgsExplicityToAnonFuncs() {
 
 	// Pass nilable struct as parameter.
 	var t3 *A
-	func(t *A) *int { // want "value is read from a variable that was never assigned to"
-		return t.a
+	func(t *A) *int {
+		return t.a //want "read from a variable that was never assigned to"
 	}(t3)
 
 	// test nested anonymous function
@@ -49,9 +49,9 @@ func testPassingArgsExplicityToAnonFuncs() {
 	var t4 *int
 	func(t *int) {
 		var t2 *int
-		func(n1 *int, n2 *int) { // want "Annotation on Param 0: 'n1'" "Annotation on Param 1: 'n2'"
-			print(*n1)
-			print(*n2)
+		func(n1 *int, n2 *int) {
+			print(*n1) //want "read from a variable that was never assigned to"
+			print(*n2) //want "read from a variable that was never assigned to"
 		}(t, t2)
 	}(t4)
 
@@ -61,9 +61,9 @@ func testPassingArgsExplicityToAnonFuncs() {
 		print(*t)
 		var t2 *int
 		// the following error is coming from n2 but not from n1
-		func(n1 *int, n2 *int) { // want "Annotation on Param 1: 'n2'"
+		func(n1 *int, n2 *int) {
 			print(*n1) // this should be ok
-			print(*n2) // this is not
+			print(*n2) //want "read from a variable that was never assigned to"
 			if n2 != nil {
 				print(*n2) // this is ok
 			}
@@ -75,14 +75,14 @@ type B struct{}
 
 func (b *B) testOverWriteReceiver() {
 	b = nil
-	func() { // want "Annotation on Param 0: 'b'"
-		print(*b)
+	func() {
+		print(*b) //want "literal nil"
 	}()
 }
 
 func (b *B) testPassReceiver() {
-	func(nb *B) { //want "Annotation on Param 0: 'nb'"
-		print(*nb) // this is not ok
+	func(nb *B) {
+		print(*nb) //want "read from a variable that was never assigned to"
 	}(b)
 }
 

--- a/testdata/src/go.uber.org/anonymousfunction/argument_passing_implicitly.go
+++ b/testdata/src/go.uber.org/anonymousfunction/argument_passing_implicitly.go
@@ -19,8 +19,8 @@ package anonymousfunction
 func testNilFlowFromClosure() {
 
 	var t *int
-	func() { // want "Annotation on Param 0: 't'"
-		print(*t)
+	func() {
+		print(*t) //want "read from a variable that was never assigned to"
 	}()
 
 	i := 1
@@ -36,10 +36,9 @@ func testNilFlowFromClosure() {
 
 	t = nil
 
-	// (Note: below 'want' captures the grouped error reported for both the print calls)
-	func() { //want "Annotation on Param 0: 't'"
-		print(*t)
-		print(*t)
+	func() {
+		print(*t) // want "literal nil"
+		print(*t) // want "literal nil"
 	}()
 
 	t = &i
@@ -47,7 +46,7 @@ func testNilFlowFromClosure() {
 	func() {
 		print(*t)
 		t = nil
-		print(*t) // want "Value literal nil at"
+		print(*t) // want "literal nil"
 	}()
 
 	// TODO we will report an error here after updating the return type of function literals to include variables from closure
@@ -58,9 +57,9 @@ func testNilFlowFromClosure() {
 	var t1 *int
 	func() {
 		var t2 *int
-		func() { // want "Annotation on Param 0: 't1'" "Annotation on Param 1: 't2'"
-			print(*t1)
-			print(*t2)
+		func() {
+			print(*t1) //want "read from a variable that was never assigned to"
+			print(*t2) //want "read from a variable that was never assigned to"
 		}()
 	}()
 
@@ -70,9 +69,9 @@ func testNilFlowFromClosure() {
 		print(*t3)
 		var t4 *int
 		// the following error is coming from t4 but not from t3
-		func() { // want "Annotation on Param 1: 't4'"
+		func() {
 			print(*t3) // this should be ok
-			print(*t4) // this is not
+			print(*t4) //want "read from a variable that was never assigned to"
 			if t4 != nil {
 				print(*t4) // this is ok
 			}
@@ -80,10 +79,10 @@ func testNilFlowFromClosure() {
 	}()
 
 	var t5 *int
-	func() { // want "Annotation on Param 2: 't5'" "Annotation on Param 0: 't1'"
-		print(*t1)
+	func() {
+		print(*t1) //want "read from a variable that was never assigned to"
 		print(*t3)
-		print(*t5)
+		print(*t5) //want "read from a variable that was never assigned to"
 	}()
 
 }

--- a/testdata/src/go.uber.org/anonymousfunction/simple.go
+++ b/testdata/src/go.uber.org/anonymousfunction/simple.go
@@ -27,14 +27,13 @@ package anonymousfunction
 // nonnil(c)
 // nonnil(d)
 type A struct {
-	// ERROR_GROUP: two nilable flows in the program, so NilAway will be reporting a grouped error message with two consumption sites for the following line
-	a *int //want "value read from the field `a`"
+	a *int
 	b *A
 	c *A
 	d *int
 }
 
-func retNilable() *int { // want "returned from the function `retNilable` in position 0"
+func retNilable() *int {
 	return nil
 }
 
@@ -42,33 +41,33 @@ func simple() {
 	// Here we test nilability analysis _inside_ the anonymous functions, where no interactions
 	// happen between the anonymous functions and the outside world.
 	aNonnilPtr := &A{}
-	print(*(aNonnilPtr.a)) // ERROR_GROUP: consumption site 1: reported at A.a declaration
+	print(*(aNonnilPtr.a)) //want "it is annotated"
 
 	func() {
 		var t *int
-		print(*t) // want "Value read from a variable that was never assigned"
+		print(*t) // want "read from a variable that was never assigned"
 		t2 := 1
 		ptr := &t2
 		print(*ptr)
 		t3 := retNilable()
-		print(*t3) // (this deref is reported at retNilable declaration)
+		print(*t3) //want "returned as result 0 from the method `retNilable`"
 		var aPtr *A
-		print(*aPtr) // want "Value read from a variable that was never assigned"
+		print(*aPtr) // want "read from a variable that was never assigned"
 		aNonnilPtr := &A{}
-		print(*(aNonnilPtr.a)) // ERROR_GROUP: consumption site 2: reported at A.a declaration
+		print(*(aNonnilPtr.a)) //want "it is annotated"
 		// A.c is marked as nonnil, so it is ok to dereference.
 		print(aNonnilPtr.c.a)
 	}()
 
 	a := func() {
 		var t *int
-		print(*t) // want "Value read from a variable that was never assigned"
+		print(*t) // want "read from a variable that was never assigned"
 	}
 	print(a)
 
 	var f func() = func() {
 		var t *int
-		print(*t) // want "Value read from a variable that was never assigned"
+		print(*t) // want "read from a variable that was never assigned"
 	}
 
 	f()
@@ -79,11 +78,11 @@ func nestedFunc() {
 	func() {
 		func() {
 			var t *int
-			print(*t) // want "Value read from a variable that was never assigned"
+			print(*t) // want "read from a variable that was never assigned"
 		}()
 		a := func() {
 			var t *int
-			print(*t) // want "Value read from a variable that was never assigned"
+			print(*t) // want "read from a variable that was never assigned"
 		}
 		print(a)
 	}()
@@ -92,7 +91,7 @@ func nestedFunc() {
 		func() {
 			func() {
 				var t *int
-				print(*t) // want "Value read from a variable that was never assigned"
+				print(*t) // want "read from a variable that was never assigned"
 			}()
 		}()
 	}()
@@ -100,5 +99,5 @@ func nestedFunc() {
 
 var a = func() {
 	var t *int
-	print(*t) // want "Value read from a variable that was never assigned"
+	print(*t) // want "read from a variable that was never assigned"
 }

--- a/testdata/src/go.uber.org/errorreturn/inference/errorreturn-with-inference.go
+++ b/testdata/src/go.uber.org/errorreturn/inference/errorreturn-with-inference.go
@@ -46,7 +46,7 @@ func retPtrAndErr2(i int) (*int, error) {
 	return &i, retNilErr2()
 }
 
-func testFuncRet2(i int) (*int, error) { //want "Annotation on Result 0 of Function testFuncRet2 overconstrained" "Annotation on Result 0 of Function testFuncRet2 overconstrained"
+func testFuncRet2(i int) (*int, error) {
 
 	var errNil = retNilErr2()
 	var errNonNil = retNonNilErr2()
@@ -75,7 +75,7 @@ func testFuncRet2(i int) (*int, error) { //want "Annotation on Result 0 of Funct
 
 func calltestFuncRet2() {
 	if v, err := testFuncRet2(0); err == nil {
-		print(*v)
+		print(*v) //want "error return in position 1 is not guaranteed to be non-nil through all paths" "error return in position 1 is not guaranteed to be non-nil through all paths"
 	}
 }
 
@@ -113,7 +113,7 @@ func callFoo5() {
 }
 
 // ***** the below test case checks mixed nilability in the presence of a nil error return expression *****
-func retPtrPtrErr(i, j int) (*int, *int, error) { //want "Annotation on Result 0 of Function retPtrPtrErr overconstrained" "Annotation on Result 1 of Function retPtrPtrErr overconstrained"
+func retPtrPtrErr(i, j int) (*int, *int, error) {
 	var e = retNilErr2()
 	switch i {
 	case 0:
@@ -136,7 +136,7 @@ func callRetPtrPtrErr() {
 		print(err.Error())
 	} else {
 		// Even with error checking, these are nilable pointers (see retPtrPtrErr above)!
-		_, _ = *a, *b
+		_, _ = *a, *b //want "error return in position 2 is not guaranteed to be non-nil through all paths" "error return in position 2 is not guaranteed to be non-nil through all paths"
 	}
 }
 
@@ -158,7 +158,7 @@ func callTestOtherPkg() {
 }
 
 // ***** below is a test case with mixed up error usage *****
-func launderWrongError(i int) (*int, error) { //want "Annotation on Result 0"
+func launderWrongError(i int) (*int, error) {
 	v1, err1 := retPtrAndErr2(i)
 	v2, err2 := retPtrAndErr2(i + 1)
 	if err1 == nil {
@@ -173,6 +173,6 @@ func launderWrongError(i int) (*int, error) { //want "Annotation on Result 0"
 
 func checkAndDeref() {
 	if x, err := launderWrongError(0); err == nil {
-		_ = *x
+		_ = *x //want "error return in position 1 is not guaranteed to be non-nil through all paths"
 	}
 }

--- a/testdata/src/go.uber.org/receivers/inference/receivers-with-inference.go
+++ b/testdata/src/go.uber.org/receivers/inference/receivers-with-inference.go
@@ -27,8 +27,8 @@ func (a *A) nilableRecv() string {
 	return a.f
 }
 
-func (a *A) nonnilRecv() string { //want "Annotation on Receiver of Method nonnilRecv overconstrained" "Annotation on Receiver of Method nonnilRecv overconstrained"
-	return a.f
+func (a *A) nonnilRecv() string {
+	return a.f //want "read from the receiver" "read from the receiver"
 }
 
 func newA() *A {
@@ -55,20 +55,20 @@ func testRecv() {
 // the below test checks for in-scope analysis of receivers. If a receiver-based call is made to an external method,
 // such as `err.Error()`, then it is treated as a normal field access of `err`, reporting an error if `err == nil`.
 
-func (a *A) retErr() error { //want "Annotation on Result 0 of Function retErr overconstrained"
+func (a *A) retErr() error {
 	return nil
 }
 
 func testInScope() {
 	var a *A
 	err := a.retErr()
-	print(err.Error())
+	print(err.Error()) //want "returned as the error result 0 of function `retErr`"
 }
 
 // -----------------------------------
 // the below test checks affiliation (interface-struct) case. Currently, this is out of scope. We don't analyze affiliations
 // for tracking nilable receivers, hence an error should be thrown at the call site itself following the default behavior.
-// This may result in false positives, but this decision was made owing to the challenges discussed in .
+// This may result in false positives, but this decision was made owing to the challenges discussed in PROGSYS-936.
 
 type I interface {
 	foo()
@@ -86,16 +86,19 @@ func (s *S) foo() {
 	}
 }
 
-func newI1() I { //want "Annotation on Result 0 of Function newI1 overconstrained"
+func newI1() I {
 	return nil
 }
 
-func newI2() I { //want "Annotation on Result 0 of Function newI2 overconstrained"
+func newI2() I {
 	var s *S
 	return s
 }
 
 func testAffiliation() {
-	newI1().foo() // TP since it's the case of untyped nil
-	newI2().foo() // FP since affiliations are not tracked for nilable receivers
+	// TP since it's the case of untyped nil
+	newI1().foo() //want "returned as result 0 from the method `newI1`"
+
+	// FP since affiliations are not tracked for nilable receivers
+	newI2().foo() //want "returned as result 0 from the method `newI2`"
 }

--- a/testdata/src/go.uber.org/slices/inference/slices-with-inference.go
+++ b/testdata/src/go.uber.org/slices/inference/slices-with-inference.go
@@ -32,20 +32,20 @@ func testInterProcedural() {
 		helperSliceParamForNonNilParam(nonNilA[0:])
 
 		// non-zero slicing triggering non-nil producer all the time, e.g, [1:3]
-		helperSliceParamForNonNilParam(nilA[1:3]) //want "Value literal nil at \"(.*)\" \\(definitely nilable\\) and is sliced into"
+		helperSliceParamForNonNilParam(nilA[1:3]) //want "literal nil"
 		helperSliceParamForNonNilParam(nonNilA[1:3])
 	case 2:
 		// use slicing as return result
 
 		// zero slicing triggering nil producer all the time, e.g., [:0]
 		b := helperReturnZeroSlicingAlwaysNilProducerForNilableParam(nilA)
-		print(b[1])
+		print(b[1]) //want "sliced into"
 		c := helperReturnZeroSlicingAlwaysNilProducerForNonNilParam(nonNilA)
-		print(c[1])
+		print(c[1]) //want "sliced into"
 
 		// zero slicing that preserves nilability of original slice, e.g., [0:]
 		b = helperReturnZeroSlicingPreserveForNilableParam(nilA)
-		print(b[1])
+		print(b[1]) //want "sliced into"
 		c = helperReturnZeroSlicingPreserveForNonNilParam(nonNilA)
 		print(c[1])
 
@@ -57,31 +57,31 @@ func testInterProcedural() {
 	}
 }
 
-func helperSliceParamForNilableParam1(b []int) { //want "Annotation on Param 0: 'b'"
-	print(b[0])
+func helperSliceParamForNilableParam1(b []int) {
+	print(b[0]) //want "sliced into"
 }
 
-func helperSliceParamForNilableParam2(b []int) { //want "Annotation on Param 0: 'b'"
-	print(b[0])
+func helperSliceParamForNilableParam2(b []int) {
+	print(b[0]) //want "sliced into"
 }
 
-func helperSliceParamForNilableParam3(b []int) { //want "Annotation on Param 0: 'b'"
-	print(b[0])
+func helperSliceParamForNilableParam3(b []int) {
+	print(b[0]) //want "sliced into"
 }
 
 func helperSliceParamForNonNilParam(b []int) {
 	print(b[0])
 }
 
-func helperReturnZeroSlicingAlwaysNilProducerForNilableParam(b []int) []int { //want "Annotation on Result 0"
+func helperReturnZeroSlicingAlwaysNilProducerForNilableParam(b []int) []int {
 	return b[:0]
 }
 
-func helperReturnZeroSlicingAlwaysNilProducerForNonNilParam(b []int) []int { //want "Annotation on Result 0"
+func helperReturnZeroSlicingAlwaysNilProducerForNonNilParam(b []int) []int {
 	return b[:0]
 }
 
-func helperReturnZeroSlicingPreserveForNilableParam(b []int) []int { //want "Annotation on Result 0"
+func helperReturnZeroSlicingPreserveForNilableParam(b []int) []int {
 	return b[0:]
 }
 
@@ -89,8 +89,8 @@ func helperReturnZeroSlicingPreserveForNonNilParam(b []int) []int {
 	return b[0:]
 }
 
-func helperReturnNonZeroSlicingNonNilProducerForNilableParam(b []int) []int { //want "Annotation on Param 0: 'b'"
-	return b[1:3]
+func helperReturnNonZeroSlicingNonNilProducerForNilableParam(b []int) []int {
+	return b[1:3] //want "sliced into"
 }
 
 func helperReturnNonZeroSlicingNonNilProducerForNonNilParam(b []int) []int {

--- a/testdata/src/go.uber.org/structinit/defaultfield/defaultfield.go
+++ b/testdata/src/go.uber.org/structinit/defaultfield/defaultfield.go
@@ -24,7 +24,7 @@ package defaultfield
 // This gives an error since field aptr escapes
 
 type A10 struct {
-	aptr *A10 //want "Annotation on escaped Field aptr overconstrained"
+	aptr *A10
 	ptr  *int
 }
 
@@ -35,18 +35,18 @@ func m() *A10 {
 
 func m3(a *A10) {
 	// relies on default annotation of field aptr since we don't track field at depth >=2
-	print(a.aptr.aptr.ptr)
+	print(a.aptr.aptr.ptr) //want "read from the field `aptr`"
 }
 
 // This should give an error since aptr escapes
 
 type A11 struct {
 	ptr  *int
-	aptr *A11 //want "Annotation on escaped Field aptr overconstrained"
+	aptr *A11
 }
 
 func m11(c *A11) {
-	print(c.aptr.aptr.ptr)
+	print(c.aptr.aptr.ptr) //want "escaped field `aptr`"
 }
 
 func callEscape() {
@@ -54,7 +54,7 @@ func callEscape() {
 	escape11(&A11{})
 }
 
-// TODO: We should only call param fields escaping if the callee function is not analyzed by NilAway
+// TODO: We should only call param fields escaping if the callee function is not analyzed by NilAway (PROGSYS-587)
 func escape11(a *A11) {
 	// no-op
 }
@@ -74,11 +74,11 @@ func m12(c *A12) {
 
 type A13 struct {
 	ptr  *int
-	aptr *A13 //want "Annotation on escaped Field aptr overconstrained"
+	aptr *A13
 }
 
 func m13(c *A13) {
-	print(c.aptr.aptr.ptr)
+	print(c.aptr.aptr.ptr) //want "escaped field `aptr`"
 }
 
 func escape13() *A13 {
@@ -94,7 +94,7 @@ type A14 struct {
 }
 
 type B14 struct {
-	cptr *C14 //want "Annotation on escaped Field cptr overconstrained"
+	cptr *C14
 }
 
 type C14 struct {
@@ -103,7 +103,7 @@ type C14 struct {
 
 func m21(c *A14) {
 	// relies on default annotation of field cptr
-	print(c.bptr.cptr.ptr)
+	print(c.bptr.cptr.ptr) //want "escaped field `cptr`"
 }
 
 func escape14(a *B14) {

--- a/testdata/src/go.uber.org/structinit/funcreturnfields/funcreturnbasic.go
+++ b/testdata/src/go.uber.org/structinit/funcreturnfields/funcreturnbasic.go
@@ -51,18 +51,18 @@ type A12 struct {
 	aptr *A12
 }
 
-func giveEmptyA12() *A12 { //want "Annotation on Field aptr of Result 0 of Function giveEmptyA12 overconstrained"
+func giveEmptyA12() *A12 {
 	t := &A12{}
 	return t
 }
 
 func m12() *int {
 	var b = giveEmptyA12()
-	return b.aptr.ptr
+	return b.aptr.ptr //want "unassigned at struct initialization"
 }
 
 // Testing function with multiple returns
-func giveOneEmptyAndOneNonEmptyA12() (*A12, *A12) { //want "Annotation on Field aptr of Result 1 of Function giveOneEmptyAndOneNonEmptyA12 overconstrained"
+func giveOneEmptyAndOneNonEmptyA12() (*A12, *A12) {
 	t1 := &A12{}
 	t1.aptr = new(A12)
 
@@ -73,18 +73,18 @@ func giveOneEmptyAndOneNonEmptyA12() (*A12, *A12) { //want "Annotation on Field 
 
 func m123() {
 	var b1, b2 = giveOneEmptyAndOneNonEmptyA12()
-	print(b1.aptr.ptr, b2.aptr.ptr)
+	print(b1.aptr.ptr, b2.aptr.ptr) //want "unassigned at struct initialization"
 }
 
 // Testing function with multiple returns
-func giveTwoEmptyA12() (*A12, *A12) { //want "Annotation on Field aptr of Result 0 of Function giveTwoEmptyA12 overconstrained" "Annotation on Field aptr of Result 1 of Function giveTwoEmptyA12 overconstrained"
+func giveTwoEmptyA12() (*A12, *A12) {
 	t1 := &A12{}
 	return t1, t1
 }
 
 func m124() {
 	var b1, b2 = giveTwoEmptyA12()
-	print(b1.aptr.ptr, b2.aptr.ptr)
+	print(b1.aptr.ptr, b2.aptr.ptr) //want "unassigned at struct initialization" "unassigned at struct initialization"
 }
 
 // Testing function with multiple returns
@@ -100,42 +100,42 @@ func m125() {
 }
 
 // In this test, rhs giveEmptyA122(someInt) is not a stable expression
-func giveEmptyA122(someInt int) *A12 { //want "Annotation on Field aptr of Result 0 of Function giveEmptyA122 overconstrained"
+func giveEmptyA122(someInt int) *A12 {
 	t := &A12{}
 	return t
 }
 
 func m122(someInt int) *int {
 	var b = giveEmptyA122(someInt)
-	return b.aptr.ptr
+	return b.aptr.ptr //want "field `aptr` of return of the function `giveEmptyA122`"
 }
 
 // In this test case, B12 is named type
 
 type B12 A12
 
-func giveEmptyB12() *B12 { //want "Annotation on Field aptr of Result 0 of Function giveEmptyB12 overconstrained"
+func giveEmptyB12() *B12 {
 	t := &B12{}
 	return t
 }
 
 func mb12() *int {
 	var b = giveEmptyB12()
-	return b.aptr.ptr
+	return b.aptr.ptr //want "field `aptr` of return of the function `giveEmptyB12`"
 }
 
 // In this test case, B122 is named type
 
 type B122 = A12
 
-func giveEmptyB122() *B122 { //want "Annotation on Field aptr of Result 0 of Function giveEmptyB122 overconstrained"
+func giveEmptyB122() *B122 {
 	t := &B122{}
 	return t
 }
 
 func mb122() *int {
 	var b = giveEmptyB122()
-	return b.aptr.ptr
+	return b.aptr.ptr //want "field `aptr` of return of the function `giveEmptyB122`"
 }
 
 // In the following test case we have an anonymous field from different package
@@ -144,11 +144,11 @@ type fakeSchema struct {
 	packageone.S
 }
 
-func slice() packageone.S { //want "Annotation on Result 0 of Function slice overconstrained"
+func slice() packageone.S {
 	f := &fakeSchema{}
 	return f.S
 }
 
 func m3() {
-	print(slice()[0])
+	print(slice()[0]) //want "sliced into"
 }

--- a/testdata/src/go.uber.org/structinit/funcreturnfields/funcreturnwitherrors.go
+++ b/testdata/src/go.uber.org/structinit/funcreturnfields/funcreturnwitherrors.go
@@ -37,7 +37,7 @@ func m09() *int {
 }
 
 // Testing interaction with error semantics: 2.
-func giveEmptyACompositeWithErr2() (*A11, error) { //want "Annotation on Field aptr of Result 0 of Function giveEmptyACompositeWithErr2 overconstrained:"
+func giveEmptyACompositeWithErr2() (*A11, error) {
 	return &A11{}, nil
 }
 
@@ -47,12 +47,12 @@ func m88() *int {
 		return new(int)
 	}
 	// This should give an error
-	return t.aptr.ptr
+	return t.aptr.ptr //want "field `aptr` of return of the function `giveEmptyACompositeWithErr2`"
 }
 
 // Testing interaction with error semantics: 3.
 func dummy() bool { return true }
-func giveEmptyACompositeWithErr3() (*A11, error) { //want "Annotation on Field aptr of Result 0 of Function giveEmptyACompositeWithErr3 overconstrained:"
+func giveEmptyACompositeWithErr3() (*A11, error) {
 	if dummy() {
 		return &A11{}, nil
 	} else {
@@ -66,7 +66,7 @@ func m78() *int {
 		return new(int)
 	}
 	// This should give an error
-	return t.aptr.ptr
+	return t.aptr.ptr //want "field `aptr` of return of the function `giveEmptyACompositeWithErr3`"
 }
 
 // Testing interaction with error semantics: 4.
@@ -102,7 +102,7 @@ func m58() *int {
 }
 
 // Testing interaction with error semantics: 6.
-func giveEmptyACompositeWithErr6() (*A11, error) { //want "Annotation on Field aptr of Result 0 of Function giveEmptyACompositeWithErr6 overconstrained"
+func giveEmptyACompositeWithErr6() (*A11, error) {
 	if dummy() {
 		return &A11{}, nil
 	} else {
@@ -116,11 +116,11 @@ func m68() *int {
 		return new(int)
 	}
 	// This should give an error
-	return t.aptr.ptr
+	return t.aptr.ptr //want "field `aptr` of return of the function `giveEmptyACompositeWithErr6`"
 }
 
 // test case for named return
-func m98() (a *A11, e error) { //want "Annotation on Field aptr of Result 0 of Function m98 overconstrained"
+func m98() (a *A11, e error) {
 	a = &A11{}
 	return
 }
@@ -128,6 +128,6 @@ func m98() (a *A11, e error) { //want "Annotation on Field aptr of Result 0 of F
 func callM98() {
 	t, err := m98()
 	if err == nil {
-		print(t.aptr.ptr)
+		print(t.aptr.ptr) //want "field `aptr` of return of the function `m98`"
 	}
 }

--- a/testdata/src/go.uber.org/structinit/funcreturnfields/functionreturntransitive.go
+++ b/testdata/src/go.uber.org/structinit/funcreturnfields/functionreturntransitive.go
@@ -20,24 +20,24 @@ package funcreturnfields
 
 // Testing with direct return of a composite literal initialization of struct
 
-func giveEmptyA() *A11 { //want "Annotation on Field aptr of Result 0 of Function giveEmptyA overconstrained"
+func giveEmptyA() *A11 {
 	t := &A11{}
 	return t
 }
 
 func m07() *int {
 	b := giveEmptyA()
-	return b.aptr.ptr
+	return b.aptr.ptr //want "field `aptr` of return of the function `giveEmptyA`"
 }
 
 // Testing with direct return of struct as a composite literal.
-func giveEmptyAComposite() *A11 { //want "Annotation on Field aptr of Result 0 of Function giveEmptyAComposite overconstrained"
+func giveEmptyAComposite() *A11 {
 	return &A11{}
 }
 
 func m08() *int {
 	t := giveEmptyAComposite()
-	return t.aptr.ptr
+	return t.aptr.ptr //want "field `aptr` of return of the function `giveEmptyAComposite`"
 }
 
 // Testing with transitive return of struct through a function call.
@@ -45,12 +45,12 @@ func giveEmptyA11Fun() *A11 {
 	return &A11{}
 }
 
-// TODO: Location of the error in this case is inappropriate.
-func giveEmptyACallFun() *A11 { //want "Annotation on Field aptr of Result 0 of Function giveEmptyACallFun overconstrained"
+// TODO: Location of the error in this case is inappropriate. (PROGSYS-357)
+func giveEmptyACallFun() *A11 {
 	return giveEmptyA11Fun()
 }
 
 func m10() *int {
 	t := giveEmptyACallFun()
-	return t.aptr.ptr
+	return t.aptr.ptr //want "field `aptr` of return of the function `giveEmptyACallFun`"
 }

--- a/testdata/src/go.uber.org/structinit/funcreturnfields/methodreturnbasic.go
+++ b/testdata/src/go.uber.org/structinit/funcreturnfields/methodreturnbasic.go
@@ -47,7 +47,7 @@ type A22 struct {
 	aptr *A22
 }
 
-func (pool *Pool) giveEmptyA() *A22 { //want "Annotation on Field aptr of Result 0 of Function giveEmptyA with receiver pool overconstrained"
+func (pool *Pool) giveEmptyA() *A22 {
 	t := &A22{}
 	return t
 }
@@ -55,5 +55,5 @@ func (pool *Pool) giveEmptyA() *A22 { //want "Annotation on Field aptr of Result
 func m22() *int {
 	pool := new(Pool)
 	var b = pool.giveEmptyA()
-	return b.aptr.ptr
+	return b.aptr.ptr //want "field `aptr` of return of the function `giveEmptyA`"
 }

--- a/testdata/src/go.uber.org/structinit/global/global.go
+++ b/testdata/src/go.uber.org/structinit/global/global.go
@@ -46,7 +46,7 @@ func h() {
 
 type A2 struct {
 	ptr  *int
-	aptr *A2 //want "Annotation on Field aptr overconstrained"
+	aptr *A2
 }
 
 var g2 *A2 = nil
@@ -61,7 +61,7 @@ func h2() {
 		return
 	}
 
-	print(g2.aptr.ptr)
+	print(g2.aptr.ptr) //want "read from the field `aptr`"
 }
 
 var g3 = &A{}

--- a/testdata/src/go.uber.org/structinit/local/local.go
+++ b/testdata/src/go.uber.org/structinit/local/local.go
@@ -28,12 +28,12 @@ type A struct {
 
 func m() {
 	var b = &A{}
-	print(b.aptr.ptr) //want "Value unassigned at struct initialization"
+	print(b.aptr.ptr) //want "unassigned at struct initialization"
 }
 
 func m2() {
 	var b = A{}
-	print(b.aptr.ptr) //want "Value unassigned at struct initialization"
+	print(b.aptr.ptr) //want "unassigned at struct initialization"
 }
 
 func m3() {
@@ -59,7 +59,7 @@ func m6() {
 
 func m7() {
 	b := &A{}
-	print(b.aptr.ptr) //want "Value unassigned at struct initialization"
+	print(b.aptr.ptr) //want "unassigned at struct initialization"
 }
 
 func m8() {
@@ -70,7 +70,7 @@ func m8() {
 func m9() {
 	var b *A
 	b = &A{}
-	print(b.aptr.ptr) //want "Value unassigned at struct initialization"
+	print(b.aptr.ptr) //want "unassigned at struct initialization"
 }
 
 func m10() {
@@ -81,18 +81,18 @@ func m10() {
 
 func m14() {
 	b := new(A)
-	print(b.aptr.ptr) //want "Value unassigned at struct initialization"
+	print(b.aptr.ptr) //want "unassigned at struct initialization"
 }
 
 func m15() {
 	var b A
-	print(b.aptr.ptr) //want "Value unassigned at struct initialization"
+	print(b.aptr.ptr) //want "unassigned at struct initialization"
 }
 
 // this test checks that we only get error for `b` being nil, and not for its uninitialized fields
 func m16() {
 	var b *A
-	print(b.aptr.ptr) //want "Value read from a variable that was never assigned to"
+	print(b.aptr.ptr) //want "read from a variable that was never assigned to"
 }
 
 // Testing unnamed struct
@@ -101,7 +101,7 @@ func m12() {
 	print(x.a.ptr)
 
 	y := new(struct{ a *A })
-	// TODO: unnamed struct initialization is not supported. Following line should give a warning
+	// TODO: unnamed struct initialization is not supported. Following line should give a warning (PROGSYS-557)
 	print(y.a.aptr)
 }
 
@@ -115,13 +115,13 @@ type A11 struct {
 
 func m11() {
 	var b = &A11{}
-	print(b.A11.ptr) //want "Value unassigned at struct initialization"
+	print(b.A11.ptr) //want "unassigned at struct initialization"
 }
 
 // Tests use of promoted fields
 // similar to the previous test
 
-// TODO: Add support for promoted fields
+// TODO: Add support for promoted fields (PROGSYS-575)
 // This test should give an error
 
 type B13 struct {

--- a/testdata/src/go.uber.org/structinit/paramfield/paramfield.go
+++ b/testdata/src/go.uber.org/structinit/paramfield/paramfield.go
@@ -39,11 +39,11 @@ func callF12() {
 	f12(t)
 }
 
-func f12(c *A) { //want "Annotation on Field aptr of Param 0: 'c' at input of Function f12 overconstrained:"
-	print(c.aptr.ptr)
+func f12(c *A) {
+	print(c.aptr.ptr) //want "field `aptr` of param 0 of `f12`"
 }
 
-//Negative test
+// Negative test
 
 func callF31() {
 	t1 := &A{}
@@ -57,11 +57,11 @@ func f31(c *A, d *A) {
 }
 
 func g31(c *A, d *A) {
-	//Both (param 0).aptr and (param 1).aptr are initialized in all calls to g31
+	// Both (param 0).aptr and (param 1).aptr are initialized in all calls to g31
 	print(c.aptr.ptr, d.aptr.ptr)
 }
 
-//Another negative test
+// Another negative test
 
 func m31(c *A) {
 	// c.aptr is initialized in all calls to m31
@@ -79,14 +79,14 @@ func m33() {
 	m31(d)
 }
 
-//Positive example with direct composite as parameter
+// Positive example with direct composite as parameter
 
 func callF14() {
 	f14(&A{})
 }
 
-func f14(c *A) { //want "Annotation on Field aptr of Param 0: 'c' at input of Function f14 overconstrained:"
-	print(c.aptr.ptr)
+func f14(c *A) {
+	print(c.aptr.ptr) //want "field `aptr` of param 0 of `f14`"
 }
 
 // Positive example with direct composite as parameter
@@ -98,11 +98,11 @@ func callF15() {
 	f15(giveA15())
 }
 
-func f15(c *A) { //want "Annotation on Field aptr of Param 0: 'c' at input of Function f15 overconstrained:"
-	print(c.aptr.ptr)
+func f15(c *A) {
+	print(c.aptr.ptr) //want "field `aptr` of argument 0 to call to function `f15`"
 }
 
-//Negative example with direct composite as parameter
+// Negative example with direct composite as parameter
 
 func callF16() {
 	f16(&A{aptr: &A{}})
@@ -138,7 +138,7 @@ func f18(c *A, d *A) {
 	print(c.aptr.ptr, d.aptr.ptr)
 }
 
-// TODO: Handle this case
+// TODO: Handle this case (PROGSYS-570)
 // Positive example with multiple return function as a parameter
 func giveA19() (*A, *A) {
 	return &A{aptr: new(A)}, &A{}
@@ -149,6 +149,6 @@ func callF19() {
 }
 
 func f19(c *A, d *A) {
-	//This should give a Nilaway error
+	// This should give a Nilaway error
 	print(c.aptr.ptr, d.aptr.ptr)
 }

--- a/testdata/src/go.uber.org/structinit/paramfield/receiverfield.go
+++ b/testdata/src/go.uber.org/structinit/paramfield/receiverfield.go
@@ -37,8 +37,8 @@ func callM22() {
 	t.m22()
 }
 
-func (c *A) m22() { //want "Annotation on Field aptr of"
-	print(c.aptr.ptr)
+func (c *A) m22() {
+	print(c.aptr.ptr) //want "field `aptr` of receiver of `m22`"
 }
 
 // Checking if Nilaway does not crash on unnamed receivers
@@ -50,8 +50,8 @@ func callF24() {
 	(A{}).f24()
 }
 
-func (c A) f24() { //want "Annotation on Field aptr of Receiver: 'c' at input of Method f24 overconstrained:"
-	print(c.aptr.ptr)
+func (c A) f24() {
+	print(c.aptr.ptr) //want "field `aptr` of receiver of `f24`"
 }
 
 // Positive example with direct composite as parameter
@@ -63,8 +63,8 @@ func callF25() {
 	giveA25().f25()
 }
 
-func (c *A) f25() { //want "Annotation on Field aptr of Receiver: 'c' at input of Method f25 overconstrained:"
-	print(c.aptr.ptr)
+func (c *A) f25() {
+	print(c.aptr.ptr) //want "field `aptr` of receiver of `f25`"
 }
 
 // Negative example with direct composite as parameter

--- a/testdata/src/go.uber.org/structinit/paramsideeffect/paramsideeffect.go
+++ b/testdata/src/go.uber.org/structinit/paramsideeffect/paramsideeffect.go
@@ -38,7 +38,7 @@ func m1() *int {
 
 // Similar but positive test
 
-func populate12(x *A) { //want "Annotation on Field newPtr of Param 0: 'x' at output of Function populate12 overconstrained"
+func populate12(x *A) {
 	x.newPtr = nil
 }
 
@@ -46,7 +46,7 @@ func m12() *int {
 	b := &A{}
 	b.aptr = &A{}
 	populate12(b)
-	print(b.newPtr.ptr)
+	print(b.newPtr.ptr) //want "field `newPtr` of argument 0 to call to function `populate12`"
 	return b.aptr.ptr
 }
 
@@ -109,7 +109,7 @@ func caller() {
 }
 
 // positive case
-func populate14(x *A) { //want "Annotation on Field newPtr of Param 0: 'x' at output of Function populate14 overconstrained"
+func populate14(x *A) {
 	x.newPtr = nil
 }
 
@@ -117,7 +117,7 @@ func m14() *int {
 	b := &A{}
 	b.newPtr = &A{}
 	populate14(b)
-	return b.newPtr.ptr
+	return b.newPtr.ptr //want "field `newPtr` of argument 0 to call to function `populate14`"
 }
 
 // negative case
@@ -133,10 +133,10 @@ func m15() *int {
 }
 
 // Following cases of false positives and false negatives are due to limitations of our current technique under these special cases
-// TODO: Find a better to way to handle these
+// TODO: Find a better to way to handle these (PROGSYS-579)
 // Another case of identical arguments to function call: False positive
 
-func initializeSecond(a1 *A, a2 *A) { //want "Annotation on Field aptr of Param 0: 'a1' at output of Function initializeSecond overconstrained"
+func initializeSecond(a1 *A, a2 *A) {
 	a1.aptr = nil
 	a2.aptr = new(A)
 }
@@ -144,7 +144,7 @@ func initializeSecond(a1 *A, a2 *A) { //want "Annotation on Field aptr of Param 
 func caller2() {
 	a := &A{}
 	initializeSecond(a, a)
-	print(a.aptr.ptr)
+	print(a.aptr.ptr) //want "field `aptr` of argument 0 to call to function `initializeSecond`"
 }
 
 // Another case of identical arguments to function call: False negative

--- a/testdata/src/go.uber.org/structinit/paramsideeffect/receiversideeffect.go
+++ b/testdata/src/go.uber.org/structinit/paramsideeffect/receiversideeffect.go
@@ -34,7 +34,7 @@ func m21() *int {
 
 // Positive test
 
-func (x *A) populateMethod2() { //want "Annotation on Field newPtr of Receiver: 'x' at output of Method populateMethod2 overconstrained"
+func (x *A) populateMethod2() {
 	x.newPtr = nil
 }
 
@@ -42,6 +42,6 @@ func m22() *int {
 	b := &A{}
 	b.aptr = &A{}
 	b.populateMethod2()
-	print(b.newPtr.ptr)
+	print(b.newPtr.ptr) //want "field `newPtr` of receiver of call to function `populateMethod2`"
 	return b.aptr.ptr
 }


### PR DESCRIPTION
This PR adds original AST expressions in the assertion nodes to correctly allow printing of positions of producer expressions.