### PR TITLE
Disable Codecov patch coverage (rely on project coverage checking)

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -15,6 +15,4 @@ coverage:
         if_ci_failed: error    # if ci fails report status as success, error, or failure
     patch:
       default:
-        enabled: yes
-        target: 80%            # For each PR, 80% of the new code should be covered, in addition to meeting
-                               # the project threshold above for overall code coverage for the codebase.
+        enabled: no

--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -13,3 +13,8 @@ coverage:
         threshold: 1%          # allow the coverage drop by 1% before marking as failure (to allow some flakiness)
         if_not_found: success  # if parent is not found report status as success, error, or failure
         if_ci_failed: error    # if ci fails report status as success, error, or failure
+    patch:
+      default:
+        enabled: yes
+        target: 80%            # For each PR, 80% of the new code should be covered, in addition to meeting
+                               # the project threshold above for overall code coverage for the codebase.


### PR DESCRIPTION
In #20, we added Codecov integration by configuring the `project` rule to
require overall project coverage to not decrease by more than 1% for every
new PR.

However, by default, Codecov configures two checks: `project` and `patch`.
We were using the defaults for `patch`, which checks the coverage of the new
lines in the PR.

After internal discussion, we are choosing to disable `patch` level checking, for two
reasons:

1. Flakiness around detecting "new code" in a PR in the presence of refactorings and code motion
2. To allow for small changes as part of a PR stack which e.g. add a new interface/type before implementing the corresponding functionality to be tested.

We expect that, by default, most PRs will be gated by the `project` check, and 
that coverage will increase over time given the restrictions on reducing coverage. 
If this turns out to not be true over time, we can always make one or both of these
checks stricter.