### PR TITLE
Support general nonnil->nonnil function contract, i.e., having a single nonnil but any numbers of any, e.g. contract(_,nonnil->nonnil,_)

### DIFF
--- a/assertion/function/assertiontree/parse_expr_producer.go
+++ b/assertion/function/assertiontree/parse_expr_producer.go
@@ -415,7 +415,7 @@ func (r *RootAssertionNode) getFuncReturnProducers(ident *ast.Ident, expr *ast.C
 
 	for i := 0; i < numResults; i++ {
 		var retKey annotation.Key
-		if r.HasContract(funcObj) {
+		if r.RetHasContract(funcObj, i) {
 			// Creates a new return site with location information at every call site for a
 			// function with contracts. The return site is unique at every call site, even with the
 			// same function called.

--- a/assertion/function/functioncontracts/analyzer_test.go
+++ b/assertion/function/functioncontracts/analyzer_test.go
@@ -21,15 +21,16 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/analysistest"
 )
 
-func TestAnalyzer(t *testing.T) {
+func TestParse(t *testing.T) {
 	t.Parallel()
 
 	testdata := analysistest.TestData()
 
-	r := analysistest.Run(t, testdata, Analyzer, "go.uber.org/functioncontracts")
+	r := analysistest.Run(t, testdata, Analyzer, "go.uber.org/functioncontracts/parse")
 	require.Equal(t, 1, len(r))
 	require.NotNil(t, r[0])
 
@@ -44,23 +45,20 @@ func TestAnalyzer(t *testing.T) {
 		actualNameToContracts[funcObj] = contracts
 	}
 
-	var getFuncObj = func(name string) *types.Func {
-		return pass.Pkg.Scope().Lookup(name).(*types.Func)
-	}
 	expectedNameToContracts := map[*types.Func][]*FunctionContract{
-		getFuncObj("f1"): {
+		getFuncObj(pass, "f1"): {
 			&FunctionContract{Ins: []ContractVal{NonNil}, Outs: []ContractVal{NonNil}},
 		},
-		getFuncObj("f2"): {
+		getFuncObj(pass, "f2"): {
 			&FunctionContract{Ins: []ContractVal{NonNil}, Outs: []ContractVal{True}},
 		},
-		getFuncObj("f3"): {
+		getFuncObj(pass, "f3"): {
 			&FunctionContract{Ins: []ContractVal{NonNil}, Outs: []ContractVal{False}},
 		},
-		getFuncObj("multipleValues"): {
+		getFuncObj(pass, "multipleValues"): {
 			&FunctionContract{Ins: []ContractVal{Any, NonNil}, Outs: []ContractVal{NonNil, True}},
 		},
-		getFuncObj("multipleContracts"): {
+		getFuncObj(pass, "multipleContracts"): {
 			&FunctionContract{Ins: []ContractVal{Any, NonNil}, Outs: []ContractVal{NonNil, True}},
 			&FunctionContract{Ins: []ContractVal{NonNil, Any}, Outs: []ContractVal{NonNil, True}},
 		},
@@ -69,4 +67,63 @@ func TestAnalyzer(t *testing.T) {
 	if diff := cmp.Diff(expectedNameToContracts, actualNameToContracts); diff != "" {
 		require.Fail(t, fmt.Sprintf("parsed contracts mismatch (-want +got):\n%s", diff))
 	}
+}
+func TestInfer(t *testing.T) {
+	t.Parallel()
+
+	testdata := analysistest.TestData()
+	r := analysistest.Run(t, testdata, Analyzer, "go.uber.org/functioncontracts/infer")
+
+	require.Equal(t, 1, len(r))
+	require.NotNil(t, r[0])
+
+	pass, result := r[0].Pass, r[0].Result
+	require.IsType(t, Result{}, result)
+	funcContractsMap := result.(Result).FunctionContracts
+
+	require.NotNil(t, funcContractsMap)
+
+	actualNameToContracts := map[*types.Func][]*FunctionContract{}
+	for funcObj, contracts := range funcContractsMap {
+		actualNameToContracts[funcObj] = contracts
+	}
+
+	expectedNameToContracts := map[*types.Func][]*FunctionContract{
+		getFuncObj(pass, "onlyLocalVar"): {
+			&FunctionContract{Ins: []ContractVal{NonNil}, Outs: []ContractVal{NonNil}},
+		},
+		getFuncObj(pass, "unknownCondition"): {
+			&FunctionContract{Ins: []ContractVal{NonNil}, Outs: []ContractVal{NonNil}},
+		},
+		getFuncObj(pass, "noLocalVar"): {
+			&FunctionContract{Ins: []ContractVal{NonNil}, Outs: []ContractVal{NonNil}},
+		},
+		getFuncObj(pass, "learnUnderlyingFromOuterMakeInterface"): {
+			&FunctionContract{Ins: []ContractVal{NonNil}, Outs: []ContractVal{NonNil}},
+		},
+		getFuncObj(pass, "twoCondsMerge"): {
+			&FunctionContract{Ins: []ContractVal{NonNil}, Outs: []ContractVal{NonNil}},
+		},
+		getFuncObj(pass, "unknownToUnknownButSameValue"): {
+			&FunctionContract{Ins: []ContractVal{NonNil}, Outs: []ContractVal{NonNil}},
+		},
+		// other functions should not exist in the map as the contract nonnil->nonnil does not hold
+		// for them.
+
+		// TODO: uncomment this when we support field access when inferring contracts.
+		//getFuncObj(pass, "field"): {
+		//	&FunctionContract{Ins: []ContractVal{NonNil}, Outs: []ContractVal{NonNil}},
+		//},
+		// TODO: uncomment this when we support nonempty slice to nonnil.
+		//getFuncObj(pass, "nonEmptySliceToNonnil"): {
+		//	&FunctionContract{Ins: []ContractVal{NonNil}, Outs: []ContractVal{NonNil}},
+		//},
+	}
+	if diff := cmp.Diff(expectedNameToContracts, actualNameToContracts); diff != "" {
+		require.Fail(t, fmt.Sprintf("inferred contracts mismatch (-want +got):\n%s", diff))
+	}
+}
+
+func getFuncObj(pass *analysis.Pass, name string) *types.Func {
+	return pass.Pkg.Scope().Lookup(name).(*types.Func)
 }

--- a/assertion/function/functioncontracts/analyzer_test.go
+++ b/assertion/function/functioncontracts/analyzer_test.go
@@ -107,6 +107,24 @@ func TestInfer(t *testing.T) {
 		getFuncObj(pass, "unknownToUnknownButSameValue"): {
 			&FunctionContract{Ins: []ContractVal{NonNil}, Outs: []ContractVal{NonNil}},
 		},
+		getFuncObj(pass, "nonnilAnyToNonnilAny"): {
+			&FunctionContract{Ins: []ContractVal{NonNil, Any}, Outs: []ContractVal{NonNil, Any}},
+		},
+		getFuncObj(pass, "nonnilAnyToAnyNonnil"): {
+			&FunctionContract{Ins: []ContractVal{NonNil, Any}, Outs: []ContractVal{Any, NonNil}},
+		},
+		getFuncObj(pass, "anyNonnilToNonnilAny"): {
+			&FunctionContract{Ins: []ContractVal{Any, NonNil}, Outs: []ContractVal{NonNil, Any}},
+		},
+		getFuncObj(pass, "anyNonnilToAnyNonnil"): {
+			&FunctionContract{Ins: []ContractVal{Any, NonNil}, Outs: []ContractVal{Any, NonNil}},
+		},
+		getFuncObj(pass, "anyNonnilAnyToAnyAnyNonnilAny"): {
+			&FunctionContract{Ins: []ContractVal{Any, NonNil, Any}, Outs: []ContractVal{Any, Any, NonNil, Any}},
+		},
+		getFuncObj(pass, "mixType"): {
+			&FunctionContract{Ins: []ContractVal{Any, NonNil}, Outs: []ContractVal{Any, NonNil}},
+		},
 		// other functions should not exist in the map as the contract nonnil->nonnil does not hold
 		// for them.
 

--- a/assertion/function/functioncontracts/function_contracts_map.go
+++ b/assertion/function/functioncontracts/function_contracts_map.go
@@ -15,15 +15,7 @@
 package functioncontracts
 
 import (
-	"fmt"
-	"go/ast"
 	"go/types"
-	"regexp"
-	"strings"
-
-	"go.uber.org/nilaway/config"
-	"go.uber.org/nilaway/util"
-	"golang.org/x/tools/go/analysis"
 )
 
 // ContractVal represents the possible value appearing in a function contract.
@@ -59,20 +51,6 @@ func stringToContractVal(keyword string) ContractVal {
 	}
 }
 
-const _sep = ","
-const _contractKeyword = "contract"
-const _contractValKeyword = NonNil + "|" + False + "|" + True + "|" + Any
-
-// _contractRE matches multiple function contracts in the same line. Each contract looks like
-// `contract(VALUE(,VALUE)+ -> VALUE(,VALUE)+)`. The RE also captures two lists of VALUEs,
-// i.e., the part before and after `->` for each contract.
-// Note that we match start and end of the line here and add a non-capturing group for the entire
-// contract, and we disallow anything else except whitespace to appear between contracts, so we
-// acknowledge only the contracts written in their own line.
-var _contractRE = regexp.MustCompile(
-	fmt.Sprintf("^\\s*//\\s*(?:\\s*%s\\s*\\(\\s*((?:%s)(?:\\s*,\\s*(?:%s))*)\\s*->\\s*((?:%s)(?:\\s*,\\s*(?:%s))*)\\s*\\)\\s*)+$",
-		_contractKeyword, _contractValKeyword, _contractValKeyword, _contractValKeyword, _contractValKeyword))
-
 // FunctionContract represents a function contract.
 type FunctionContract struct {
 	Ins  []ContractVal
@@ -81,65 +59,3 @@ type FunctionContract struct {
 
 // Map stores the mappings from *types.Func to associated function contracts.
 type Map map[*types.Func][]*FunctionContract
-
-// collectFunctionContracts collects all the function contracts and returns a map that associates
-// every function with its contracts if it has any. One function can have multiple contracts.
-func collectFunctionContracts(pass *analysis.Pass) Map {
-	conf := pass.ResultOf[config.Analyzer].(*config.Config)
-
-	m := Map{}
-	for _, file := range pass.Files {
-		if !conf.IsFileInScope(file) || !util.DocContainsFunctionContractsCheck(file.Doc) {
-			continue
-		}
-		for _, decl := range file.Decls {
-			funcDecl, ok := decl.(*ast.FuncDecl)
-			if !ok || funcDecl.Doc == nil {
-				// Ignore any non-function declaration or the function has no comment
-				// TODO: If we want to support contracts for anonymous function (function
-				//  literals) in the future, then we need to handle more types here.
-				continue
-			}
-			funcObj := pass.TypesInfo.ObjectOf(funcDecl.Name).(*types.Func)
-			if funcContracts := parseContractsForSingleFunction(funcDecl.Doc); len(funcContracts) != 0 {
-				m[funcObj] = funcContracts
-			}
-		}
-	}
-	return m
-}
-
-// parseContractsForSingleFunction parses a slice of function contracts from a singe comment group.
-// If no contract is found from the comment group, an empty slice is returned.
-func parseContractsForSingleFunction(doc *ast.CommentGroup) []*FunctionContract {
-	contracts := make([]*FunctionContract, 0)
-	for _, lineComment := range doc.List {
-		res := _contractRE.FindAllStringSubmatch(lineComment.Text, -1)
-		if res == nil {
-			continue
-		}
-		for _, matching := range res {
-			// matching is a slice of three elements; the first is the whole matched string and the
-			// next two are the captured groups of contract values before and after `->`.
-			ins := parseListOfContractValues(matching[1])
-			outs := parseListOfContractValues(matching[2])
-			ctrt := &FunctionContract{
-				Ins:  ins,
-				Outs: outs,
-			}
-			contracts = append(contracts, ctrt)
-		}
-	}
-	return contracts
-}
-
-// parseListOfContractValues splits a string of comma separated contract value keywords and returns
-// a slice of ContractVal.
-func parseListOfContractValues(wholeStr string) []ContractVal {
-	valKeywords := strings.Split(wholeStr, _sep)
-	contractVals := make([]ContractVal, len(valKeywords))
-	for i, v := range valKeywords {
-		contractVals[i] = stringToContractVal(strings.TrimSpace(v))
-	}
-	return contractVals
-}

--- a/assertion/function/functioncontracts/function_contracts_map.go
+++ b/assertion/function/functioncontracts/function_contracts_map.go
@@ -59,3 +59,74 @@ type FunctionContract struct {
 
 // Map stores the mappings from *types.Func to associated function contracts.
 type Map map[*types.Func][]*FunctionContract
+
+// newNonnilToNonnilContract creates a function contract that has only one NonNil value at the
+// given index p for input and r for output.
+func newNonnilToNonnilContract(p, nParams, r, nRets int) *FunctionContract {
+	return &FunctionContract{
+		Ins:  newSingleNonnilContractValList(p, nParams),
+		Outs: newSingleNonnilContractValList(r, nRets),
+	}
+}
+
+// newSingleNonnilContractValList creates a list of n ContractVals with only one NonNil value at
+// the given index t.
+func newSingleNonnilContractValList(t, n int) []ContractVal {
+	vals := make([]ContractVal, n)
+	for i := 0; i < n; i++ {
+		if i == t {
+			vals[i] = NonNil
+		} else {
+			vals[i] = Any
+		}
+	}
+	return vals
+}
+
+// IsGeneralNonnnilToNonnil returns true if the given contract is a general nonnil to nonnil
+// contract. Namely, the contract has only one nonnil in input and only one nonnil in output and
+// all the other values are any, e.g., contract(_,nonnil->nonnil,_) is OK, but
+// contract(nonnil,nonnil->nonnil,_) is not.
+func (c *FunctionContract) IsGeneralNonnnilToNonnil() bool {
+	return oneNonnilOthersAny(c.Ins) && oneNonnilOthersAny(c.Outs)
+}
+
+// IndexOfNonnilIn returns the index of the first NonNil value in the input of the contract. If
+// there is no NonNil value in the input, it returns -1.
+func (c *FunctionContract) IndexOfNonnilIn() int {
+	for i, val := range c.Ins {
+		if val == NonNil {
+			return i
+		}
+	}
+	return -1
+}
+
+// IndexOfNonnilOut returns the index of the first NonNil value in the output of the contract. If
+// there is no NonNil value in the output, it returns -1.
+func (c *FunctionContract) IndexOfNonnilOut() int {
+	for i, val := range c.Outs {
+		if val == NonNil {
+			return i
+		}
+	}
+	return -1
+}
+
+func oneNonnilOthersAny(vals []ContractVal) bool {
+	seenNonnil := false
+	for _, val := range vals {
+		if val != Any && val != NonNil {
+			return false
+		}
+		if val == Any {
+			continue
+		}
+		// val == NonNil
+		if seenNonnil {
+			return false
+		}
+		seenNonnil = true
+	}
+	return seenNonnil
+}

--- a/assertion/function/functioncontracts/infer.go
+++ b/assertion/function/functioncontracts/infer.go
@@ -1,0 +1,523 @@
+package functioncontracts
+
+import (
+	"fmt"
+	"go/token"
+	"go/types"
+
+	"go.uber.org/nilaway/util"
+	"golang.org/x/tools/go/ssa"
+)
+
+// _maxNumTablesPerBlock is the maximum number of nilnessTables that we will keep for each block.
+// If the number of nilnessTables exceeds this number, we will stop analyzing the function and
+// infer nothing, out of performance consideration.
+const _maxNumTablesPerBlock = 1024
+
+// inferContracts infers function contracts for a function if it has no contracts written. It
+// returns a list of inferred contracts, which may be empty if no contract is inferred but is never
+// nil.
+func inferContracts(fn *ssa.Function) []*FunctionContract {
+	if len(fn.Blocks) == 0 {
+		panic(
+			fmt.Sprintf("The function %s has no blocks even though it declared return values",
+				fn.Signature.String()))
+	}
+
+	nilnessTableSetByBB := make(map[*ssa.BasicBlock]nilnessTableSet)
+	retInstrs := getReturnInstrs(fn) // TODO: Consider *ssa.Panic
+	// No need of an expensive dataflow analysis if we can derive contracts from the return
+	// instructions directly.
+	if ctrs := deriveContracts(retInstrs, fn, nilnessTableSetByBB); len(ctrs) != 0 {
+		return ctrs
+	}
+
+	// Add the entry block to the queue.
+	// TODO: visit fn.Recover.
+	var queue []*ssa.BasicBlock
+	queue = append(queue, fn.Blocks[0])
+	seen := make([]bool, len(fn.Blocks)) // seen[i] means we have visited block i at least once.
+
+	// Visit every block in the queue.
+	for len(queue) > 0 {
+		b := queue[0]
+		queue = queue[1:]
+
+		// Create a nilnessTableSet for this block if it doesn't exist.
+		if _, ok := nilnessTableSetByBB[b]; !ok {
+			nilnessTableSetByBB[b] = newNilnessTableSet()
+		}
+
+		// Propagate nilnessTables from predecessors. Union every predecessor's nilnessTableSet
+		// into this block's nilnessTableSet.
+
+		// Map each predecessor to the nilnessTables propagated from it.
+		nilnessTablesUnderPred := make(map[*ssa.BasicBlock]nilnessTableSet)
+		for _, pred := range b.Preds {
+			var nilnessTableSetOfPred nilnessTableSet
+			if !seen[pred.Index] {
+				// Skip any predecessor that has not been visited yet.
+				continue
+			}
+			if r, ok := nilnessTableSetByBB[pred]; ok && len(r) != 0 {
+				nilnessTableSetOfPred = r
+			} else {
+				nilnessTableSetOfPred = newNilnessTableSet()
+				nilnessTableSetOfPred, _ = add(nilnessTableSetOfPred, nilnessTable{})
+			}
+			nilnessTableSetUnderThisPred := newNilnessTableSet()
+			for _, table := range nilnessTableSetOfPred {
+				// Copy all the existing values.
+				nTable := table.copy()
+				// Learn new nilness from the branch if any.
+				lTable, ok := learnNilness(b, pred, table)
+				if !ok {
+					// conflict found when extending this table, we should drop this table.
+					continue
+				}
+				nTable.addAll(lTable)
+				nilnessTableSetUnderThisPred, _ = add(nilnessTableSetUnderThisPred, nTable)
+			}
+			nilnessTablesUnderPred[pred] = nilnessTableSetUnderThisPred
+		}
+
+		// Transfer nilness inside the block
+		for _, instr := range b.Instrs {
+			switch instr := instr.(type) {
+			case *ssa.Phi:
+				for i, cand := range instr.Edges {
+					pred := b.Preds[i]
+					if _, ok := nilnessTablesUnderPred[pred]; !ok {
+						// There is no table set up for this predecessor because the predecessor is
+						// skipped in the previous for loop, since it is not visited yet. We skip
+						// it here as well.
+						continue
+					}
+					for _, table := range nilnessTablesUnderPred[pred] {
+						candNil := table.nilnessOf(cand)
+						if candNil == unknown {
+							// Do not save the nilness if it is unknown. There are two cases:
+							// 1. the phi value cannot have nil as a valid value, e.g. it is an
+							// int.
+							// 2. the phi value can have nil as a valid value, but we do not know
+							// the nilness of the value.
+							continue
+						}
+						// Append the nilness of the phi value and the related values' nilness
+						// expanded from the nilness of the phi value.
+						table.expandNilness(instr, candNil)
+					}
+				}
+				// TODO: function call, field addr, store, etc.
+			}
+		}
+
+		// Update nilnessTableSetByBB for this block.
+		var isUpdated bool
+		for _, tables := range nilnessTablesUnderPred {
+			for _, table := range tables {
+				if len(table) == 0 {
+					continue
+				}
+				// Only save the table if it is not empty.
+				nilnessTableSetByBB[b], isUpdated = add(nilnessTableSetByBB[b], table)
+			}
+		}
+
+		// No need to visit the successors if the nilness table set of this block is not updated.
+		if seen[b.Index] && !isUpdated {
+			continue
+		}
+		seen[b.Index] = true
+
+		// TODO: nicely handle exponential explosion of tables.
+		if len(nilnessTableSetByBB[b]) >= _maxNumTablesPerBlock {
+			// Too many tables, we should give up inferring contracts for this function.
+			return []*FunctionContract{}
+		}
+
+		// Add successors to queue since the nilness table set of this block has been updated.
+		queue = append(queue, b.Succs...)
+	}
+
+	return deriveContracts(retInstrs, fn, nilnessTableSetByBB)
+}
+
+// learnNilness learns nilness for the block succ, extended from one nilnessTable table of its
+// predecessor pred. The function creates a new nilnessTable that stores **only newly learned**
+// nilness for succ block and a bool flag that indicates whether a conflict is seen when going to
+// succ block from pred block. If there is no a conflict, the bool flag is true, otherwise it is
+// false. Note, when the bool flag is false, the returned nilnessTable can be empty because we do
+// not learn nilness for al kinds of conditions. For now we support only what is supported in
+// the function branch.
+func learnNilness(succ *ssa.BasicBlock, pred *ssa.BasicBlock, table nilnessTable) (nilnessTable, bool) {
+	lTable := nilnessTable{} // learned nilnessTable
+	eqSucc, neSucc, binOp := branch(pred)
+	// TODO: for now we learn nilness from only these two condition: ? == ? and ? != ?
+	if binOp == nil || eqSucc == nil || neSucc == nil {
+		// TODO: only binOp == nil is sufficient, but nilaway would not be happy with it.
+		return lTable, true
+	}
+	// TODO: each successor should learn a different nilness in terms of the variable
+	//  involved in the condition.
+	xnil := table.nilnessOf(binOp.X)
+	ynil := table.nilnessOf(binOp.Y)
+
+	// Both operands are known of nilness.
+	// Determine whether the branch is reachable.
+	if xnil != unknown && ynil != unknown {
+		if (xnil == ynil && succ == eqSucc) || (xnil != ynil && succ == neSucc) {
+			return lTable, true
+		}
+		// conflict
+		return lTable, false
+	}
+
+	// Only one operand is known of nilness.
+	if ynil == unknown {
+		// learn the nilness of Y
+		if succ == eqSucc {
+			lTable.expandNilness(binOp.Y, xnil)
+		} else {
+			lTable.expandNilness(binOp.Y, xnil.negate())
+		}
+	} else {
+		// learn the nilness of X
+		if succ == eqSucc {
+			lTable.expandNilness(binOp.X, ynil)
+		} else {
+			lTable.expandNilness(binOp.X, ynil.negate())
+		}
+	}
+	return lTable, true
+}
+
+// deriveContracts checks nilness of parameter and return values at every exit block to infer
+// contracts.
+func deriveContracts(
+	retInstrs []*ssa.Return,
+	fn *ssa.Function,
+	nilnessTableSetByBB map[*ssa.BasicBlock]nilnessTableSet) []*FunctionContract {
+	// TODO: verify other or multiple param/return contracts in the future; for now we consider
+	//  contract(nonnil->nonnil) only.
+	param := fn.Params[0]
+	nonnilOrUnknownParamChoices := 0
+	nilParamChoices := 0
+	nonnilRetChoices := 0
+	totalChoices := 0
+
+	// We try to find a counterexample to nonnil->nonnil. If we find one, we immediately break out
+	// of the loop and return the contract(nonnil->nonnil) does not hold. Otherwise, we will
+	// move on to post-check before we can conclude the contaract(nonnil->nonnil) holds.
+	for _, retInstr := range retInstrs {
+		// b ends with a return
+		ret := retInstr.Results[0]
+		tables := newNilnessTableSet()
+		if r, ok := nilnessTableSetByBB[retInstr.Block()]; ok {
+			tables = r
+		} else {
+			tables, _ = add(tables, nilnessTable{})
+		}
+		for _, table := range tables {
+			totalChoices++
+			pNil := table.nilnessOf(param)
+			rNil := table.nilnessOf(ret)
+			// All the possibilities:
+			// nonnil->nonnil     // OK
+			// unknown->nonnil    // OK
+			// nil->nonnil        // OK
+			// nonnil->unknown    // counterexample to contract(nonnil->nonnil)
+			// unknown->unknown   // two cases
+			//   unknown->unknown // counterexample in general
+			//   x->x             // OK if two unknown are the same value
+			// nil->unknown       // OK
+			// nonnil->nil        // counterexample to contract(nonnil->nonnil)
+			// unknown->nil       // counterexample to contract(nonnil->nonnil)
+			// nil->nil           // OK
+			//
+			if rNil == isnonnil {
+				nonnilRetChoices++
+			}
+			if pNil == isnil {
+				nilParamChoices++
+				// nil param never leads to a counterexample to contract(nonnil->nonnil)
+				continue
+			}
+			// pNil == isnonnil or unknown, rNil can be anything, i.e. isnonnil, unknown, isnil.
+			nonnilOrUnknownParamChoices++
+			if rNil == isnonnil || // Absolutely OK if rNil == isnonnil
+				(pNil == unknown && rNil == unknown && param == ret) { // The only OK case otherwise
+				// Those cases are not counterexamples to contract(nonnil->nonnil)
+				continue
+			}
+			// All the remaining cases are counterexamples to contract(nonnil->nonnil)
+			return []*FunctionContract{}
+		}
+	}
+
+	// Post-check: we deny contract(nonnil->nonnil) for the following cases:
+	//
+	// 1. If the parameter is nil at every path, the contract nonnil->nonnil is trivially true, but
+	// we suppress inferring such a useless contract to avoid the following overhead, such as
+	// trigger duplication. However, I feel it is not possible that all paths have the parameter as
+	// isnil, since the parameter always starts with unknown, and we do only branching nil and
+	// nonnil.
+	//
+	// 2. It is essentially _->nonnil that holds for this function, so it is not necessary to
+	// infer nonnil->nonnil.
+	if (nilParamChoices == totalChoices && nonnilOrUnknownParamChoices == 0) ||
+		nonnilRetChoices == totalChoices {
+		return []*FunctionContract{}
+	}
+
+	// totalChoices > nilParamChoices >= 0 && totalChoices >= nonnilOrUnknownParamChoices > 0 &&
+	// nonnilRetChoices < totalChoices
+
+	// nonnil->nonnil is valid at all exit blocks
+	return []*FunctionContract{
+		{Ins: []ContractVal{NonNil}, Outs: []ContractVal{NonNil}},
+	}
+}
+
+func getReturnInstrs(fn *ssa.Function) []*ssa.Return {
+	returnInstrs := make([]*ssa.Return, 0)
+	for _, b := range fn.Blocks {
+		// len(x) still returns 0 when x is nil
+		if len(b.Succs) != 0 || len(b.Instrs) == 0 {
+			continue
+		}
+		// b is an exit block, either panic or return
+		if instr, ok := b.Instrs[len(b.Instrs)-1].(*ssa.Return); ok {
+			returnInstrs = append(returnInstrs, instr)
+		}
+	}
+	return returnInstrs
+}
+
+// branch reports whether we can make a branch and learn nilness from the true and false successor.
+// The function returns equal, not-equal successor and the binary operation iff
+//
+//	(1) b ends with an equality or inequality comparison;
+//	(2) the operands can have nil as a valid value;
+//
+// Otherwise, the function returns all nil.
+func branch(b *ssa.BasicBlock) (*ssa.BasicBlock, *ssa.BasicBlock, *ssa.BinOp) {
+	ifInstr, ok := b.Instrs[len(b.Instrs)-1].(*ssa.If)
+	if !ok {
+		return nil, nil, nil
+	}
+	binOp, ok := ifInstr.Cond.(*ssa.BinOp)
+	// Check only one operand is sufficient since the two operands must have the same type.
+	if !ok || util.TypeBarsNilness(binOp.X.Type()) {
+		// not a binary comparison or the type cannot have nil as a value.
+		return nil, nil, nil
+	}
+	switch binOp.Op {
+	case token.EQL:
+		return b.Succs[0], b.Succs[1], binOp
+	case token.NEQ:
+		return b.Succs[1], b.Succs[0], binOp
+	}
+	return nil, nil, nil
+}
+
+// isBuiltinAppendCall reports if the call is a call to builtin append.
+func isBuiltinAppendCall(v *ssa.Call) bool {
+	// TODO: consider merge this and assertion.BuiltinAppend
+	bi, ok := v.Call.Value.(*ssa.Builtin)
+	if !ok {
+		return false
+	}
+	return bi.Name() == "append"
+}
+
+type nilness int
+
+func (n nilness) negate() nilness { return -n }
+
+const (
+	isnonnil         = -1
+	unknown  nilness = 0
+	isnil            = 1
+)
+
+var nilnessStrings = []string{"non-nil", "unknown", "nil"}
+
+func (n nilness) String() string { return nilnessStrings[n+1] }
+
+type nilnessTable map[ssa.Value]nilness
+
+// nilnessOf reports whether v is definitely nil, definitely not nil, or unknown given the nilness
+// table.
+// Adapted from org_golang_x_tools/go/analysis/passes/nilness/nilness.go
+func (t nilnessTable) nilnessOf(v ssa.Value) nilness {
+	switch v := v.(type) {
+	// unwrap ChangeInterface and Slice values recursively, to detect if underlying values have any
+	// facts recorded or are otherwise known with regard to nilness.
+	//
+	// This work must be in addition to expanding facts about ChangeInterfaces during
+	// inference/fact gathering because this covers cases where the nilness of a value is
+	// intrinsic, rather than based on inferred facts, such as a zero value interface variable.
+	// That said, this work alone would only inform us when facts are about underlying values,
+	// rather than outer values, when the analysis is transitive in both directions.
+	case *ssa.ChangeInterface:
+		if underlying := t.nilnessOf(v.X); underlying != unknown {
+			return underlying
+		}
+	case *ssa.MakeInterface:
+		if underlying := t.nilnessOf(v.X); underlying != unknown {
+			return underlying
+		}
+	case *ssa.Slice:
+		if underlying := t.nilnessOf(v.X); underlying != unknown {
+			return underlying
+		}
+	case *ssa.SliceToArrayPointer:
+		nn := t.nilnessOf(v.X)
+		// Get the length of underlying array pointer of slice
+		if v.Type().(*types.Pointer).Elem().Underlying().(*types.Array).Len() > 0 {
+			if nn == isnil {
+				// We know that *(*[1]byte)(nil) is going to panic because of the conversion. So
+				// return unknown to the caller, prevent useless nil deference reporting due to *
+				// operator.
+				return unknown
+			}
+			// Otherwise, the conversion will yield a non-nil pointer to array. Note that the
+			// instruction can still panic if array length greater than slice length. If the value
+			// is used by another instruction, that instruction can assume the panic did not happen
+			// when that instruction is reached.
+			return isnonnil
+		}
+		// In case array length is zero, the conversion result depends on nilness of the slice.
+		if nn != unknown {
+			return nn
+		}
+	case *ssa.Call:
+		if !isBuiltinAppendCall(v) {
+			break
+		}
+		// append(s, x) always returns a nonnil.
+		if len(v.Call.Args) > 1 {
+			return isnonnil
+		}
+		// append(s) depends on the nilability of s.
+		return t.nilnessOf(v.Call.Args[0])
+	}
+
+	// Is value intrinsically nil or non-nil?
+	switch v := v.(type) {
+	case *ssa.Alloc,
+		*ssa.FieldAddr,
+		*ssa.FreeVar,
+		*ssa.Function,
+		*ssa.Global,
+		*ssa.IndexAddr,
+		*ssa.MakeChan,
+		*ssa.MakeClosure,
+		*ssa.MakeMap,
+		*ssa.MakeSlice:
+		return isnonnil
+	case *ssa.Const:
+		if v.IsNil() {
+			return isnil // nil or zero value of a pointer-like type
+		}
+		return unknown // non-pointer
+	}
+
+	// Search table for the value.
+	if nn, ok := t[v]; ok {
+		return nn
+	}
+
+	// TODO: When we see a pointer indirection, we can check if the indirection of the same pointer
+	//  has been saved in the table. If so, we can use the saved value.
+	return unknown
+}
+
+// expandNilness takes a single known nilness and learn the set of nilness that can be known
+// about it or any of its related values. Some operations, like ChangeInterface, have transitive
+// nilness, such that if you know the underlying value is nil, you also know the value itself is
+// nil, and vice versa. This operation allows callers to match on any of the related values in
+// analyses, rather than just the one form of the value that happened to appear in a comparison.
+//
+// This work must be in addition to unwrapping values within nilnessOf because while this work
+// helps give facts about transitively known values based on inferred facts, the recursive check
+// within nilnessOf covers cases where nilness facts are intrinsic to the underlying value, such as
+// a zero value interface variables.
+//
+// ChangeInterface is the only expansion currently supported, but others, like Slice, could be
+// added. At this time, this tool does not check slice operations in a way this expansion could
+// help, for example:
+//
+// var s []string
+//
+//	if s0 := s[:0]; s0 == nil {
+//	  fmt.Println("s0 and s are both nil.")
+//	}
+//
+// Adapted from org_golang_x_tools/go/analysis/passes/nilness/nilness.go
+func (t nilnessTable) expandNilness(val ssa.Value, nn nilness) {
+	if _, ok := t[val]; ok {
+		// Don't reprocess.
+		return
+	}
+	t[val] = nn
+	switch v := val.(type) {
+	case *ssa.ChangeInterface:
+		t.expandNilness(v.X, nn)
+	case *ssa.MakeInterface:
+		t.expandNilness(v.X, nn)
+	case *ssa.Call:
+		if isBuiltinAppendCall(v) && len(v.Call.Args) == 1 {
+			// append(s) always has the same nilness as s.
+			t.expandNilness(v.Call.Args[0], nn)
+		}
+	}
+}
+
+// copy returns a copy of the nilnessTableSet.
+func (t nilnessTable) copy() nilnessTable {
+	cpt := make(nilnessTable)
+	for k, v := range t {
+		cpt[k] = v
+	}
+	return cpt
+}
+
+// equals returns if two nilnessTableSet are equal.
+func (t nilnessTable) equals(other nilnessTable) bool {
+	if len(t) != len(other) {
+		return false
+	}
+	for k, v := range t {
+		if other[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// addAll adds all the entries from other to t.
+func (t nilnessTable) addAll(other nilnessTable) {
+	for k, v := range other {
+		if r, ok := t[k]; !ok || r != v {
+			t[k] = v
+		}
+	}
+}
+
+type nilnessTableSet []nilnessTable
+
+func add(s nilnessTableSet, t nilnessTable) (nilnessTableSet, bool) {
+	// TODO: an efficient check for whether t is already in s.
+	for _, v := range s {
+		if v.equals(t) {
+			return s, false
+		}
+	}
+	return append(s, t), true
+}
+
+func newNilnessTableSet() nilnessTableSet {
+	return make(nilnessTableSet, 0)
+}

--- a/assertion/function/functioncontracts/infer.go
+++ b/assertion/function/functioncontracts/infer.go
@@ -1,3 +1,17 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package functioncontracts
 
 import (

--- a/assertion/function/functioncontracts/parse.go
+++ b/assertion/function/functioncontracts/parse.go
@@ -1,3 +1,17 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package functioncontracts
 
 import (

--- a/assertion/function/functioncontracts/parse.go
+++ b/assertion/function/functioncontracts/parse.go
@@ -1,0 +1,60 @@
+package functioncontracts
+
+import (
+	"fmt"
+	"go/ast"
+	"regexp"
+	"strings"
+)
+
+const _sep = ","
+const _contractKeyword = "contract"
+const _contractValKeyword = NonNil + "|" + False + "|" + True + "|" + Any
+
+// _contractRE matches multiple function contracts in the same line. Each contract looks like
+// `contract(VALUE(,VALUE)+ -> VALUE(,VALUE)+)`. The RE also captures two lists of VALUEs,
+// i.e., the part before and after `->` for each contract.
+// Note that we match start and end of the line here and add a non-capturing group for the entire
+// contract, and we disallow anything else except whitespace to appear between contracts, so we
+// acknowledge only the contracts written in their own line.
+var _contractRE = regexp.MustCompile(
+	fmt.Sprintf("^\\s*//\\s*(?:\\s*%s\\s*\\(\\s*((?:%s)(?:\\s*,\\s*(?:%s))*)\\s*->\\s*((?:%s)(?:\\s*,\\s*(?:%s))*)\\s*\\)\\s*)+$",
+		_contractKeyword, _contractValKeyword, _contractValKeyword, _contractValKeyword, _contractValKeyword))
+
+// parseContracts parses a slice of function contracts from a singe comment group. If no contract
+// is found from the comment group, an empty slice is returned.
+func parseContracts(doc *ast.CommentGroup) []*FunctionContract {
+	contracts := make([]*FunctionContract, 0)
+	if doc == nil {
+		return contracts
+	}
+	for _, lineComment := range doc.List {
+		res := _contractRE.FindAllStringSubmatch(lineComment.Text, -1)
+		if res == nil {
+			continue
+		}
+		for _, matching := range res {
+			// matching is a slice of three elements; the first is the whole matched string and the
+			// next two are the captured groups of contract values before and after `->`.
+			ins := parseListOfContractValues(matching[1])
+			outs := parseListOfContractValues(matching[2])
+			ctrt := &FunctionContract{
+				Ins:  ins,
+				Outs: outs,
+			}
+			contracts = append(contracts, ctrt)
+		}
+	}
+	return contracts
+}
+
+// parseListOfContractValues splits a string of comma separated contract value keywords and returns
+// a slice of ContractVal.
+func parseListOfContractValues(wholeStr string) []ContractVal {
+	valKeywords := strings.Split(wholeStr, _sep)
+	contractVals := make([]ContractVal, len(valKeywords))
+	for i, v := range valKeywords {
+		contractVals[i] = stringToContractVal(strings.TrimSpace(v))
+	}
+	return contractVals
+}

--- a/assertion/function/functioncontracts/testdata/src/go.uber.org/functioncontracts/infer/main.go
+++ b/assertion/function/functioncontracts/testdata/src/go.uber.org/functioncontracts/infer/main.go
@@ -1,0 +1,318 @@
+/*
+Test functionality of inferring function contracts.
+*/
+
+// <nilaway contract enable>
+package infer
+
+import (
+	"math/rand"
+)
+
+func onlyLocalVar(x *int) *int {
+	// SSA:
+	// 0: {}
+	//   x != nil:*int
+	//   if t0 goto 1 else 2
+	// 1: {x: nonnil}
+	// 	 jump 2
+	// 2: {x: nonnil, y: nonnil} OR {x: nil, y: nil}
+	// 	 phi [0: nil:*int, 1: x] #y
+	//   t1 != nil:*int
+	//   if t2 goto 3 else 4
+	// 3: {x: nonnil, y: nonnil}
+	//   return t1
+	// 4: {x: nil, y: nil}
+	//   return x
+	var y *int
+	if x != nil {
+		y = x
+	}
+	if y != nil {
+		return y
+	}
+	return x
+}
+
+func unknownCondition(x *int) *int {
+	// SSA:
+	// 0: {}
+	//   x != nil:*int
+	//   if t0 goto 1 else 2
+	// 1: {x: nonnil}
+	// 	 jump 2
+	// 2: {x: nonnil, y: nonnil} OR {x: nil, y: nil}
+	// 	 phi [0: nil:*int, 1: x] #y
+	//   phi [0: 0:int, 1: 1:int] #z
+	//   t2 == 0:int
+	//   if t3 goto 3 else 4
+	// 3: {x: nonnil, y: nonnil} OR {x: nil, y: nil}
+	//   jump 4
+	// 4: {x: nonnil, y: nonnil, x(t4): nonnil} OR {x: nil, y: nil, x(t4): nil}
+	//   phi [2: x, 3: t1] #x
+	//   return t4
+	var y *int = nil
+	var z int = 0
+	if x != nil {
+		y = x
+		z = 1
+	}
+	if z == 0 { // represents some unknown condition
+		x = y
+	}
+	return x
+}
+
+func noLocalVar(x *int) *int {
+	if x != nil {
+		return new(int)
+	}
+	// Return nonnil or nil randomly if x is nil
+	if rand.Float64() > 0.5 {
+		return new(int)
+	} else {
+		return nil
+	}
+}
+
+// contract(nonnil -> nonnil) does not hold.
+func nonnilToNil(x *int) *int {
+	if x == nil {
+		return new(int)
+	}
+	return nil
+}
+
+// contract(nonnil -> nonnil) does not hold.
+func nonnilToUnknown(x *int) *int {
+	if x == nil {
+		return nil
+	}
+	// Return nonnil or nil randomly if x is nonnil
+	if rand.Float64() > 0.5 {
+		return new(int)
+	} else {
+		return nil
+	}
+}
+
+// contract(nonnil -> nonnil) does not hold.
+func unknownToNil(x *int) *int {
+	return nil
+}
+
+type S struct {
+	f *int
+}
+
+// The function has valid contract(nonnil -> nonnil) but we are not able to infer it now. SSA
+// create a new value for each occurence of s.f, we would not learn nilness of it from the table.
+// To infer contract successfully for this function, we need to look deeply at pointer
+// indirections.
+func field(s *S) *int {
+	// SSA:
+	// Block 0:
+	//   s == nil:*S // t0
+	//   if t0 goto 1 else 2
+	// Block 1:
+	//   return nil:*int
+	// Block 2:
+	//   &s.f [#0] // t1
+	//   *t1 // t2
+	//   t2 == nil:*int
+	//   if t3 goto 3 else 4
+	// Block 3:
+	//   new int (new) // t4
+	//   &s.f [#0] // t5
+	//   *t5 = t4
+	//   jump 4
+	// Block 4:
+	//   &s.f [#0] // t6
+	//   *t6
+	//   return t7
+	if s == nil {
+		return nil
+	}
+	if s.f == nil {
+		s.f = new(int)
+	}
+	return s.f
+}
+
+// exceeds maximum number of paths so we do not infer anything
+func manyBranchesLocalVar(x *int) []*int {
+	v1 := nilOrNonnilIntPointer()
+	v2 := nilOrNonnilIntPointer()
+	v3 := nilOrNonnilIntPointer()
+	v4 := nilOrNonnilIntPointer()
+	v5 := nilOrNonnilIntPointer()
+	v6 := nilOrNonnilIntPointer()
+	v7 := nilOrNonnilIntPointer()
+	v8 := nilOrNonnilIntPointer()
+	v9 := nilOrNonnilIntPointer()
+	v10 := nilOrNonnilIntPointer()
+	v11 := nilOrNonnilIntPointer()
+	v12 := nilOrNonnilIntPointer()
+	v13 := nilOrNonnilIntPointer()
+	v14 := nilOrNonnilIntPointer()
+	v15 := nilOrNonnilIntPointer()
+	var vs []*int
+	if x == nil {
+		return vs
+	}
+	if v1 != nil {
+		vs = append(vs, nilOrNonnilIntPointer())
+	}
+	if v2 != nil {
+		vs = append(vs, nilOrNonnilIntPointer())
+	}
+	if v3 != nil {
+		vs = append(vs, nilOrNonnilIntPointer())
+	}
+	if v4 != nil {
+		vs = append(vs, nilOrNonnilIntPointer())
+	}
+	if v5 != nil {
+		vs = append(vs, nilOrNonnilIntPointer())
+	}
+	if v6 != nil {
+		vs = append(vs, nilOrNonnilIntPointer())
+	}
+	if v7 != nil {
+		vs = append(vs, nilOrNonnilIntPointer())
+	}
+	if v8 != nil {
+		vs = append(vs, nilOrNonnilIntPointer())
+	}
+	if v9 != nil {
+		vs = append(vs, nilOrNonnilIntPointer())
+	}
+	if v10 != nil {
+		vs = append(vs, nilOrNonnilIntPointer())
+	}
+	if v11 != nil {
+		vs = append(vs, nilOrNonnilIntPointer())
+	}
+	if v12 != nil {
+		vs = append(vs, nilOrNonnilIntPointer())
+	}
+	if v13 != nil {
+		vs = append(vs, nilOrNonnilIntPointer())
+	}
+	if v14 != nil {
+		vs = append(vs, nilOrNonnilIntPointer())
+	}
+	if v15 != nil {
+		vs = append(vs, nilOrNonnilIntPointer())
+	}
+	return vs
+}
+
+func nilOrNonnilIntPointer() *int {
+	if rand.Float64() > 0.5 {
+		return new(int)
+	} else {
+		return nil
+	}
+}
+
+// contract(nonnil -> nonnil) does not hold since b is a bool which cannot have nil as a valid
+// value.
+func nilIncompatibleType(b bool) *int {
+	if b {
+		return new(int)
+	} else {
+		return new(int)
+	}
+}
+
+// contract(nonnil -> nonnil) holds but we do not infer.
+func alwaysReturnNonnil(x *int) *int {
+	return new(int)
+}
+
+// contract(nonnil -> nonnil) does not hold.
+func learnOuterFromUnderlyingMakeInterface(i any) any {
+	if i == nil {
+		return i
+	}
+	var s []int // *ssa.MakeInterface: make any <- []int (nil:[]int)
+	return s    // We should learn s is nil
+}
+
+type I interface {
+	m()
+}
+
+type SI struct{}
+
+func (s *SI) m() {}
+
+func nilOrNonnilSI() *SI {
+	if rand.Float64() > 0.5 {
+		return new(SI)
+	} else {
+		return nil
+	}
+}
+
+// contract(nonnil -> nonnil) holds.
+func learnUnderlyingFromOuterMakeInterface(in I) I {
+	if in == nil {
+		return in
+	}
+	si := nilOrNonnilSI()
+	i := I(si) // *ssa.MakeInterface: make I <- *SI (si)
+	if i == nil {
+		// We should learn si is nil from i is nil
+		return new(SI)
+	}
+	// We should learn si is nonnil from i is nonnil
+	return si
+}
+
+// we are not able to infer contract(nonnil -> nonnil) here because for now nil is defined as
+// strict nil, which does not include the empty slice.
+func nonEmptySliceToNonnil(s []int) []int {
+	// SSA:
+	// Block 0:
+	//   t0: *ssa.Call: len(s)
+	//   *ssa.Jump: jump 1
+	// Block 1:
+	//   t1: *ssa.Phi: phi [0: nil:[]int, 2: t10] #ns
+	//   t2: *ssa.Phi: phi [0: -1:int, 2: t3]
+	//   t3: *ssa.BinOp: t2 + 1:int
+	//   t4: *ssa.BinOp: t3 < t0
+	//       *ssa.If: if t4 goto 2 else 3
+	// Block 2:
+	//   t5: *ssa.IndexAddr: &s[t3]
+	//   t6: *ssa.UnOp: *t5
+	//   t7: *ssa.Alloc: new [1]int (varargs)
+	//   t8: *ssa.IndexAddr: &t7[0:int]
+	//   	 *ssa.Store: *t8 = t6
+	//   t9: *ssa.Slice: slice t7[:]
+	//   t10: *ssa.Call: append(t1, t9...)
+	//       *ssa.Jump: jump 1
+	// Block 3:
+	//   *ssa.Return: return t1
+	var ns []int
+	for _, e := range s {
+		ns = append(ns, e)
+	}
+	return ns
+}
+
+type STR struct {
+	f *int
+}
+
+func twoCondsMerge(x *STR) *STR {
+	if x == nil || x.f == nil {
+		return x
+	}
+	return x
+}
+
+func unknownToUnknownButSameValue(x *int) *int {
+	return x
+}

--- a/assertion/function/functioncontracts/testdata/src/go.uber.org/functioncontracts/infer/main.go
+++ b/assertion/function/functioncontracts/testdata/src/go.uber.org/functioncontracts/infer/main.go
@@ -316,6 +316,11 @@ type STR struct {
 	f *int
 }
 
+// contract(nonnil -> nonnil) does not hold because we do not consider receiver as a parameter.
+func (s *STR) receiverNotConsidered(fr *int) *STR {
+	return s
+}
+
 func twoCondsMerge(x *STR) *STR {
 	if x == nil || x.f == nil {
 		return x
@@ -325,4 +330,43 @@ func twoCondsMerge(x *STR) *STR {
 
 func unknownToUnknownButSameValue(x *int) *int {
 	return x
+}
+
+func nonnilAnyToNonnilAny(x *int, y *int) (*int, *int) {
+	if x != nil {
+		return new(int), nil
+	}
+	return x, y
+}
+
+func nonnilAnyToAnyNonnil(x *int, y *int) (*int, *int) {
+	if x != nil {
+		return nil, new(int)
+	}
+	return y, x
+}
+
+func anyNonnilToNonnilAny(x *int, y *int) (*int, *int) {
+	if y != nil {
+		return new(int), nil
+	}
+	return y, x
+}
+
+func anyNonnilToAnyNonnil(x *int, y *int) (*int, *int) {
+	if y != nil {
+		return nil, new(int)
+	}
+	return x, y
+}
+
+func anyNonnilAnyToAnyAnyNonnilAny(x, y, z *int) (*int, *int, *int, *int) {
+	return nil, nil, y, nil
+}
+
+func mixType(x int, y *int) (int, *int) {
+	if y != nil {
+		return 0, new(int)
+	}
+	return x, y
 }

--- a/assertion/function/functioncontracts/testdata/src/go.uber.org/functioncontracts/infer/main.go
+++ b/assertion/function/functioncontracts/testdata/src/go.uber.org/functioncontracts/infer/main.go
@@ -1,6 +1,16 @@
-/*
-Test functionality of inferring function contracts.
-*/
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // <nilaway contract enable>
 package infer

--- a/assertion/function/functioncontracts/testdata/src/go.uber.org/functioncontracts/parse/main.go
+++ b/assertion/function/functioncontracts/testdata/src/go.uber.org/functioncontracts/parse/main.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // <nilaway contract enable>
-package functioncontracts
+package parse
 
 // contract(nonnil -> nonnil)
 func f1(x *int) *int {

--- a/nilaway_test.go
+++ b/nilaway_test.go
@@ -221,7 +221,11 @@ func TestFunctionContracts(t *testing.T) {
 	t.Parallel()
 
 	testdata := analysistest.TestData()
-	analysistest.Run(t, testdata, Analyzer, "go.uber.org/functioncontracts", "go.uber.org/functioncontracts/inference")
+	analysistest.Run(t, testdata, Analyzer,
+		"go.uber.org/functioncontracts/parse",
+		"go.uber.org/functioncontracts/parse/inference",
+		"go.uber.org/functioncontracts/infer",
+		"go.uber.org/functioncontracts/infer/inference")
 }
 
 func TestPrettyPrint(t *testing.T) { //nolint:paralleltest

--- a/testdata/src/go.uber.org/functioncontracts/infer/functioncontracts.go
+++ b/testdata/src/go.uber.org/functioncontracts/infer/functioncontracts.go
@@ -1,16 +1,15 @@
 /*
-This package aims to test function contracts.
+This package aims to test automated inferred function contracts in no inference mode.
 
 <nilaway no inference>
 <nilaway contract enable>
 */
-package functioncontracts
+package infer
 
 import "math/rand"
 
 // Test the contracted function contains a full trigger nilable -> return 0.
 // nilable(x, result 0)
-// contract(nonnil -> nonnil)
 func fooReturn(x *int) *int {
 	if x != nil {
 		// Return nonnil
@@ -39,7 +38,6 @@ func barReturn2() {
 
 // Test the contracted function retains a full trigger param 0 -> nonnil.
 // nilable(x, result 0)
-// contract(nonnil -> nonnil)
 func fooParam(x *int) *int {
 	if x != nil {
 		return new(int)
@@ -68,13 +66,13 @@ func barParam2() {
 func sink(v int) {}
 
 // Test the contracted function contains another contracted function.
-// nilable(x, result 0)
+// TODO: remove the contract here when we can automatically infer the contract for this function.
 // contract(nonnil -> nonnil)
+// nilable(x, result 0)
 func fooNested(x *int) *int {
 	return fooBase(x)
 }
 
-// contract(nonnil -> nonnil)
 // nilable(x, result 0)
 func fooBase(x *int) *int {
 	if x != nil {
@@ -101,7 +99,6 @@ func barNested2() {
 }
 
 // Test the contracted function is called multiple times in another function.
-// contract(nonnil -> nonnil)
 // nilable(x, result 0)
 func fooReturnCalledMultipleTimesInTheSameFunction(x *int) *int {
 	if x != nil {
@@ -136,7 +133,6 @@ func barReturnCalledMultipleTimesInTheSameFunction() {
 
 // Test call site annotations are wrongly written.
 // nilable(x, result 0)
-// contract(nonnil -> nonnil)
 func fooWrongCallSiteAnnotation(x *int) *int {
 	if x != nil {
 		// Return nonnil
@@ -157,7 +153,6 @@ func barWrongCallSiteAnnotation() {
 }
 
 // nonnil(x) nilable(result 0)
-// contract(nonnil -> nonnil)
 func fooNoCallSiteAnnoatation(x *int) *int {
 	if x != nil {
 		// Return nonnil

--- a/testdata/src/go.uber.org/functioncontracts/infer/functioncontracts.go
+++ b/testdata/src/go.uber.org/functioncontracts/infer/functioncontracts.go
@@ -1,3 +1,17 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*
 This package aims to test automated inferred function contracts in no inference mode.
 

--- a/testdata/src/go.uber.org/functioncontracts/infer/functioncontracts.go
+++ b/testdata/src/go.uber.org/functioncontracts/infer/functioncontracts.go
@@ -187,3 +187,48 @@ func barNoCallSiteAnnoatation() {
 	v := fooNoCallSiteAnnoatation(a) // want "nilable value passed"
 	print(*v)                        // want "nilable value dereferenced"
 }
+
+// nilable(x, y, result 0, result 1)
+func fooContractAnyNonnilToNonnilAnyReturn(x, y *int) (*int, *int) {
+	if y != nil {
+		return new(int), nil
+	}
+	return nil, x
+}
+
+func barContractAnyNonnilToNonnilAnyReturn1() {
+	n := 1
+	a1 := &n
+	b1, _ := fooContractAnyNonnilToNonnilAnyReturn(nil, a1) // nonnil(param 1, result 0)
+	print(*b1)                                              // No "nilable value dereferenced" wanted
+}
+
+func barContractAnyNonnilToNonnilAnyReturn2() {
+	var a2 *int
+	n := 1
+	b2, _ := fooContractAnyNonnilToNonnilAnyReturn(&n, a2) // nilable(param 1, result 0)
+	print(*b2)                                             // want "nilable value dereferenced"
+}
+
+// nilable(x, y, result 0, result 1)
+func fooContractAnyNonnilToNonnilAnyParam(x, y *int) (*int, *int) {
+	if y != nil {
+		return new(int), nil
+	}
+	sink(*y) // want "nilable value dereferenced"
+	return nil, x
+}
+
+func barContractAnyNonnilToNonnilAnyParam1() {
+	n := 1
+	a1 := &n
+	b1, _ := fooContractAnyNonnilToNonnilAnyParam(nil, a1) // nonnil(param 1, result 0)
+	print(*b1)                                             // No "nilable value dereferenced" wanted
+}
+
+func barContractAnyNonnilToNonnilAnyParam2() {
+	var a2 *int
+	n := 1
+	b2, _ := fooContractAnyNonnilToNonnilAnyParam(&n, a2) // nilable(param 1, result 0)
+	print(*b2)                                            // want "nilable value dereferenced"
+}

--- a/testdata/src/go.uber.org/functioncontracts/infer/inference/functioncontracts-with-inference.go
+++ b/testdata/src/go.uber.org/functioncontracts/infer/inference/functioncontracts-with-inference.go
@@ -158,3 +158,46 @@ func barReturnCalledMultipleTimesInTheSameFunction() {
 	b4 := fooReturnCalledMultipleTimesInTheSameFunction(a4)
 	print(*b4) // "nilable value dereferenced" wanted
 }
+
+func fooContractAnyNonnilToNonnilAnyReturn(x, y *int) (*int, *int) { // want "^ Annotation on Result 0.*\n.*Must be NILABLE.*\n.*AND.*\n.*Must be NONNIL.*NONNIL$"
+	if y != nil {
+		return new(int), nil
+	}
+	return nil, x
+}
+
+func barContractAnyNonnilToNonnilAnyReturn1() {
+	n := 1
+	a1 := &n
+	b1, _ := fooContractAnyNonnilToNonnilAnyReturn(nil, a1)
+	print(*b1) // No "nilable value dereferenced" wanted
+}
+
+func barContractAnyNonnilToNonnilAnyReturn2() {
+	var a2 *int
+	n := 1
+	b2, _ := fooContractAnyNonnilToNonnilAnyReturn(&n, a2)
+	print(*b2) // "nilable value dereferenced" wanted
+}
+
+func fooContractAnyNonnilToNonnilAnyParam(x, y *int) (*int, *int) { // want "^ Annotation on Param 1.*\n.*Must be NILABLE.*\n.*AND.*\n.*Must be NONNIL.*NONNIL$" "^ Annotation on Result 0.*\n.*Must be NILABLE.*\n.*AND.*\n.*Must be NONNIL.*NONNIL$"
+	if y != nil {
+		return new(int), nil
+	}
+	sink(*y) // "nilable value dereferenced" wanted
+	return nil, x
+}
+
+func barContractAnyNonnilToNonnilAnyParam1() {
+	n := 1
+	a1 := &n
+	b1, _ := fooContractAnyNonnilToNonnilAnyParam(nil, a1)
+	print(*b1) // No "nilable value dereferenced" wanted
+}
+
+func barContractAnyNonnilToNonnilAnyParam2() {
+	var a2 *int
+	n := 1
+	b2, _ := fooContractAnyNonnilToNonnilAnyParam(&n, a2)
+	print(*b2) // "nilable value dereferenced" wanted
+}

--- a/testdata/src/go.uber.org/functioncontracts/infer/inference/functioncontracts-with-inference.go
+++ b/testdata/src/go.uber.org/functioncontracts/infer/inference/functioncontracts-with-inference.go
@@ -1,3 +1,17 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*
 This package aims to test automated inferred function contracts in full inference mode.
 

--- a/testdata/src/go.uber.org/functioncontracts/infer/inference/functioncontracts-with-inference.go
+++ b/testdata/src/go.uber.org/functioncontracts/infer/inference/functioncontracts-with-inference.go
@@ -1,0 +1,146 @@
+/*
+This package aims to test automated inferred function contracts in full inference mode.
+
+<nilaway contract enable>
+*/
+package inference
+
+import "math/rand"
+
+// Test the contracted function contains a full trigger nilable -> return 0.
+func fooReturn(x *int) *int { // want "^ Annotation on Result 0.*\n.*Must be NILABLE.*\n.*AND.*\n.*Must be NONNIL.*NONNIL$"
+	if x != nil {
+		// Return nonnil
+		return new(int)
+	}
+	// Return nonnil or nil randomly
+	if rand.Float64() > 0.5 {
+		return new(int)
+	} else {
+		return nil
+	}
+}
+
+func barReturn1() {
+	n := 1
+	a1 := &n
+	b1 := fooReturn(a1)
+	print(*b1) // No "nilable value dereferenced" wanted
+}
+
+func barReturn2() {
+	var a2 *int
+	b2 := fooReturn(a2)
+	print(*b2) // "nilable value dereferenced" wanted
+}
+
+// Test the contracted function contains a full trigger param 0 -> nonnil.
+func fooParam(x *int) *int { // want "^ Annotation on Param 0.*\n.*Must be NILABLE.*\n.*AND.*\n.*Must be NONNIL.*NONNIL$" "^ Annotation on Result 0.*\n.*Must be NILABLE.*\n.*AND.*\n.*Must be NONNIL.*NONNIL$"
+	if x != nil {
+		return new(int)
+	}
+	if rand.Float64() > 0.5 {
+		return new(int)
+	} else {
+		sink(*x) // "nilable value dereferenced" wanted
+		return nil
+	}
+}
+
+func barParam1() {
+	n := 1
+	a1 := &n
+	b1 := fooParam(a1)
+	print(*b1)
+}
+
+func barParam2() {
+	var a2 *int
+	b2 := fooParam(a2)
+	print(*b2)
+}
+
+func sink(v int) {}
+
+// Test the contracted function contains another contracted function.
+// TODO: remove the contract here when we can automatically infer the contract for this function.
+// contract(nonnil -> nonnil)
+func fooNested(x *int) *int {
+	return fooBase(x)
+}
+
+func fooBase(x *int) *int { // want "^ Annotation on Result 0.*\n.*Must be NILABLE.*\n.*AND.*\n.*Must be NONNIL.*NONNIL$"
+	if x != nil {
+		return new(int)
+	}
+	if rand.Float64() > 0.5 {
+		return nil
+	} else {
+		return new(int)
+	}
+}
+
+func barNested1() {
+	n := 1
+	a1 := &n
+	b1 := fooNested(a1)
+	print(*b1) // No "nilable value dereferenced" wanted
+}
+
+func barNested2() {
+	var a2 *int
+	b2 := fooNested(a2)
+	print(*b2) // "nilable value dereferenced" wanted
+}
+
+// Test the contracted function is called by another function.
+func fooParamCalledInAnotherFunction(x *int) *int { // want "^ Annotation on Param 0.*\n.*Must be NILABLE.*\n.*AND.*\n.*Must be NONNIL.*NONNIL$"
+	if x != nil {
+		return new(int)
+	}
+	if rand.Float64() > 0.5 {
+		return new(int)
+	} else {
+		sink(*x) // "nilable value dereferenced" wanted
+		return nil
+	}
+}
+
+func barParamCalledInAnotherFunction() {
+	var x *int
+	call(fooParamCalledInAnotherFunction(x))
+}
+
+func call(x *int) {}
+
+// Test a contracted function is called multiple times in another function.
+func fooReturnCalledMultipleTimesInTheSameFunction(x *int) *int { // want "^ Annotation on Result 0.*\n.*Must be NILABLE.*\n.*AND.*\n.*Must be NONNIL.*NONNIL$" "^ Annotation on Result 0.*\n.*Must be NILABLE.*\n.*AND.*\n.*Must be NONNIL.*NONNIL$"
+	if x != nil {
+		return new(int)
+	}
+	if rand.Float64() > 0.5 {
+		return new(int)
+	} else {
+		return nil
+	}
+}
+
+func barReturnCalledMultipleTimesInTheSameFunction() {
+	n := 1
+	a1 := &n
+	b1 := fooReturnCalledMultipleTimesInTheSameFunction(a1)
+	print(*b1) // No "nilable value dereferenced" wanted
+
+	var a2 *int
+	b2 := fooReturnCalledMultipleTimesInTheSameFunction(a2)
+	print(*b2) // "nilable value dereferenced" wanted
+
+	m := 2
+	a3 := &m
+	b3 := fooReturnCalledMultipleTimesInTheSameFunction(a3)
+	print(*b3) // No "nilable value dereferenced" wanted
+
+	var a4 *int
+	b4 := fooReturnCalledMultipleTimesInTheSameFunction(a4)
+	print(*b4) // "nilable value dereferenced" wanted
+}

--- a/testdata/src/go.uber.org/functioncontracts/parse/functioncontracts.go
+++ b/testdata/src/go.uber.org/functioncontracts/parse/functioncontracts.go
@@ -192,3 +192,50 @@ func barNoCallSiteAnnoatation() {
 	v := fooNoCallSiteAnnoatation(a) // want "nilable value passed"
 	print(*v)                        // want "nilable value dereferenced"
 }
+
+// nilable(x, y, result 0, result 1)
+// contract(_,nonnil -> nonnil,_)
+func fooContractAnyNonnilToNonnilAnyReturn(x, y *int) (*int, *int) {
+	if y != nil {
+		return new(int), nil
+	}
+	return nil, x
+}
+
+func barContractAnyNonnilToNonnilAnyReturn1() {
+	n := 1
+	a1 := &n
+	b1, _ := fooContractAnyNonnilToNonnilAnyReturn(nil, a1) // nonnil(param 1, result 0)
+	print(*b1)                                              // No "nilable value dereferenced" wanted
+}
+
+func barContractAnyNonnilToNonnilAnyReturn2() {
+	var a2 *int
+	n := 1
+	b2, _ := fooContractAnyNonnilToNonnilAnyReturn(&n, a2) // nilable(param 1, result 0)
+	print(*b2)                                             // want "nilable value dereferenced"
+}
+
+// nilable(x, y, result 0, result 1)
+// contract(_,nonnil -> nonnil,_)
+func fooContractAnyNonnilToNonnilAnyParam(x, y *int) (*int, *int) {
+	if y != nil {
+		return new(int), nil
+	}
+	sink(*y) // want "nilable value dereferenced"
+	return nil, x
+}
+
+func barContractAnyNonnilToNonnilAnyParam1() {
+	n := 1
+	a1 := &n
+	b1, _ := fooContractAnyNonnilToNonnilAnyParam(nil, a1) // nonnil(param 1, result 0)
+	print(*b1)                                             // No "nilable value dereferenced" wanted
+}
+
+func barContractAnyNonnilToNonnilAnyParam2() {
+	var a2 *int
+	n := 1
+	b2, _ := fooContractAnyNonnilToNonnilAnyParam(&n, a2) // nilable(param 1, result 0)
+	print(*b2)                                            // want "nilable value dereferenced"
+}

--- a/testdata/src/go.uber.org/functioncontracts/parse/functioncontracts.go
+++ b/testdata/src/go.uber.org/functioncontracts/parse/functioncontracts.go
@@ -1,0 +1,180 @@
+/*
+This package aims to test hand-written function contracts in no inference mode.
+
+<nilaway no inference>
+<nilaway contract enable>
+*/
+package parse
+
+import "math/rand"
+
+// Test the contracted function contains a full trigger nilable -> return 0.
+// nilable(x, result 0)
+// contract(nonnil -> nonnil)
+func fooReturn(x *int) *int {
+	if x != nil {
+		// Return nonnil
+		return new(int)
+	}
+	// Return nonnil or nil randomly
+	if rand.Float64() > 0.5 {
+		return new(int)
+	} else {
+		return nil
+	}
+}
+
+func barReturn1() {
+	n := 1
+	a1 := &n
+	b1 := fooReturn(a1) // nonnil(param 0, result 0)
+	print(*b1)          // No "nilable value dereferenced" wanted
+}
+
+func barReturn2() {
+	var a2 *int
+	b2 := fooReturn(a2) // nilable(param 0, result 0)
+	print(*b2)          // want "nilable value dereferenced"
+}
+
+// Test the contracted function retains a full trigger param 0 -> nonnil.
+// nilable(x, result 0)
+// contract(nonnil -> nonnil)
+func fooParam(x *int) *int {
+	if x != nil {
+		return new(int)
+	}
+	if rand.Float64() > 0.5 {
+		return new(int)
+	} else {
+		sink(*x) // want "nilable value dereferenced"
+		return nil
+	}
+}
+
+func barParam1() {
+	n := 1
+	a1 := &n
+	b1 := fooParam(a1) // nonnil(param 0, result 0)
+	print(*b1)
+}
+
+func barParam2() {
+	var a2 *int
+	b2 := fooParam(a2) // nilable(param 0, result 0)
+	print(*b2)         // want "nilable value dereferenced"
+}
+
+func sink(v int) {}
+
+// Test the contracted function contains another contracted function.
+// nilable(x, result 0)
+// contract(nonnil -> nonnil)
+func fooNested(x *int) *int {
+	return fooBase(x)
+}
+
+// contract(nonnil -> nonnil)
+// nilable(x, result 0)
+func fooBase(x *int) *int {
+	if x != nil {
+		return new(int)
+	}
+	if rand.Float64() > 0.5 {
+		return nil
+	} else {
+		return new(int)
+	}
+}
+
+func barNested1() {
+	n := 1
+	a1 := &n
+	b1 := fooNested(a1) // nonnil(param 0, result 0)
+	print(*b1)          // No "nilable value dereferenced" wanted
+}
+
+func barNested2() {
+	var a2 *int
+	b2 := fooNested(a2) // nilable(param 0, result 0)
+	print(*b2)          // want "nilable value dereferenced"
+}
+
+// Test the contracted function is called multiple times in another function.
+// contract(nonnil -> nonnil)
+// nilable(x, result 0)
+func fooReturnCalledMultipleTimesInTheSameFunction(x *int) *int {
+	if x != nil {
+		return new(int)
+	}
+	if rand.Float64() > 0.5 {
+		return new(int)
+	} else {
+		return nil
+	}
+}
+
+func barReturnCalledMultipleTimesInTheSameFunction() {
+	n := 1
+	a1 := &n
+	b1 := fooReturnCalledMultipleTimesInTheSameFunction(a1) // nonnil(param 0, result 0)
+	print(*b1)                                              // No "nilable value dereferenced" wanted
+
+	var a2 *int
+	b2 := fooReturnCalledMultipleTimesInTheSameFunction(a2) // nilable(param 0, result 0)
+	print(*b2)                                              // want "nilable value dereferenced"
+
+	m := 2
+	a3 := &m
+	b3 := fooReturnCalledMultipleTimesInTheSameFunction(a3) // nonnil(param 0, result 0)
+	print(*b3)                                              // No "nilable value dereferenced" wanted
+
+	var a4 *int
+	b4 := fooReturnCalledMultipleTimesInTheSameFunction(a4) // nilable(param 0, result 0)
+	print(*b4)                                              // want "nilable value dereferenced"
+}
+
+// Test call site annotations are wrongly written.
+// nilable(x, result 0)
+// contract(nonnil -> nonnil)
+func fooWrongCallSiteAnnotation(x *int) *int {
+	if x != nil {
+		// Return nonnil
+		return new(int)
+	}
+	// Return nonnil or nil randomly
+	if rand.Float64() > 0.5 {
+		return new(int)
+	} else {
+		return nil
+	}
+}
+
+func barWrongCallSiteAnnotation() {
+	var a *int
+	b := fooWrongCallSiteAnnotation(a) // nonnil(param 0, result 0) // want "read from a variable that was never assigned to"
+	print(*b)                          // safe because the call site annotation is used
+}
+
+// nonnil(x) nilable(result 0)
+// contract(nonnil -> nonnil)
+func fooNoCallSiteAnnoatation(x *int) *int {
+	if x != nil {
+		// Return nonnil
+		return new(int)
+	}
+	// Return nonnil or nil randomly
+	if rand.Float64() > 0.5 {
+		return new(int)
+	} else {
+		return nil
+	}
+}
+
+func barNoCallSiteAnnoatation() {
+	var a *int
+	// We should rely on the function header annotations if we do not find any call site
+	// annotations.
+	v := fooNoCallSiteAnnoatation(a) // want "nilable value passed"
+	print(*v)                        // want "nilable value dereferenced"
+}

--- a/testdata/src/go.uber.org/functioncontracts/parse/functioncontracts.go
+++ b/testdata/src/go.uber.org/functioncontracts/parse/functioncontracts.go
@@ -1,3 +1,17 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /*
 This package aims to test hand-written function contracts in no inference mode.
 

--- a/testdata/src/go.uber.org/functioncontracts/parse/inference/functioncontracts-with-inference.go
+++ b/testdata/src/go.uber.org/functioncontracts/parse/inference/functioncontracts-with-inference.go
@@ -181,3 +181,48 @@ func barUnamedParam2() {
 	b2 := fooUnamedParam(a2)
 	print(*b2) // No "nilable value dereferenced" wanted
 }
+
+// contract(_,nonnil -> nonnil,_)
+func fooContractAnyNonnilToNonnilAnyReturn(x, y *int) (*int, *int) { // want "^ Annotation on Result 0.*\n.*Must be NILABLE.*\n.*AND.*\n.*Must be NONNIL.*NONNIL$"
+	if y != nil {
+		return new(int), nil
+	}
+	return nil, x
+}
+
+func barContractAnyNonnilToNonnilAnyReturn1() {
+	n := 1
+	a1 := &n
+	b1, _ := fooContractAnyNonnilToNonnilAnyReturn(nil, a1)
+	print(*b1) // No "nilable value dereferenced" wanted
+}
+
+func barContractAnyNonnilToNonnilAnyReturn2() {
+	var a2 *int
+	n := 1
+	b2, _ := fooContractAnyNonnilToNonnilAnyReturn(&n, a2)
+	print(*b2) // "nilable value dereferenced" wanted
+}
+
+// contract(_,nonnil -> nonnil,_)
+func fooContractAnyNonnilToNonnilAnyParam(x, y *int) (*int, *int) { // want "^ Annotation on Param 1.*\n.*Must be NILABLE.*\n.*AND.*\n.*Must be NONNIL.*NONNIL$" "^ Annotation on Result 0.*\n.*Must be NILABLE.*\n.*AND.*\n.*Must be NONNIL.*NONNIL$"
+	if y != nil {
+		return new(int), nil
+	}
+	sink(*y) // "nilable value dereferenced" wanted
+	return nil, x
+}
+
+func barContractAnyNonnilToNonnilAnyParam1() {
+	n := 1
+	a1 := &n
+	b1, _ := fooContractAnyNonnilToNonnilAnyParam(nil, a1)
+	print(*b1) // No "nilable value dereferenced" wanted
+}
+
+func barContractAnyNonnilToNonnilAnyParam2() {
+	var a2 *int
+	n := 1
+	b2, _ := fooContractAnyNonnilToNonnilAnyParam(&n, a2)
+	print(*b2) // "nilable value dereferenced" wanted
+}

--- a/testdata/src/go.uber.org/functioncontracts/parse/inference/functioncontracts-with-inference.go
+++ b/testdata/src/go.uber.org/functioncontracts/parse/inference/functioncontracts-with-inference.go
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// <nilaway contract enable>
+/*
+This package aims to test hand-written function contracts in full inference mode.
+
+<nilaway contract enable>
+*/
 package inference
 
 import "math/rand"


### PR DESCRIPTION
Support general nonnil->nonnil function contract, i.e., having a single nonnil but any numbers of any, e.g. contract(_,nonnil->nonnil,_).