### PR TITLE
Update CI configurations to use Go 1.20 and 1.21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           cache: false
 
       - uses: golangci/golangci-lint-action@v3
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ "1.19.x", "1.20.x" ]
+        go: [ "1.20.x", "1.21.x" ]
     steps:
       - uses: actions/checkout@v3
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ how to pass them using different linter drivers.
 
 ## Support 
 
+We follow the same [version support policy](https://go.dev/doc/devel/release#policy) as the [Go](https://golang.org/) 
+project: we support and test the last two major versions of Go.
+
 Please feel free to [open a GitHub issue](https://github.com/uber-go/nilaway/issues) if you have any questions, bug 
 reports, and feature requests.
 


### PR DESCRIPTION
[Go 1.21 is released](https://go.dev/blog/go1.21), so this PR upgrades the versions we use in CI (from 1.19 and 1.20 to 1.20 and 1.21). Also, this PR makes it explicit in the README that we follow the same version support policy as the Go project: only last two major versions are supported.