### PR TITLE
[Follow-up of PR #24] Support function contract nonnil->nonnil for no infer mode

### DIFF
--- a/accumulation/analyzer.go
+++ b/accumulation/analyzer.go
@@ -203,7 +203,7 @@ func checkErrors(triggers []annotation.FullTrigger, annMap annotation.Map) []ann
 	for _, trigger := range filteredTriggers {
 		// Skip checking any full triggers we created by duplicating from contracted functions
 		// to the caller function.
-		if !trigger.Duplicated() && trigger.Check(annMap) {
+		if !trigger.CreatedFromDuplication && trigger.Check(annMap) {
 			triggered = append(triggered, trigger)
 		}
 	}

--- a/accumulation/analyzer.go
+++ b/accumulation/analyzer.go
@@ -201,7 +201,9 @@ func checkErrors(triggers []annotation.FullTrigger, annMap annotation.Map) []ann
 
 	var triggered []annotation.FullTrigger
 	for _, trigger := range filteredTriggers {
-		if trigger.Check(annMap) {
+		// Skip checking any full triggers we created by duplicating from contracted functions
+		// to the caller function.
+		if !trigger.Duplicated() && trigger.Check(annMap) {
 			triggered = append(triggered, trigger)
 		}
 	}

--- a/annotation/full_trigger.go
+++ b/annotation/full_trigger.go
@@ -38,12 +38,21 @@ type FullTrigger struct {
 	// If this field is nil, it means the trigger is not a controlled trigger and the trigger will
 	// be activated all the time.
 	Controller *CallSiteParamAnnotationKey
+	// CreatedFromDuplication is true if the full trigger is created from duplicating another full
+	// trigger; otherwise false, which is also the default value for any normal full trigger.
+	CreatedFromDuplication bool
 }
 
 // Controlled returns true if this full trigger is controlled by a controller site; otherwise
 // returns false.
 func (t *FullTrigger) Controlled() bool {
 	return t.Controller != nil
+}
+
+// Duplicated returns true if the full trigger is created from duplicating another full trigger;
+// otherwise returns false.
+func (t *FullTrigger) Duplicated() bool {
+	return t.CreatedFromDuplication
 }
 
 // Pos returns the position for logging the error specified by the ConsumeTrigger

--- a/annotation/full_trigger.go
+++ b/annotation/full_trigger.go
@@ -49,12 +49,6 @@ func (t *FullTrigger) Controlled() bool {
 	return t.Controller != nil
 }
 
-// Duplicated returns true if the full trigger is created from duplicating another full trigger;
-// otherwise returns false.
-func (t *FullTrigger) Duplicated() bool {
-	return t.CreatedFromDuplication
-}
-
 // Pos returns the position for logging the error specified by the ConsumeTrigger
 func (t *FullTrigger) Pos() token.Pos {
 	return t.Consumer.Pos()

--- a/annotation/key.go
+++ b/annotation/key.go
@@ -84,6 +84,10 @@ func (pk CallSiteParamAnnotationKey) Lookup(annMap Map) (Val, bool) {
 	if paramVal, ok := annMap.CheckFuncCallSiteParamAnn(pk); ok {
 		return paramVal, true
 	}
+	// Revert to the function's ParamAnnotationKey look up if there is no call-site annotation.
+	if paramVal, ok := annMap.CheckFuncParamAnn(pk.FuncDecl, pk.ParamNum); ok {
+		return paramVal, true
+	}
 	return nonAnnotatedDefault, false
 }
 
@@ -250,6 +254,10 @@ type CallSiteRetAnnotationKey struct {
 func (rk CallSiteRetAnnotationKey) Lookup(annMap Map) (Val, bool) {
 	if retVal, ok := annMap.CheckFuncCallSiteRetAnn(rk); ok {
 		return retVal, true
+	}
+	// Revert to the function's RetAnnotationKey look up if there is no call-site annotation.
+	if paramVal, ok := annMap.CheckFuncRetAnn(rk.FuncDecl, rk.RetNum); ok {
+		return paramVal, true
 	}
 	return nonAnnotatedDefault, false
 }

--- a/annotation/key.go
+++ b/annotation/key.go
@@ -81,7 +81,7 @@ func (pk CallSiteParamAnnotationKey) ParamName() *types.Var {
 
 // Lookup looks this key up in the passed map, returning a Val.
 func (pk CallSiteParamAnnotationKey) Lookup(annMap Map) (Val, bool) {
-	if paramVal, ok := annMap.CheckFuncParamAnn(pk.FuncDecl, pk.ParamNum); ok {
+	if paramVal, ok := annMap.CheckFuncCallSiteParamAnn(pk); ok {
 		return paramVal, true
 	}
 	return nonAnnotatedDefault, false
@@ -248,7 +248,7 @@ type CallSiteRetAnnotationKey struct {
 
 // Lookup looks this key up in the passed map, returning a Val.
 func (rk CallSiteRetAnnotationKey) Lookup(annMap Map) (Val, bool) {
-	if retVal, ok := annMap.CheckFuncRetAnn(rk.FuncDecl, rk.RetNum); ok {
+	if retVal, ok := annMap.CheckFuncCallSiteRetAnn(rk); ok {
 		return retVal, true
 	}
 	return nonAnnotatedDefault, false

--- a/annotation/map.go
+++ b/annotation/map.go
@@ -704,7 +704,3 @@ func newObservedMap(pass *analysis.Pass, files []*ast.File) *ObservedMap {
 func getLineFromPos(pos token.Pos, pass *analysis.Pass) int {
 	return pass.Fset.Position(pos).Line
 }
-
-func getFileNameFromPos(pos token.Pos, pass *analysis.Pass) string {
-	return pass.Fset.Position(pos).Filename
-}

--- a/annotation/map.go
+++ b/annotation/map.go
@@ -35,6 +35,8 @@ type Map interface {
 	CheckFuncRecvAnn(*types.Func) (Val, bool)
 	CheckDeepTypeAnn(*types.TypeName) (Val, bool)
 	CheckGlobalVarAnn(*types.Var) (Val, bool)
+	CheckFuncCallSiteParamAnn(key CallSiteParamAnnotationKey) (Val, bool)
+	CheckFuncCallSiteRetAnn(key CallSiteRetAnnotationKey) (Val, bool)
 }
 
 // Val is a possible value of an Annotation
@@ -153,6 +155,27 @@ type ObservedMap struct {
 
 	// this maps declarations of global variables to their annotations
 	globalVarsAnnMap map[*types.Var]Val
+
+	// funcCallSiteParamAnnMap maps a function call site to a slice with the annotations of its
+	// duplicated params at the call site.
+	funcCallSiteParamAnnMap map[CallSite][]ArgLocAndVal
+
+	// funcCallSiteRetAnnMap maps a function call site to a slice with the annotations of its
+	// duplicated returns at the call site.
+	funcCallSiteRetAnnMap map[CallSite][]Val
+}
+
+// CallSite uniquely identifies a function call. It contains the called function object and the
+// code location of the call expression.
+type CallSite struct {
+	Fun      *types.Func
+	Location token.Position
+}
+
+// ArgLocAndVal pairs the code location of the argument expression and the annotation value.
+type ArgLocAndVal struct {
+	Location token.Position
+	Val      Val
 }
 
 // Range calls the passed function `op` on each annotation site in this map. If `setSitesOnly`
@@ -194,6 +217,21 @@ func (m *ObservedMap) Range(op func(key Key, isDeep bool, val bool), setSitesOnl
 
 	for gvar, val := range m.globalVarsAnnMap {
 		callOpOnKeyVal(GlobalVarAnnotationKey{VarDecl: gvar}, val)
+	}
+
+	for callSite, vals := range m.funcCallSiteParamAnnMap {
+		for i, argLocAndVal := range vals {
+			// the location inside the callSite is the location of the call expression, we want
+			// the location of every argument expression
+			funcObj := callSite.Fun
+			callOpOnKeyVal(NewCallSiteParamKey(funcObj, i, argLocAndVal.Location), argLocAndVal.Val)
+		}
+	}
+
+	for callSite, vals := range m.funcCallSiteRetAnnMap {
+		for i, val := range vals {
+			callOpOnKeyVal(NewCallSiteRetKey(callSite.Fun, i, callSite.Location), val)
+		}
 	}
 }
 
@@ -398,6 +436,10 @@ func newObservedMap(pass *analysis.Pass, files []*ast.File) *ObservedMap {
 	deepTypeAnnMap := make(map[*types.TypeName]Val)
 	globalVarsAnnMap := make(map[*types.Var]Val)
 
+	funcObjToFuncDecl := make(map[*types.Func]*ast.FuncDecl)
+	funcCallSiteParamAnnMap := make(map[CallSite][]ArgLocAndVal)
+	funcCallSiteRetAnnMap := make(map[CallSite][]Val)
+
 	typeOf := func(expr ast.Expr) types.Type {
 		return pass.TypesInfo.Types[expr].Type
 	}
@@ -405,19 +447,20 @@ func newObservedMap(pass *analysis.Pass, files []*ast.File) *ObservedMap {
 	// for a function declaration, accumulate its parameters from an *ast.Fieldlist object
 	// listing them, look them up in the docstring, and return an equally long list of
 	// annotationVals
-	accFromFieldList := func(set nilabilitySet, fieldList *ast.FieldList, isParamList bool) []Val {
+	accFromFieldList := func(set nilabilitySet, fieldList *ast.FieldList, isParamList bool,
+		isCallSiteAnnotation bool) []Val {
 		if fieldList == nil {
 			// this is included for nil-safety
 			return nil
 		}
 
 		var annVals []Val
+		var lookupKey string
 		for _, field := range fieldList.List {
 			if len(field.Names) == 0 {
 				// case of anonymous field - on which we do not permit annotations
 				// non-named fields
 
-				var lookupKey string
 				if isParamList {
 					lookupKey = paramStr(len(annVals))
 				} else {
@@ -442,7 +485,16 @@ func newObservedMap(pass *analysis.Pass, files []*ast.File) *ObservedMap {
 						fieldType = typeOf(field.Type)
 					}
 
-					annVals = append(annVals, set.checkNilability(name.Name, fieldType))
+					if isCallSiteAnnotation {
+						if isParamList {
+							lookupKey = paramStr(len(annVals))
+						} else {
+							lookupKey = resultStr(len(annVals))
+						}
+					} else {
+						lookupKey = name.Name
+					}
+					annVals = append(annVals, set.checkNilability(lookupKey, fieldType))
 				}
 			}
 		}
@@ -454,7 +506,7 @@ func newObservedMap(pass *analysis.Pass, files []*ast.File) *ObservedMap {
 			if len(decl.Recv.List) > 1 {
 				panic(fmt.Sprintf("Multiple receivers found for method %s", decl.Name))
 			}
-			return accFromFieldList(set, decl.Recv, false)[0]
+			return accFromFieldList(set, decl.Recv, false, false)[0]
 		}
 		return nonAnnotatedDefault
 	}
@@ -466,9 +518,11 @@ func newObservedMap(pass *analysis.Pass, files []*ast.File) *ObservedMap {
 				case *ast.FuncDecl:
 					funcObj := pass.TypesInfo.ObjectOf(decl.Name).(*types.Func)
 					set := nilabilityFromCommentGroup(decl.Doc)
-					funcParamAnnMap[funcObj] = accFromFieldList(set, decl.Type.Params, true)
-					funcRetAnnMap[funcObj] = accFromFieldList(set, decl.Type.Results, false)
+					funcParamAnnMap[funcObj] = accFromFieldList(set, decl.Type.Params, true, false)
+					funcRetAnnMap[funcObj] = accFromFieldList(set, decl.Type.Results, false, false)
 					funcRecvAnnMap[funcObj] = readRecvAnnotations(decl, set)
+					// store the mapping from the function object to the ast node.
+					funcObjToFuncDecl[funcObj] = decl
 				case *ast.GenDecl:
 					// this is used for any declaration besides a function
 					// here, we specifically look for declarations of struct types
@@ -529,8 +583,8 @@ func newObservedMap(pass *analysis.Pass, files []*ast.File) *ObservedMap {
 											// this is the common case - a simply declared method
 											set := nilabilityFromCommentGroup(method.Doc)
 											funcObj := pass.TypesInfo.ObjectOf(method.Names[0]).(*types.Func)
-											funcParamAnnMap[funcObj] = accFromFieldList(set, method.Type.(*ast.FuncType).Params, true)
-											funcRetAnnMap[funcObj] = accFromFieldList(set, method.Type.(*ast.FuncType).Results, false)
+											funcParamAnnMap[funcObj] = accFromFieldList(set, method.Type.(*ast.FuncType).Params, true, false)
+											funcRetAnnMap[funcObj] = accFromFieldList(set, method.Type.(*ast.FuncType).Results, false, false)
 										case 0:
 										// this is the case of inheritance - i.e. a method with another
 										// method named within it, in this case the identifiers will
@@ -570,12 +624,87 @@ func newObservedMap(pass *analysis.Pass, files []*ast.File) *ObservedMap {
 			}
 		}
 	}
-	return &ObservedMap{
-		fieldAnnMap:      fieldAnnMap,
-		funcParamAnnMap:  funcParamAnnMap,
-		funcRetAnnMap:    funcRetAnnMap,
-		funcRecvAnnMap:   funcRecvAnnMap,
-		deepTypeAnnMap:   deepTypeAnnMap,
-		globalVarsAnnMap: globalVarsAnnMap,
+
+	// Parse inline annotations at call sites.
+	for _, file := range files {
+		if !conf.IsFileInScope(file) || !util.DocContainsFunctionContractsCheck(file.Doc) {
+			continue
+		}
+		// Store a mapping between single comment's line number to its text.
+		comments := make(map[int]*ast.CommentGroup)
+		for _, group := range file.Comments {
+			if len(group.List) != 1 {
+				continue
+			}
+			comment := group.List[0]
+			comments[getLineFromPos(comment.Pos(), pass)] = group
+		}
+
+		// Now, find all *ast.CallExpr nodes and find their comment and extract annotations.
+		// Comment nodes are floating in GO asts. https://github.com/golang/go/issues/20744
+		// Thus, we require the comments for annotations are written in the same line as the
+		// function call expression, so we can match them by line numbers.
+		ast.Inspect(file, func(node ast.Node) bool {
+			expr, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			commentGroup, ok := comments[getLineFromPos(expr.Pos(), pass)]
+			if !ok {
+				// No annotations for this CallExpr node, but we still need to traverse further since
+				// there could be comments for nested CallExpr nodes.
+				return true
+			}
+
+			ident := util.FuncIdentFromCallExpr(expr)
+			// if ident is nil, keep searching for nested CallExpr nodes.
+			if ident == nil {
+				return true
+			}
+			funcObj, ok := pass.TypesInfo.ObjectOf(ident).(*types.Func)
+			if !ok {
+				// not a function, keep searching for nested CallExpr nodes.
+				return true
+			}
+
+			set := nilabilityFromCommentGroup(commentGroup)
+			if len(set) == 0 {
+				// empty set, no annotation, keep searching for nested CallExpr nodes.
+				return true
+			}
+			funcDecl, ok := funcObjToFuncDecl[funcObj]
+			if !ok {
+				panic(funcObj.FullName() + " not found but this should not happen since we " +
+					"have parsed annotations once for every function declaration and the " +
+					"mappings should have been set up.")
+			}
+			callSite := CallSite{Fun: funcObj, Location: util.PosToLocation(expr.Pos(), pass)}
+			for i, val := range accFromFieldList(set, funcDecl.Type.Params, true, true) {
+				argLoc := util.PosToLocation(expr.Args[i].Pos(), pass)
+				funcCallSiteParamAnnMap[callSite] = append(funcCallSiteParamAnnMap[callSite],
+					ArgLocAndVal{Location: argLoc, Val: val})
+			}
+			funcCallSiteRetAnnMap[callSite] = accFromFieldList(set, funcDecl.Type.Results, false, true)
+			// keep searching for nested CallExpr nodes.
+			return true
+		})
 	}
+	return &ObservedMap{
+		fieldAnnMap:             fieldAnnMap,
+		funcParamAnnMap:         funcParamAnnMap,
+		funcRetAnnMap:           funcRetAnnMap,
+		funcRecvAnnMap:          funcRecvAnnMap,
+		deepTypeAnnMap:          deepTypeAnnMap,
+		globalVarsAnnMap:        globalVarsAnnMap,
+		funcCallSiteParamAnnMap: funcCallSiteParamAnnMap,
+		funcCallSiteRetAnnMap:   funcCallSiteRetAnnMap,
+	}
+}
+
+func getLineFromPos(pos token.Pos, pass *analysis.Pass) int {
+	return pass.Fset.Position(pos).Line
+}
+
+func getFileNameFromPos(pos token.Pos, pass *analysis.Pass) string {
+	return pass.Fset.Position(pos).Filename
 }

--- a/assertion/function/analyzer.go
+++ b/assertion/function/analyzer.go
@@ -367,9 +367,10 @@ func duplicateFullTrigger(
 	//  inference engine because we would not want to see a conflict at this site due to different
 	//  call sites.
 	dupTrigger := annotation.FullTrigger{
-		Producer:   trigger.Producer,
-		Consumer:   trigger.Consumer,
-		Controller: nil,
+		Producer:               trigger.Producer,
+		Consumer:               trigger.Consumer,
+		Controller:             nil,
+		CreatedFromDuplication: true,
 	}
 	if isParamProducer {
 		dupTrigger.Producer = annotation.DuplicateParamProducer(trigger.Producer, argLoc)

--- a/inference/inferred_map.go
+++ b/inference/inferred_map.go
@@ -276,6 +276,18 @@ func (i *InferredMap) CheckGlobalVarAnn(v *types.Var) (annotation.Val, bool) {
 	return i.checkAnnotationKey(annotation.GlobalVarAnnotationKey{VarDecl: v})
 }
 
+// CheckFuncCallSiteParamAnn checks this InferredMap for a concrete mapping of the call site param
+// key provided.
+func (i *InferredMap) CheckFuncCallSiteParamAnn(key annotation.CallSiteParamAnnotationKey) (annotation.Val, bool) {
+	return i.checkAnnotationKey(key)
+}
+
+// CheckFuncCallSiteRetAnn checks this InferredMap for a concrete mapping of the call site return
+// key provided.
+func (i *InferredMap) CheckFuncCallSiteRetAnn(key annotation.CallSiteRetAnnotationKey) (annotation.Val, bool) {
+	return i.checkAnnotationKey(key)
+}
+
 func (i *InferredMap) checkAnnotationKey(key annotation.Key) (annotation.Val, bool) {
 	shallowKey := newPrimitiveSite(key, false)
 	deepKey := newPrimitiveSite(key, true)

--- a/nilaway_test.go
+++ b/nilaway_test.go
@@ -221,7 +221,7 @@ func TestFunctionContracts(t *testing.T) {
 	t.Parallel()
 
 	testdata := analysistest.TestData()
-	analysistest.Run(t, testdata, Analyzer, "go.uber.org/functioncontracts/inference")
+	analysistest.Run(t, testdata, Analyzer, "go.uber.org/functioncontracts", "go.uber.org/functioncontracts/inference")
 }
 
 func TestPrettyPrint(t *testing.T) { //nolint:paralleltest

--- a/testdata/src/go.uber.org/functioncontracts/functioncontracts.go
+++ b/testdata/src/go.uber.org/functioncontracts/functioncontracts.go
@@ -137,7 +137,7 @@ func barReturnCalledMultipleTimesInTheSameFunction() {
 // Test call site annotations are wrongly written.
 // nilable(x, result 0)
 // contract(nonnil -> nonnil)
-func fooWrongAnnotation(x *int) *int {
+func fooWrongCallSiteAnnotation(x *int) *int {
 	if x != nil {
 		// Return nonnil
 		return new(int)
@@ -150,8 +150,31 @@ func fooWrongAnnotation(x *int) *int {
 	}
 }
 
-func barWrongAnnotation() {
+func barWrongCallSiteAnnotation() {
 	var a *int
-	b := fooWrongAnnotation(a) // nonnil(param 0, result 0) // want "read from a variable that was never assigned to"
-	print(*b)                  // safe because the call site annotation is used
+	b := fooWrongCallSiteAnnotation(a) // nonnil(param 0, result 0) // want "read from a variable that was never assigned to"
+	print(*b)                          // safe because the call site annotation is used
+}
+
+// nonnil(x) nilable(result 0)
+// contract(nonnil -> nonnil)
+func fooNoCallSiteAnnoatation(x *int) *int {
+	if x != nil {
+		// Return nonnil
+		return new(int)
+	}
+	// Return nonnil or nil randomly
+	if rand.Float64() > 0.5 {
+		return new(int)
+	} else {
+		return nil
+	}
+}
+
+func barNoCallSiteAnnoatation() {
+	var a *int
+	// We should rely on the function header annotations if we do not find any call site
+	// annotations.
+	v := fooNoCallSiteAnnoatation(a) // want "nilable value passed"
+	print(*v)                        // want "nilable value dereferenced"
 }

--- a/testdata/src/go.uber.org/functioncontracts/functioncontracts.go
+++ b/testdata/src/go.uber.org/functioncontracts/functioncontracts.go
@@ -1,0 +1,157 @@
+/*
+This package aims to test function contracts.
+
+<nilaway no inference>
+<nilaway contract enable>
+*/
+package functioncontracts
+
+import "math/rand"
+
+// Test the contracted function contains a full trigger nilable -> return 0.
+// nilable(x, result 0)
+// contract(nonnil -> nonnil)
+func fooReturn(x *int) *int {
+	if x != nil {
+		// Return nonnil
+		return new(int)
+	}
+	// Return nonnil or nil randomly
+	if rand.Float64() > 0.5 {
+		return new(int)
+	} else {
+		return nil
+	}
+}
+
+func barReturn1() {
+	n := 1
+	a1 := &n
+	b1 := fooReturn(a1) // nonnil(param 0, result 0)
+	print(*b1)          // No "nilable value dereferenced" wanted
+}
+
+func barReturn2() {
+	var a2 *int
+	b2 := fooReturn(a2) // nilable(param 0, result 0)
+	print(*b2)          // want "nilable value dereferenced"
+}
+
+// Test the contracted function retains a full trigger param 0 -> nonnil.
+// nilable(x, result 0)
+// contract(nonnil -> nonnil)
+func fooParam(x *int) *int {
+	if x != nil {
+		return new(int)
+	}
+	if rand.Float64() > 0.5 {
+		return new(int)
+	} else {
+		sink(*x) // want "nilable value dereferenced"
+		return nil
+	}
+}
+
+func barParam1() {
+	n := 1
+	a1 := &n
+	b1 := fooParam(a1) // nonnil(param 0, result 0)
+	print(*b1)
+}
+
+func barParam2() {
+	var a2 *int
+	b2 := fooParam(a2) // nilable(param 0, result 0)
+	print(*b2)         // want "nilable value dereferenced"
+}
+
+func sink(v int) {}
+
+// Test the contracted function contains another contracted function.
+// nilable(x, result 0)
+// contract(nonnil -> nonnil)
+func fooNested(x *int) *int {
+	return fooBase(x)
+}
+
+// contract(nonnil -> nonnil)
+// nilable(x, result 0)
+func fooBase(x *int) *int {
+	if x != nil {
+		return new(int)
+	}
+	if rand.Float64() > 0.5 {
+		return nil
+	} else {
+		return new(int)
+	}
+}
+
+func barNested1() {
+	n := 1
+	a1 := &n
+	b1 := fooNested(a1) // nonnil(param 0, result 0)
+	print(*b1)          // No "nilable value dereferenced" wanted
+}
+
+func barNested2() {
+	var a2 *int
+	b2 := fooNested(a2) // nilable(param 0, result 0)
+	print(*b2)          // want "nilable value dereferenced"
+}
+
+// Test the contracted function is called multiple times in another function.
+// contract(nonnil -> nonnil)
+// nilable(x, result 0)
+func fooReturnCalledMultipleTimesInTheSameFunction(x *int) *int {
+	if x != nil {
+		return new(int)
+	}
+	if rand.Float64() > 0.5 {
+		return new(int)
+	} else {
+		return nil
+	}
+}
+
+func barReturnCalledMultipleTimesInTheSameFunction() {
+	n := 1
+	a1 := &n
+	b1 := fooReturnCalledMultipleTimesInTheSameFunction(a1) // nonnil(param 0, result 0)
+	print(*b1)                                              // No "nilable value dereferenced" wanted
+
+	var a2 *int
+	b2 := fooReturnCalledMultipleTimesInTheSameFunction(a2) // nilable(param 0, result 0)
+	print(*b2)                                              // want "nilable value dereferenced"
+
+	m := 2
+	a3 := &m
+	b3 := fooReturnCalledMultipleTimesInTheSameFunction(a3) // nonnil(param 0, result 0)
+	print(*b3)                                              // No "nilable value dereferenced" wanted
+
+	var a4 *int
+	b4 := fooReturnCalledMultipleTimesInTheSameFunction(a4) // nilable(param 0, result 0)
+	print(*b4)                                              // want "nilable value dereferenced"
+}
+
+// Test call site annotations are wrongly written.
+// nilable(x, result 0)
+// contract(nonnil -> nonnil)
+func fooWrongAnnotation(x *int) *int {
+	if x != nil {
+		// Return nonnil
+		return new(int)
+	}
+	// Return nonnil or nil randomly
+	if rand.Float64() > 0.5 {
+		return new(int)
+	} else {
+		return nil
+	}
+}
+
+func barWrongAnnotation() {
+	var a *int
+	b := fooWrongAnnotation(a) // nonnil(param 0, result 0) // want "read from a variable that was never assigned to"
+	print(*b)                  // safe because the call site annotation is used
+}


### PR DESCRIPTION
Follow up of PR #24 , support no infer mode for function contract nonnil->nonnil. This is the final PR of the stack.

For no infer mode, we annotate param and result at every call site of the contracted function. We duplicate param and return sites so they would not conflict with each other (which is done in #24 ). Theoretically we do not need to duplicate full triggers of contracted functions, but in order to keep the analysis phase the same between full and no infer mode, we still duplicate (done in #24) but we just ignore those duplicated triggers in the inference phase when we are in no infer mode.

Implementation:
- Parse inline annotations at call sites.
- Use the parsed annotations to check for conflicts.