### PR TITLE
Support contracts across packages.

### DIFF
--- a/accumulation/analyzer.go
+++ b/accumulation/analyzer.go
@@ -131,7 +131,7 @@ func run(pass *analysis.Pass) (result interface{}, _ error) {
 		// Incorporate assertions from this package one-by-one into the inferredAnnotationMap, possibly
 		// determining local and upstream sites in the process. This is guaranteed not to determine any
 		// sites unless we really have a reason they have to be determined.
-		engine.ObservePackage(assertionsResult.FullTriggers)
+		engine.ObservePackage(assertionsResult.FullTriggers, assertionsResult.Implications)
 		inferredMap, diagnostics = engine.InferredMapWithDiagnostics()
 
 	case inference.NoInfer:

--- a/assertion/analyzer.go
+++ b/assertion/analyzer.go
@@ -26,6 +26,7 @@ import (
 	"go.uber.org/nilaway/assertion/function"
 	"go.uber.org/nilaway/assertion/global"
 	"go.uber.org/nilaway/config"
+	"go.uber.org/nilaway/inference"
 	"golang.org/x/tools/go/analysis"
 )
 
@@ -41,6 +42,9 @@ type Result struct {
 	// part of the result of this sub-analyzer so that the upper-level analyzers can decide what
 	// to do with them.
 	Errors []error
+	// Implications is the extra implications generated from the function contracts analysis, to be
+	// used in the inference stage.
+	Implications []*inference.Implication
 }
 
 // Analyzer here is the analyzer than generates assertions and passes them onto the accumulator to
@@ -90,5 +94,5 @@ func run(pass *analysis.Pass) (result interface{}, _ error) {
 		errs = append(errs, resultErrs...)
 	}
 
-	return Result{FullTriggers: triggers, Errors: errs}, nil
+	return Result{FullTriggers: triggers, Errors: errs, Implications: r1.Implications}, nil
 }

--- a/assertion/function/analyzer.go
+++ b/assertion/function/analyzer.go
@@ -19,7 +19,11 @@ import (
 	"context"
 	"fmt"
 	"go/ast"
+	"go/token"
 	"go/types"
+	"os"
+	"path"
+	"path/filepath"
 	"reflect"
 	"runtime/debug"
 	"strings"
@@ -31,10 +35,12 @@ import (
 	"go.uber.org/nilaway/assertion/function/functioncontracts"
 	"go.uber.org/nilaway/assertion/structfield"
 	"go.uber.org/nilaway/config"
+	"go.uber.org/nilaway/inference"
 	"go.uber.org/nilaway/util"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/ctrlflow"
 	"golang.org/x/tools/go/cfg"
+	"golang.org/x/tools/go/types/objectpath"
 )
 
 const _doc = "Build the trees of assertions for each function in this package, propagating them to " +
@@ -49,6 +55,9 @@ type Result struct {
 	// part of the result of this sub-analyzer so that the upper-level analyzers can decide what
 	// to do with them.
 	Errors []error
+	// Implications is the extra implications generated from the function contracts analysis, to be
+	// used in the inference stage.
+	Implications []*inference.Implication
 }
 
 // Analyzer here is the analyzer than generates assertions and passes them onto the accumulator to
@@ -57,6 +66,7 @@ var Analyzer = &analysis.Analyzer{
 	Name:       "nilaway_function_analyzer",
 	Doc:        _doc,
 	Run:        run,
+	FactTypes:  []analysis.Fact{new(Cache)},
 	ResultType: reflect.TypeOf((*Result)(nil)).Elem(),
 	Requires: []*analysis.Analyzer{
 		config.Analyzer,
@@ -89,6 +99,17 @@ type functionResult struct {
 	// funcDecl is the function declaration itself.
 	funcDecl *ast.FuncDecl
 }
+
+// Cache stores the implications of all the contracted functions defined in upstream packages,
+// which represents the full triggers that need to be duplicated for each contracted function.
+type Cache struct {
+	// ImplicationsToDup is a map from the id of the contracted function to the implications
+	// (duplicable full triggers) of that function.
+	ImplicationsToDup map[string][]*inference.Implication
+}
+
+// AFact enables use of the facts passing mechanism in Go's analysis framework.
+func (*Cache) AFact() {}
 
 func run(pass *analysis.Pass) (result interface{}, _ error) {
 	// As a last resort, we recover from a panic when running the analyzer, convert the panic to
@@ -243,18 +264,86 @@ func run(pass *analysis.Pass) (result interface{}, _ error) {
 	}
 
 	// Duplicate triggers in contracted functions in the callers of the function
+	var implicationsByFuncID map[string][]*inference.Implication
 	if len(funcContracts) != 0 {
-		duplicateFullTriggersFromContractedFunctionsToCallers(pass, funcContracts, funcTriggers,
-			funcResults)
+		primitivizer := NewPrimitivizer(pass)
+		upstreamImplicationsToDup := pullUpstreamImplicationsToDup(pass)
+		implicationsByFuncID = duplicateFullTriggersFromContractedFunctionsToCallers(
+			pass, primitivizer, funcContracts, funcResults, upstreamImplicationsToDup)
+		exportImplicationsToDup(pass, primitivizer, funcResults, funcContracts)
 	}
 
-	// Flatten the triggers
+	// Flatten the triggers and implications
 	triggers := make([]annotation.FullTrigger, 0, triggerCount)
+	implicatons := make([]*inference.Implication, 0)
 	for _, s := range funcTriggers {
 		triggers = append(triggers, s...)
 	}
+	for _, impl := range implicationsByFuncID {
+		implicatons = append(implicatons, impl...)
+	}
+	return Result{FullTriggers: triggers, Errors: errs, Implications: implicatons}, nil
+}
 
-	return Result{FullTriggers: triggers, Errors: errs}, nil
+func pullUpstreamImplicationsToDup(pass *analysis.Pass) map[string][]*inference.Implication {
+	implsToDup := map[string][]*inference.Implication{}
+	facts := pass.AllPackageFacts()
+	if len(facts) == 0 {
+		return implsToDup
+	}
+	for _, f := range facts {
+		switch c := f.Fact.(type) {
+		case *Cache:
+			for funcID, impls := range c.ImplicationsToDup {
+				implsToDup[funcID] = append(implsToDup[funcID], impls...)
+			}
+		}
+	}
+	return implsToDup
+}
+
+func exportImplicationsToDup(
+	pass *analysis.Pass,
+	primitivizer *Primitivizer,
+	funcResults map[*types.Func]*functionResult,
+	funcContracts functioncontracts.Map,
+) {
+	implsToExport := map[string][]*inference.Implication{}
+	for funcObj, r := range funcResults {
+		funcID := funcObj.FullName()
+		if _, ok := funcContracts[funcID]; !ok {
+			// Skip if the function has no contract.
+			continue
+		}
+		ctrts := funcContracts[funcID]
+		if ctrts == nil {
+			// should not happen since ctrtFunc is a contracted function
+			panic(fmt.Sprintf(
+				"Did not find the contracted function %s in funcContracts",
+				funcID))
+		}
+		contract := ctrts[0]
+		ctrtParamIndex := contract.IndexOfNonnilIn()
+		ctrtRetIndex := contract.IndexOfNonnilOut()
+		for _, trigger := range r.triggers {
+			p, isContractedParam := trigger.Producer.Annotation.(annotation.FuncParam)
+			if isContractedParam {
+				isContractedParam = ctrtParamIndex == p.TriggerIfNilable.Ann.(annotation.ParamAnnotationKey).ParamNum
+			}
+			c, isContractedReturn := trigger.Consumer.Annotation.(annotation.UseAsReturn)
+			if isContractedReturn {
+				isContractedReturn = ctrtRetIndex == c.TriggerIfNonNil.Ann.(annotation.RetAnnotationKey).RetNum
+			}
+			if !isContractedParam && !isContractedReturn {
+				continue
+			}
+			// only export implications that will be duplicated by the callers in downstream
+			// packages, i.e., the implications with param producers or return consumers.
+			impl := ToImplication(primitivizer, trigger, ctrtParamIndex, ctrtRetIndex)
+			implsToExport[funcID] = append(implsToExport[funcID], impl)
+		}
+	}
+	pass.ExportPackageFact(&Cache{ImplicationsToDup: implsToExport})
 }
 
 // duplicateFullTriggersFromContractedFunctionsToCallers duplicates all the full triggers that have
@@ -266,10 +355,11 @@ func run(pass *analysis.Pass) (result interface{}, _ error) {
 // but uses the new producers/consumers instead.
 func duplicateFullTriggersFromContractedFunctionsToCallers(
 	pass *analysis.Pass,
+	primitivizer *Primitivizer,
 	funcContracts functioncontracts.Map,
-	funcTriggers [][]annotation.FullTrigger,
 	funcResults map[*types.Func]*functionResult,
-) {
+	upstreamImplicationsToDup map[string][]*inference.Implication,
+) map[string][]*inference.Implication {
 
 	// Find all the calls to contracted functions
 	// callsByCtrtFunc is a mapping: contracted function -> caller -> all the call expressions
@@ -298,16 +388,45 @@ func duplicateFullTriggersFromContractedFunctionsToCallers(
 
 	// For every contracted function, duplicate some of its full triggers (that involves param or
 	// return) into all the callers
-	dupTriggers := map[*types.Func][]annotation.FullTrigger{}
+	implications := map[string][]*inference.Implication{}
 	for ctrtFunc, calls := range callsByCtrtFunc {
 		r := funcResults[ctrtFunc]
 		if r == nil {
-			// should not happen since funcResults should contain all the functions including any
-			// contracted functions.
-			panic(fmt.Sprintf("Did not find the contracted function %s in funcResults",
-				ctrtFunc.FullName()))
+			// Find in the upstream packages
+			ctrtFuncID := ctrtFunc.FullName()
+			implsToDup := upstreamImplicationsToDup[ctrtFuncID]
+			if implsToDup == nil {
+				// TODO: we do not have the duplicated implications for the contracted function
+				//  because those functions do not have FuncParam producer or UseAsReturn consumer.
+				//  They have some special alternatives like UseAsErrorResult, to which we do not
+				//  add CallSiteRetAnnotationKey yet.
+
+				// This could lead to some false negatives since we duplicated call sites but not
+				// connected them to the sites in contracted functions. However, I think this
+				// should be rare. Anyway we will add the support for all producers/consumers using
+				// ParamAnnotationKey and RetAnnotationKey in the future.
+				continue
+			}
+			ctrts := funcContracts[ctrtFuncID]
+			if ctrts == nil {
+				// should not happen since ctrtFunc is a contracted function
+				panic(fmt.Sprintf(
+					"Did not find the contracted function %s in funcContracts", ctrtFuncID))
+			}
+			for _, impl := range implsToDup {
+				// Duplicate the full trigger in every caller
+				for caller, callExprs := range calls {
+					for _, callExpr := range callExprs {
+						dupImpl := duplicateImplication(pass, primitivizer, impl, ctrtFunc, callExpr)
+						// Store the implication
+						callerID := caller.FullName()
+						implications[callerID] = append(implications[callerID], dupImpl)
+					}
+				}
+			}
+			return implications
 		}
-		ctrts := funcContracts[ctrtFunc]
+		ctrts := funcContracts[ctrtFunc.FullName()]
 		if ctrts == nil {
 			// should not happen since ctrtFunc is a contracted function
 			panic(fmt.Sprintf(
@@ -341,23 +460,83 @@ func duplicateFullTriggersFromContractedFunctionsToCallers(
 				for _, callExpr := range callExprs {
 					dupTrigger := duplicateFullTrigger(trigger, ctrtFunc, callExpr, pass,
 						ctrtParamIndex, isContractedParam, isContractedReturn)
-					// Store the duplicated full trigger
-					dupTriggers[caller] = append(dupTriggers[caller], dupTrigger)
+					// Convert the duplicated full trigger into an implication
+					implication := ToImplication(primitivizer, dupTrigger, ctrtParamIndex, ctrtRetIndex)
+					// Store the implication
+					callerID := caller.FullName()
+					implications[callerID] = append(implications[callerID], implication)
 				}
 			}
 		}
 	}
 
-	// Update funcTriggers with duplicated triggers
-	for funcObj, triggers := range dupTriggers {
-		r := funcResults[funcObj]
-		if r == nil {
-			// should not happen since funcResults should contain all the functions including any
-			// contracted functions.
-			panic(fmt.Sprintf("Did not find the contracted function %s in funcResults", funcObj.Id()))
-		}
-		funcTriggers[r.index] = append(funcTriggers[r.index], triggers...)
+	return implications
+}
+
+func duplicateImplication(
+	pass *analysis.Pass,
+	primitivizer *Primitivizer,
+	impl *inference.Implication,
+	ctrtFunc *types.Func,
+	callExpr *ast.CallExpr,
+) *inference.Implication {
+	dupImpl := &inference.Implication{
+		Producer:         impl.Producer,
+		Consumer:         impl.Consumer,
+		Assertion:        impl.Assertion,
+		Controlled:       false,
+		IsProducerValid:  impl.IsProducerValid,
+		IsConsumerValid:  impl.IsConsumerValid,
+		HasParamProducer: impl.HasParamProducer,
+		HasRetConsumer:   impl.HasRetConsumer,
+		CtrtParamIndex:   impl.CtrtParamIndex,
+		CtrtRetIndex:     impl.CtrtRetIndex,
 	}
+
+	argExpr := callExpr.Args[dupImpl.CtrtParamIndex]
+	argLoc := util.PosToLocation(argExpr.Pos(), pass)
+
+	assertion := dupImpl.Assertion
+	if dupImpl.HasParamProducer {
+		// Convert the producer site originally generated from ParamAnnotationKey to a new producer
+		// site as if from CallSiteParamAnnotationKey.
+		if dupImpl.CtrtParamIndex == -1 {
+			panic("ParamIndex is supposed to be set if HasParamProducer is true!")
+		}
+		callSiteParamKey := annotation.NewCallSiteParamKey(ctrtFunc, dupImpl.CtrtParamIndex, argLoc)
+		// FuncParam.Kind() == conditional so we pass in false
+		dupImpl.Producer = primitivizer.site(callSiteParamKey, false)
+
+		// Change the assertion
+		if prestring, ok := assertion.ProducerRepr.(annotation.FuncParamPrestring); ok {
+			// The Location field is the only difference in the prestring from ParamAnnotationKey
+			// and CallSiteParamAnnotationKey. See function (u FuncParam).Prestring().
+			prestring.Location = argLoc.String()
+		} else {
+			panic(fmt.Sprintf("Expected type %T but got %T", annotation.FuncParamPrestring{}, assertion.ProducerRepr))
+		}
+	}
+	if dupImpl.IsConsumerValid {
+		// Convert the producer site originally generated from ReturnAnnotationKey to a new producer
+		// site as if from CallSiteReturnAnnotationKey.
+		retLoc := util.PosToLocation(callExpr.Pos(), pass)
+		callSiteReturnKey := annotation.NewCallSiteRetKey(ctrtFunc, dupImpl.CtrtRetIndex, retLoc)
+		// UseAsReturn.Kind() == conditional so we pass in false
+		dupImpl.Consumer = primitivizer.site(callSiteReturnKey, false)
+
+		// Set up controller
+		c := annotation.NewCallSiteParamKey(ctrtFunc, dupImpl.CtrtParamIndex, argLoc)
+		dupImpl.Controller = primitivizer.site(c, false)
+		dupImpl.Controlled = true
+
+		// Change the assertion
+		if prestring, ok := assertion.ConsumerRepr.(annotation.UseAsReturnPrestring); ok {
+			// The Location field is the only difference in the prestring from RetAnnotationKey and
+			// CallSiteRetAnnotationKey. See function (u UseAsReturn).Prestring().
+			prestring.Location = retLoc.String()
+		}
+	}
+	return dupImpl
 }
 
 // duplicateFullTrigger creates a (possibly controlled) full trigger from the given full trigger
@@ -451,7 +630,7 @@ func findCallsToContractedFunctions(
 // and the contract is a general nonnil -> nonnil contract, i.e., the contract has only one
 // nonnil in input and only one nonnil in output, and all the other values are any.
 func hasOnlyNonNilToNonNilContract(funcContracts functioncontracts.Map, funcObj *types.Func) bool {
-	contracts, ok := funcContracts[funcObj]
+	contracts, ok := funcContracts[funcObj.FullName()]
 	if !ok || len(contracts) != 1 {
 		return false
 	}
@@ -496,4 +675,239 @@ func analyzeFunc(
 		index:    index,
 		funcDecl: funcDecl,
 	}
+}
+
+// Primitivizer is able to convert full triggers and annotation sites to their primitive forms. It
+// is useful for getting the correct primitive sites and positions for upstream objects due to the
+// lack of complete position information in downstream analysis. For example:
+//
+// upstream/main.go:
+// const GlobalVar *int
+//
+// downstream/main.go:
+// func main() { print(*upstream.GlobalVar) }
+//
+// Here, when analyzing the upstream package we will export a primitive site for `GlobalVar` that
+// encodes the package and site representations, and more importantly, the position information to
+// uniquely identify the site. However, when analyzing the downstream package, the
+// `upstream/main.go` file in the `analysis.Pass.Fset` will not have complete line and column
+// information. Instead, the [importer] injects 65535 fake "lines" into the file, and the object
+// we get for `upstream.GlobalVar` will contain completely different position information due to
+// this hack (in practice, we have observed that the lines for the objects are correct, but not
+// others). This leads to mismatches in our inference engine: we cannot find nilabilities of
+// upstream objects in the imported InferredMap since their Position fields in the primitive sites
+// are different. The Primitivizer here contains logic to fix such discrepancies so that the
+// returned primitive sites for the same objects always contain correct (and same) Position information.
+//
+// [importer]: https://cs.opensource.google/go/x/tools/+/refs/tags/v0.7.0:go/internal/gcimporter/bimport.go;l=375-385;drc=c1dd25e80b559a5b0e8e2dd7d5bd1e946aa996a0;bpv=0;bpt=0
+type Primitivizer struct {
+	pass *analysis.Pass
+	// upstreamObjPositions maps "pkg repr + object path" to the correct position.
+	upstreamObjPositions map[string]token.Position
+	files                map[string]fileInfo
+	// execRoot is the cached bazel sandbox prefix for trimming the filenames.
+	execRoot string
+}
+
+// NewPrimitivizer returns a new Primitivizer.
+func NewPrimitivizer(pass *analysis.Pass) *Primitivizer {
+	// To tackle the position discrepancies for upstream sites, we have added an ObjectPath field,
+	// which can be used to uniquely identify an exported object relative to the package. Then,
+	// we can simply cache the correct position information when importing InferredMaps, since the
+	// positions collected in the upstream analysis are always correct. Later when querying upstream
+	// objects in downstream analysis, we can look up the cache and fill in the correct position in
+	// the returned primitive site instead.
+
+	// Create a cache for upstream object positions.
+	upstreamObjPositions := make(map[string]token.Position)
+	for _, packageFact := range pass.AllPackageFacts() {
+		cache, ok := packageFact.Fact.(*Cache)
+		if !ok {
+			continue
+		}
+		for _, impls := range cache.ImplicationsToDup {
+			for _, impl := range impls {
+				for _, site := range impl.AllSites() {
+					if site.ObjectPath == "" {
+						continue
+					}
+
+					objRepr := site.PkgRepr + "." + string(site.ObjectPath)
+					if existing, ok := upstreamObjPositions[objRepr]; ok && existing != site.Position {
+						/*config.WriteToLog(fmt.Sprintf(
+						"conflicting position information on upstream object %q: existing: %v, got: %v",
+						objRepr, existing, site.Position))*/
+						panic(fmt.Sprintf(
+							"conflicting position information on upstream object %q: existing: %v, got: %v",
+							objRepr, existing, site.Position))
+					}
+					upstreamObjPositions[objRepr] = site.Position
+				}
+			}
+		}
+	}
+
+	// Find the bazel execroot (i.e., random sandbox prefix) for trimming the file names.
+	execRoot, err := os.Getwd()
+	if err != nil {
+		panic("cannot get current working directory")
+	}
+	// config.WriteToLog(fmt.Sprintf("exec root: %q", execRoot))
+
+	// Iterate all files within the Fset (which includes upstream and current package files), and
+	// store the mapping between its file name (modulo the bazel prefix) and the token.File object.
+	files := make(map[string]fileInfo)
+	pass.Fset.Iterate(func(file *token.File) bool {
+		name, err := filepath.Rel(execRoot, file.Name())
+		if err != nil {
+			// For files in standard libraries, there is no bazel sandbox prefix, so we can just
+			// keep the original name.
+			name = file.Name()
+		}
+		files[name] = fileInfo{
+			file:    file,
+			isLocal: strings.HasSuffix(path.Dir(name), pass.Pkg.Path()),
+		}
+		return true
+	})
+
+	return &Primitivizer{
+		pass:                 pass,
+		upstreamObjPositions: upstreamObjPositions,
+		files:                files,
+		execRoot:             execRoot,
+	}
+}
+
+// fullTrigger returns the primitive version of the full trigger.
+func (p *Primitivizer) fullTrigger(trigger annotation.FullTrigger) inference.PrimitiveFullTrigger {
+	// Expr is always nonnil, but our struct init analysis is capped at depth 1 so NilAway does not
+	// know this fact. Here, we explicitly guard against such cases to provide a hint.
+	if trigger.Consumer.Expr == nil {
+		panic(fmt.Sprintf("consume trigger %v has a nil Expr", trigger.Consumer))
+	}
+
+	producer, consumer := trigger.Prestrings(p.pass)
+	return inference.PrimitiveFullTrigger{
+		ProducerRepr: producer,
+		ConsumerRepr: consumer,
+	}
+}
+
+// site returns the primitive version of the annotation site.
+func (p *Primitivizer) site(key annotation.Key, isDeep bool) inference.PrimitiveSite {
+	pkgRepr := ""
+	if pkg := key.Object().Pkg(); pkg != nil {
+		pkgRepr = pkg.Path()
+	}
+
+	objPath, err := objectpath.For(key.Object())
+	if err != nil {
+		// An error will occur when trying to get object path for unexported objects, in which case
+		// we simply assign an empty object path.
+		objPath = ""
+	}
+
+	var position token.Position
+	// For upstream objects, we need to look up the local position cache for correct positions.
+	if key.Object().Pkg() != nil && p.pass.Pkg != key.Object().Pkg() {
+		// Correct upstream information may not always be in the cache: we may not even have it
+		// since we skipped analysis for standard and 3rd party libraries.
+		if p, ok := p.upstreamObjPositions[pkgRepr+"."+string(objPath)]; ok {
+			// config.WriteToLog(fmt.Sprintf("found position cache for %s.%s: %v", pkgRepr, string(objPath), p))
+			position = p
+		} //else {
+		// config.WriteToLog(fmt.Sprintf("did not find position cache for %s.%s", pkgRepr, string(objPath)))
+		//}
+	}
+
+	// Default case (local objects or objects from skipped upstream packages), we can simply use
+	// their Object.Pos() and retrieve the position information. However, we must trim the bazel
+	// sandbox prefix from the filenames for cross-package references.
+	if !position.IsValid() {
+		position = p.pass.Fset.Position(key.Object().Pos())
+		if name, err := filepath.Rel(p.execRoot, position.Filename); err == nil {
+			position.Filename = name
+		}
+	}
+
+	site := inference.PrimitiveSite{
+		PkgRepr:    pkgRepr,
+		Repr:       key.String(),
+		IsDeep:     isDeep,
+		Exported:   key.Object().Exported(),
+		ObjectPath: objPath,
+		Position:   position,
+	}
+
+	//if objPath != "" {
+	// config.WriteToLog(fmt.Sprintf("objpath: %s.%s for site %v", pkgRepr, objPath, site))
+	//}
+
+	return site
+}
+
+// ToImplication converts a FullTrigger to an Implication. The FullTrigger must have a FuncParam
+// Producer and a FuncReturn Consumer.
+func ToImplication(
+	primitivizer *Primitivizer,
+	trigger annotation.FullTrigger,
+	ctrtParamIndex int,
+	ctrtRetIndex int,
+) *inference.Implication {
+	// Expr is always nonnil, but our struct init analysis is capped at depth 1 so NilAway does not
+	// know this fact. Here, we explicitly guard against such cases to provide a hint.
+	if trigger.Consumer.Expr == nil {
+		panic(fmt.Sprintf("consume trigger %v has a nil Expr", trigger.Consumer))
+	}
+
+	var controller, producerSite, consumerSite inference.PrimitiveSite
+	validProducer, validConsumer, paramProducer, returnConsumer := false, false, false, false
+	if trigger.Controlled() {
+		// trigger.Controller is of *CallSiteParamAnnotationKey type, which is enclosed in either
+		// ArgPass or FuncParam, both with Kind() == Conditional. Thus, we can safely use false
+		// here.
+		controller = primitivizer.site(trigger.Controller, false)
+	}
+	prod, cons := trigger.Producer.Annotation, trigger.Consumer.Annotation
+	pKind, cKind := prod.Kind(), cons.Kind()
+	pSite, cSite := prod.UnderlyingSite(), cons.UnderlyingSite()
+	if pKind == annotation.Conditional || pKind == annotation.DeepConditional {
+		validProducer = true
+		if pSite == nil {
+			panic("trigger is conditional but the underlying site is nil")
+		}
+		producerSite = primitivizer.site(pSite, pKind == annotation.DeepConditional)
+		_, paramProducer = prod.(annotation.FuncParam)
+	}
+	if cKind == annotation.Conditional || cKind == annotation.DeepConditional {
+		validConsumer = true
+		if cSite == nil {
+			panic("trigger is conditional but the underlying site is nil")
+		}
+		consumerSite = primitivizer.site(cSite, cKind == annotation.DeepConditional)
+		_, returnConsumer = cons.(annotation.UseAsReturn)
+	}
+	// At least one if branches above should have been executed, in other words, validProducer ||
+	// validConsumer should be always true. This is because either producer is a FuncParam, or
+	// consumer is a UseAsReturn, or both hold. See
+	// assertion.function.duplicateFullTriggersFromContractedFunctionsToCallers for why.
+	return &inference.Implication{
+		Producer:         producerSite,
+		Consumer:         consumerSite,
+		Assertion:        primitivizer.fullTrigger(trigger),
+		Controller:       controller,
+		Controlled:       trigger.Controlled(),
+		IsProducerValid:  validProducer,
+		IsConsumerValid:  validConsumer,
+		HasParamProducer: paramProducer,
+		HasRetConsumer:   returnConsumer,
+		CtrtParamIndex:   ctrtParamIndex,
+		CtrtRetIndex:     ctrtRetIndex,
+	}
+}
+
+type fileInfo struct {
+	file    *token.File
+	isLocal bool
 }

--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -59,7 +59,7 @@ func (r *RootAssertionNode) LocationOf(expr ast.Expr) token.Position {
 // one nonnil in input and only one nonnil in output and all the other values are any, e.g.,
 // contract(_,nonnil->nonnil,_) is OK, but contract(nonnil,nonnil->nonnil,_) is not.
 func (r *RootAssertionNode) getSingleNonnilToNonnilContract(funcObj *types.Func) *functioncontracts.FunctionContract {
-	ctrts := r.functionContext.funcContracts[funcObj]
+	ctrts := r.functionContext.funcContracts[funcObj.FullName()]
 	if ctrts == nil || len(ctrts) != 1 || !ctrts[0].IsGeneralNonnnilToNonnil() {
 		return nil
 	}

--- a/assertion/function/functioncontracts/analyzer_test.go
+++ b/assertion/function/functioncontracts/analyzer_test.go
@@ -40,27 +40,30 @@ func TestParse(t *testing.T) {
 
 	require.NotNil(t, funcContractsMap)
 
-	actualNameToContracts := map[*types.Func][]*FunctionContract{}
-	for funcObj, contracts := range funcContractsMap {
-		actualNameToContracts[funcObj] = contracts
+	actualNameToContracts := map[string][]*FunctionContract{}
+	for funcID, contracts := range funcContractsMap {
+		actualNameToContracts[funcID] = contracts
 	}
 
-	expectedNameToContracts := map[*types.Func][]*FunctionContract{
-		getFuncObj(pass, "f1"): {
+	expectedNameToContracts := map[string][]*FunctionContract{
+		getFuncID(pass, "f1"): {
 			&FunctionContract{Ins: []ContractVal{NonNil}, Outs: []ContractVal{NonNil}},
 		},
-		getFuncObj(pass, "f2"): {
+		getFuncID(pass, "f2"): {
 			&FunctionContract{Ins: []ContractVal{NonNil}, Outs: []ContractVal{True}},
 		},
-		getFuncObj(pass, "f3"): {
+		getFuncID(pass, "f3"): {
 			&FunctionContract{Ins: []ContractVal{NonNil}, Outs: []ContractVal{False}},
 		},
-		getFuncObj(pass, "multipleValues"): {
+		getFuncID(pass, "multipleValues"): {
 			&FunctionContract{Ins: []ContractVal{Any, NonNil}, Outs: []ContractVal{NonNil, True}},
 		},
-		getFuncObj(pass, "multipleContracts"): {
+		getFuncID(pass, "multipleContracts"): {
 			&FunctionContract{Ins: []ContractVal{Any, NonNil}, Outs: []ContractVal{NonNil, True}},
 			&FunctionContract{Ins: []ContractVal{NonNil, Any}, Outs: []ContractVal{NonNil, True}},
+		},
+		getFuncID(pass, "ExportedFromParse"): {
+			&FunctionContract{Ins: []ContractVal{NonNil}, Outs: []ContractVal{NonNil}},
 		},
 		// function contractCommentInOtherLine should not exist in the map as it has no contract.
 	}
@@ -83,57 +86,63 @@ func TestInfer(t *testing.T) {
 
 	require.NotNil(t, funcContractsMap)
 
-	actualNameToContracts := map[*types.Func][]*FunctionContract{}
+	actualNameToContracts := map[string][]*FunctionContract{}
 	for funcObj, contracts := range funcContractsMap {
 		actualNameToContracts[funcObj] = contracts
 	}
 
-	expectedNameToContracts := map[*types.Func][]*FunctionContract{
-		getFuncObj(pass, "onlyLocalVar"): {
+	expectedNameToContracts := map[string][]*FunctionContract{
+		getFuncID(pass, "onlyLocalVar"): {
 			&FunctionContract{Ins: []ContractVal{NonNil}, Outs: []ContractVal{NonNil}},
 		},
-		getFuncObj(pass, "unknownCondition"): {
+		getFuncID(pass, "unknownCondition"): {
 			&FunctionContract{Ins: []ContractVal{NonNil}, Outs: []ContractVal{NonNil}},
 		},
-		getFuncObj(pass, "noLocalVar"): {
+		getFuncID(pass, "noLocalVar"): {
 			&FunctionContract{Ins: []ContractVal{NonNil}, Outs: []ContractVal{NonNil}},
 		},
-		getFuncObj(pass, "learnUnderlyingFromOuterMakeInterface"): {
+		getFuncID(pass, "learnUnderlyingFromOuterMakeInterface"): {
 			&FunctionContract{Ins: []ContractVal{NonNil}, Outs: []ContractVal{NonNil}},
 		},
-		getFuncObj(pass, "twoCondsMerge"): {
+		getFuncID(pass, "ExportedFromInfer"): {
 			&FunctionContract{Ins: []ContractVal{NonNil}, Outs: []ContractVal{NonNil}},
 		},
-		getFuncObj(pass, "unknownToUnknownButSameValue"): {
+		getFuncID(pass, "twoCondsMerge"): {
 			&FunctionContract{Ins: []ContractVal{NonNil}, Outs: []ContractVal{NonNil}},
 		},
-		getFuncObj(pass, "nonnilAnyToNonnilAny"): {
+		getFuncID(pass, "unknownToUnknownButSameValue"): {
+			&FunctionContract{Ins: []ContractVal{NonNil}, Outs: []ContractVal{NonNil}},
+		},
+		getFuncID(pass, "nonnilAnyToNonnilAny"): {
 			&FunctionContract{Ins: []ContractVal{NonNil, Any}, Outs: []ContractVal{NonNil, Any}},
 		},
-		getFuncObj(pass, "nonnilAnyToAnyNonnil"): {
+		getFuncID(pass, "nonnilAnyToAnyNonnil"): {
 			&FunctionContract{Ins: []ContractVal{NonNil, Any}, Outs: []ContractVal{Any, NonNil}},
 		},
-		getFuncObj(pass, "anyNonnilToNonnilAny"): {
+		getFuncID(pass, "anyNonnilToNonnilAny"): {
 			&FunctionContract{Ins: []ContractVal{Any, NonNil}, Outs: []ContractVal{NonNil, Any}},
 		},
-		getFuncObj(pass, "anyNonnilToAnyNonnil"): {
+		getFuncID(pass, "anyNonnilToAnyNonnil"): {
 			&FunctionContract{Ins: []ContractVal{Any, NonNil}, Outs: []ContractVal{Any, NonNil}},
 		},
-		getFuncObj(pass, "anyNonnilAnyToAnyAnyNonnilAny"): {
+		getFuncID(pass, "anyNonnilAnyToAnyAnyNonnilAny"): {
 			&FunctionContract{Ins: []ContractVal{Any, NonNil, Any}, Outs: []ContractVal{Any, Any, NonNil, Any}},
 		},
-		getFuncObj(pass, "mixType"): {
+		getFuncID(pass, "mixType"): {
 			&FunctionContract{Ins: []ContractVal{Any, NonNil}, Outs: []ContractVal{Any, NonNil}},
+		},
+		getFuncID(pass, "ExportedFromInfer"): {
+			&FunctionContract{Ins: []ContractVal{NonNil}, Outs: []ContractVal{NonNil}},
 		},
 		// other functions should not exist in the map as the contract nonnil->nonnil does not hold
 		// for them.
 
 		// TODO: uncomment this when we support field access when inferring contracts.
-		//getFuncObj(pass, "field"): {
+		//getFuncID(pass, "field"): {
 		//	&FunctionContract{Ins: []ContractVal{NonNil}, Outs: []ContractVal{NonNil}},
 		//},
 		// TODO: uncomment this when we support nonempty slice to nonnil.
-		//getFuncObj(pass, "nonEmptySliceToNonnil"): {
+		//getFuncID(pass, "nonEmptySliceToNonnil"): {
 		//	&FunctionContract{Ins: []ContractVal{NonNil}, Outs: []ContractVal{NonNil}},
 		//},
 	}
@@ -142,6 +151,47 @@ func TestInfer(t *testing.T) {
 	}
 }
 
-func getFuncObj(pass *analysis.Pass, name string) *types.Func {
-	return pass.Pkg.Scope().Lookup(name).(*types.Func)
+func TestUpstream(t *testing.T) {
+	t.Parallel()
+
+	testdata := analysistest.TestData()
+	r := analysistest.Run(t, testdata, Analyzer, "go.uber.org/functioncontracts")
+	require.Equal(t, 1, len(r))
+	require.NotNil(t, r[0])
+
+	pass, result := r[0].Pass, r[0].Result
+	require.IsType(t, Result{}, result)
+	funcContractsMap := result.(Result).FunctionContracts
+
+	require.NotNil(t, funcContractsMap)
+
+	actualNameToContracts := map[string][]*FunctionContract{}
+	for funcObj, contracts := range funcContractsMap {
+		actualNameToContracts[funcObj] = contracts
+	}
+
+	expectedNameToContracts := map[string][]*FunctionContract{
+		getFuncID(pass, "ExportedFromParse"): {
+			&FunctionContract{Ins: []ContractVal{NonNil}, Outs: []ContractVal{NonNil}},
+		},
+		getFuncID(pass, "ExportedFromInfer"): {
+			&FunctionContract{Ins: []ContractVal{NonNil}, Outs: []ContractVal{NonNil}},
+		},
+	}
+	if diff := cmp.Diff(expectedNameToContracts, actualNameToContracts); diff != "" {
+		require.Fail(t, fmt.Sprintf("inferred contracts mismatch (-want +got):\n%s", diff))
+	}
+}
+
+func getFuncID(pass *analysis.Pass, name string) string {
+	obj := pass.Pkg.Scope().Lookup(name)
+	if obj == nil {
+		for _, iPkg := range pass.Pkg.Imports() {
+			obj = iPkg.Scope().Lookup(name)
+			if obj != nil {
+				break
+			}
+		}
+	}
+	return obj.(*types.Func).FullName()
 }

--- a/assertion/function/functioncontracts/function_contracts_map.go
+++ b/assertion/function/functioncontracts/function_contracts_map.go
@@ -14,10 +14,6 @@
 
 package functioncontracts
 
-import (
-	"go/types"
-)
-
 // ContractVal represents the possible value appearing in a function contract.
 type ContractVal string
 
@@ -57,8 +53,8 @@ type FunctionContract struct {
 	Outs []ContractVal
 }
 
-// Map stores the mappings from *types.Func to associated function contracts.
-type Map map[*types.Func][]*FunctionContract
+// Map stores the mappings from *types.Func.FullName() string to associated function contracts.
+type Map map[string][]*FunctionContract
 
 // newNonnilToNonnilContract creates a function contract that has only one NonNil value at the
 // given index p for input and r for output.

--- a/assertion/function/functioncontracts/testdata/src/go.uber.org/functioncontracts/infer/main.go
+++ b/assertion/function/functioncontracts/testdata/src/go.uber.org/functioncontracts/infer/main.go
@@ -1,3 +1,5 @@
+// want package:".*"
+
 //  Copyright (c) 2023 Uber Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -369,4 +371,11 @@ func mixType(x int, y *int) (int, *int) {
 		return 0, new(int)
 	}
 	return x, y
+}
+
+func ExportedFromInfer(x *int) *int {
+	if x != nil {
+		return new(int)
+	}
+	return nil
 }

--- a/assertion/function/functioncontracts/testdata/src/go.uber.org/functioncontracts/main.go
+++ b/assertion/function/functioncontracts/testdata/src/go.uber.org/functioncontracts/main.go
@@ -1,0 +1,15 @@
+/*
+Test functionality of collecting function contracts from upstream packages.
+*/
+
+package functioncontracts
+
+import (
+	"go.uber.org/functioncontracts/infer"
+	"go.uber.org/functioncontracts/parse"
+)
+
+func use() {
+	_ = parse.ExportedFromParse(nil)
+	_ = infer.ExportedFromInfer(nil)
+}

--- a/assertion/function/functioncontracts/testdata/src/go.uber.org/functioncontracts/parse/main.go
+++ b/assertion/function/functioncontracts/testdata/src/go.uber.org/functioncontracts/parse/main.go
@@ -1,3 +1,5 @@
+// want package:".*"
+
 //  Copyright (c) 2023 Uber Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -65,3 +67,11 @@ func multipleContracts(x *int, y *int) (*int, bool) {
 // function has no param or return. Only a contract in its own line should be parsed, not even `//
 // contract(nonnil -> nonnil)`.
 func contractCommentInOtherLine() {}
+
+// contract(nonnil -> nonnil)
+func ExportedFromParse(x *int) *int {
+	if x != nil {
+		return new(int)
+	}
+	return nil
+}

--- a/inference/conflict.go
+++ b/inference/conflict.go
@@ -85,15 +85,17 @@ type conflict interface {
 // `nil` and the same field `f` of `T` passed to a deeper field access without nil check in a
 // different source file.
 type singleAssertionConflict struct {
-	trigger         primitiveFullTrigger
+	pos             token.Pos
+	trigger         PrimitiveFullTrigger
 	originalTrigger annotation.FullTrigger
 }
 
 // newSingleAssertionConflict constructs and returns a singleAssertionConflict.
-func newSingleAssertionConflict(pass *analysis.Pass, trigger annotation.FullTrigger) *singleAssertionConflict {
+func newSingleAssertionConflict(pos token.Pos, trigger PrimitiveFullTrigger, origTrigger annotation.FullTrigger) *singleAssertionConflict {
 	return &singleAssertionConflict{
-		trigger:         fullTriggerAsPrimitive(pass, trigger),
-		originalTrigger: trigger,
+		pos:             pos,
+		trigger:         trigger,
+		originalTrigger: origTrigger,
 	}
 }
 
@@ -104,7 +106,7 @@ func (t *singleAssertionConflict) getSiteMessage() string {
 
 // getPosition returns the source code position of the conflict.
 func (t *singleAssertionConflict) getPosition() token.Pos {
-	return t.trigger.Pos
+	return t.pos
 }
 
 // getProducerMessage returns the error message to be reported for the producer part of the conflict.
@@ -126,14 +128,16 @@ func (t *singleAssertionConflict) key() groupKey {
 // chains of assertions to be both nilable (true) and nonnil (false). It encodes the overconstrained
 // site, and the reason that the site had to be true and had to be false, as ExplainedBools.
 type overconstrainedConflict struct {
-	site             primitiveSite
+	pos              token.Pos
+	site             PrimitiveSite
 	trueExplanation  ExplainedBool
 	falseExplanation ExplainedBool
 }
 
 // newOverconstrainedConflict  constructs and returns an overconstrainedConflict.
-func newOverconstrainedConflict(site primitiveSite, trueExplanation, falseExplanation ExplainedBool) *overconstrainedConflict {
+func newOverconstrainedConflict(pos token.Pos, site PrimitiveSite, trueExplanation, falseExplanation ExplainedBool) *overconstrainedConflict {
 	return &overconstrainedConflict{
+		pos:              pos,
 		site:             site,
 		trueExplanation:  trueExplanation,
 		falseExplanation: falseExplanation,
@@ -147,7 +151,7 @@ func (t *overconstrainedConflict) getSiteMessage() string {
 
 // getPosition returns the source code position of the conflict.
 func (t *overconstrainedConflict) getPosition() token.Pos {
-	return t.site.Pos
+	return t.pos
 }
 
 // getProducerMessage returns the error message to be reported for the producer part of the conflict.

--- a/inference/explained_bool.go
+++ b/inference/explained_bool.go
@@ -55,7 +55,7 @@ func (ExplainedFalse) Val() bool {
 // truth.
 type TrueBecauseShallowConstraint struct {
 	ExplainedTrue
-	ExternalAssertion primitiveFullTrigger
+	ExternalAssertion PrimitiveFullTrigger
 }
 
 func (t TrueBecauseShallowConstraint) String() string {
@@ -72,7 +72,7 @@ func (t TrueBecauseShallowConstraint) String() string {
 // falsehood.
 type FalseBecauseShallowConstraint struct {
 	ExplainedFalse
-	ExternalAssertion primitiveFullTrigger
+	ExternalAssertion PrimitiveFullTrigger
 }
 
 func (f FalseBecauseShallowConstraint) String() string {
@@ -87,7 +87,7 @@ func (f FalseBecauseShallowConstraint) String() string {
 // `TrueBecauseAnnotation`, `TrueBecauseShallowConstraint`, or another `TrueBecauseDeepConstraint`.
 type TrueBecauseDeepConstraint struct {
 	ExplainedTrue
-	InternalAssertion primitiveFullTrigger
+	InternalAssertion PrimitiveFullTrigger
 	DeeperExplanation ExplainedBool
 }
 
@@ -103,7 +103,7 @@ func (t TrueBecauseDeepConstraint) String() string {
 // `FalseBecauseAnnotation`, `FalseBecauseShallowConstraint`, or another `FalseBecauseDeepConstraint`.
 type FalseBecauseDeepConstraint struct {
 	ExplainedFalse
-	InternalAssertion primitiveFullTrigger
+	InternalAssertion PrimitiveFullTrigger
 	DeeperExplanation ExplainedBool
 }
 

--- a/inference/primitive.go
+++ b/inference/primitive.go
@@ -15,13 +15,19 @@
 package inference
 
 import (
+	"fmt"
 	"go/token"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
 
 	"go.uber.org/nilaway/annotation"
 	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/types/objectpath"
 )
 
-// A primitiveFullTrigger is a reduced version of an annotation.FullTrigger that can embedded into an
+// A PrimitiveFullTrigger is a reduced version of an annotation.FullTrigger that can embedded into an
 // InferredMap for importation/exportation via the Facts mechanism. This reduction step must
 // be performed because FullTriggers themselves contain `types.Object`s, which have no exported fields
 // and thus cannot be present in Facts-communicated data structures. PrimitiveFullTriggers encode
@@ -32,73 +38,251 @@ import (
 // minimal information that will vary between string representations meant to be passed with the
 // static type information necessary to format that minimal information into a full string
 // representation without needing to encode it all when using Gob encodings through the Facts mechanism
-type primitiveFullTrigger struct {
+type PrimitiveFullTrigger struct {
 	ProducerRepr annotation.Prestring
 	ConsumerRepr annotation.Prestring
 	Pos          token.Pos
 }
 
-func fullTriggerAsPrimitive(pass *analysis.Pass, trigger annotation.FullTrigger) primitiveFullTrigger {
-	producer, consumer := trigger.Prestrings(pass)
-	return primitiveFullTrigger{
-		ProducerRepr: producer,
-		ConsumerRepr: consumer,
-		Pos:          trigger.Consumer.Expr.Pos(),
-	}
-}
-
-// A primitiveSite represents an atomic choice that may be made about annotations. It is
-// more specific than a Key only in factoring out information such as depth (deep annotation
-// or not that would make the choice anything other than a boolean).
-//
-// Triggers created by the assertions analyzer can either be reduced to a primitiveSite,
-// or they are a PrimitiveAlways or a PrimitiveNever
+// A PrimitiveSite represents an atomic choice that may be made about annotations. It is
+// more specific than an annotation.Key only in factoring out information such as depth (deep
+// annotation or not that would make the choice anything other than a boolean).
 //
 // Equality on these structs is vital to correctness as they form the keys in the implication graphs
-// shared by inference (InferredAnnotationMaps). In particular, if the encoding through
-// newPrimitiveSite below is not injective, then learned facts about different annotation sites
-// will overwrite each other. Injectivity is currently guaranteed through the combination of `Pos` -
-// an integer offset within the file set analyzed, and `PkgStringRepr` - a string representation of
-// the package this site was found in.
+// shared by inference (InferredMap). In particular, if the encoding through PrimitiveSite below is
+// not injective, then learned facts about different annotation sites will overwrite each other.
 //
-// Further, the mapping from AnnotationKeys to PrimitiveAnnotationSites must be deterministic - or it
+// Further, the mapping from annotation.Key to PrimitiveSite must be deterministic - or it
 // is possible that information about a site will be missed because it is stored under a different
 // encoding.
 //
 // Finally, it is essential that the information contained in these objects is minimal - as they are
 // encoded into `Fact`s so frequently that artifact sizes would explode if these got too large.
 // This means no extensive string representations, and no deep structs.
-type primitiveSite struct {
-	StringRepr    string
-	IsDeep        bool
-	Pos           token.Pos
-	PkgStringRepr string
-	Exported      bool
+type PrimitiveSite struct {
+	// PkgRepr is the string representation of the package this site resides in.
+	PkgRepr string
+	// Repr is the string representation of the site itself.
+	Repr string
+	// IsDeep is used to differentiate shallow and deep nilabilities of the same sites.
+	IsDeep bool
+	// Position stores the complete position information (filename, offset, line, column) of the
+	// site. It is essential in maintaining the injectivities of the sites since Repr only encodes
+	// minimal information for error printing purposes. For example, the first return value of two
+	// same-name methods for different structs could end up having the same Repr (e.g.,
+	// "Result 0 of function foo"). Any random prefixes added by the build system (e.g., bazel
+	// sandbox prefix) must be trimmed for cross-package reference.
+	Position token.Position
+	// Exported indicates whether this site is exported in the package or not.
+	Exported bool
+	// ObjectPath is an opaque name that identifies a types.Object relative to its package (see
+	// objectpath.Path for more details). This is essential in order to match upstream objects in
+	// downstream analysis. The position information of upstream objects is incomplete due to the
+	// way the nogo driver loads packages. As a result, the Position in this struct could differ in
+	// downstream analysis, even when referring to the same upstream object. ObjectPath here is
+	// useful in correctly matching the upstream objects, and subsequently fixing the Position in
+	// the Primitivizer. Note that ObjectPath only exists for exported objects; otherwise it will
+	// be empty ("").
+	ObjectPath objectpath.Path
 }
 
-// newPrimitiveSite encodes a passed Key as a primitiveSite, needing a boolean `isDeep` to complete
-// the translation.
-// As discussed above for `primitiveSite`, it is vital that this function is injective,
-// deterministic, and produces minimized output. Multi Package inference relies on all of these
-// properties.
-func newPrimitiveSite(key annotation.Key, isDeep bool) primitiveSite {
-	pkgStringRepr := ""
-	if pkg := key.Object().Pkg(); pkg != nil {
-		pkgStringRepr = pkg.Path()
-	}
-	return primitiveSite{
-		StringRepr:    key.String(),
-		IsDeep:        isDeep,
-		Pos:           key.Object().Pos(),
-		PkgStringRepr: pkgStringRepr,
-		Exported:      key.Object().Exported(),
-	}
-}
-
-func (s primitiveSite) String() string {
+// String returns the string representation of the primitive site for debugging purposes _only_.
+func (s *PrimitiveSite) String() string {
 	deepStr := ""
 	if s.IsDeep {
 		deepStr = "Deep "
 	}
-	return deepStr + s.StringRepr
+	return deepStr + s.Repr
+}
+
+type fileInfo struct {
+	file    *token.File
+	isLocal bool
+}
+
+// Primitivizer is able to convert full triggers and annotation sites to their primitive forms. It
+// is useful for getting the correct primitive sites and positions for upstream objects due to the
+// lack of complete position information in downstream analysis. For example:
+//
+// upstream/main.go:
+// const GlobalVar *int
+//
+// downstream/main.go:
+// func main() { print(*upstream.GlobalVar) }
+//
+// Here, when analyzing the upstream package we will export a primitive site for `GlobalVar` that
+// encodes the package and site representations, and more importantly, the position information to
+// uniquely identify the site. However, when analyzing the downstream package, the
+// `upstream/main.go` file in the `analysis.Pass.Fset` will not have complete line and column
+// information. Instead, the [importer] injects 65535 fake "lines" into the file, and the object
+// we get for `upstream.GlobalVar` will contain completely different position information due to
+// this hack (in practice, we have observed that the lines for the objects are correct, but not
+// others). This leads to mismatches in our inference engine: we cannot find nilabilities of
+// upstream objects in the imported InferredMap since their Position fields in the primitive sites
+// are different. The Primitivizer here contains logic to fix such discrepancies so that the
+// returned primitive sites for the same objects always contain correct (and same) Position information.
+//
+// [importer]: https://cs.opensource.google/go/x/tools/+/refs/tags/v0.7.0:go/internal/gcimporter/bimport.go;l=375-385;drc=c1dd25e80b559a5b0e8e2dd7d5bd1e946aa996a0;bpv=0;bpt=0
+type Primitivizer struct {
+	pass *analysis.Pass
+	// upstreamObjPositions maps "pkg repr + object path" to the correct position.
+	upstreamObjPositions map[string]token.Position
+	files                map[string]fileInfo
+	// execRoot is the cached bazel sandbox prefix for trimming the filenames.
+	execRoot string
+}
+
+// NewPrimitivizer returns a new Primitivizer.
+func NewPrimitivizer(pass *analysis.Pass) *Primitivizer {
+	// To tackle the position discrepancies for upstream sites, we have added an ObjectPath field,
+	// which can be used to uniquely identify an exported object relative to the package. Then,
+	// we can simply cache the correct position information when importing InferredMaps, since the
+	// positions collected in the upstream analysis are always correct. Later when querying upstream
+	// objects in downstream analysis, we can look up the cache and fill in the correct position in
+	// the returned primitive site instead.
+
+	// Create a cache for upstream object positions.
+	upstreamObjPositions := make(map[string]token.Position)
+	for _, packageFact := range pass.AllPackageFacts() {
+		importedMap, ok := packageFact.Fact.(*InferredMap)
+		if !ok {
+			continue
+		}
+		importedMap.Range(func(site PrimitiveSite, _ InferredVal) bool {
+			if site.ObjectPath == "" {
+				return true
+			}
+
+			objRepr := site.PkgRepr + "." + string(site.ObjectPath)
+			if existing, ok := upstreamObjPositions[objRepr]; ok && existing != site.Position {
+				/*config.WriteToLog(fmt.Sprintf(
+				"conflicting position information on upstream object %q: existing: %v, got: %v",
+				objRepr, existing, site.Position))*/
+				panic(fmt.Sprintf(
+					"conflicting position information on upstream object %q: existing: %v, got: %v",
+					objRepr, existing, site.Position))
+			}
+			upstreamObjPositions[objRepr] = site.Position
+			return true
+		})
+	}
+
+	// Find the bazel execroot (i.e., random sandbox prefix) for trimming the file names.
+	execRoot, err := os.Getwd()
+	if err != nil {
+		panic("cannot get current working directory")
+	}
+	// config.WriteToLog(fmt.Sprintf("exec root: %q", execRoot))
+
+	// Iterate all files within the Fset (which includes upstream and current package files), and
+	// store the mapping between its file name (modulo the bazel prefix) and the token.File object.
+	files := make(map[string]fileInfo)
+	pass.Fset.Iterate(func(file *token.File) bool {
+		name, err := filepath.Rel(execRoot, file.Name())
+		if err != nil {
+			// For files in standard libraries, there is no bazel sandbox prefix, so we can just
+			// keep the original name.
+			name = file.Name()
+		}
+		files[name] = fileInfo{
+			file:    file,
+			isLocal: strings.HasSuffix(path.Dir(name), pass.Pkg.Path()),
+		}
+		return true
+	})
+
+	return &Primitivizer{
+		pass:                 pass,
+		upstreamObjPositions: upstreamObjPositions,
+		files:                files,
+		execRoot:             execRoot,
+	}
+}
+
+// fullTrigger returns the primitive version of the full trigger.
+func (p *Primitivizer) fullTrigger(trigger annotation.FullTrigger) PrimitiveFullTrigger {
+	// Expr is always nonnil, but our struct init analysis is capped at depth 1 so NilAway does not
+	// know this fact. Here, we explicitly guard against such cases to provide a hint.
+	if trigger.Consumer.Expr == nil {
+		panic(fmt.Sprintf("consume trigger %v has a nil Expr", trigger.Consumer))
+	}
+
+	producer, consumer := trigger.Prestrings(p.pass)
+	return PrimitiveFullTrigger{
+		ProducerRepr: producer,
+		ConsumerRepr: consumer,
+	}
+}
+
+// site returns the primitive version of the annotation site.
+func (p *Primitivizer) site(key annotation.Key, isDeep bool) PrimitiveSite {
+	pkgRepr := ""
+	if pkg := key.Object().Pkg(); pkg != nil {
+		pkgRepr = pkg.Path()
+	}
+
+	objPath, err := objectpath.For(key.Object())
+	if err != nil {
+		// An error will occur when trying to get object path for unexported objects, in which case
+		// we simply assign an empty object path.
+		objPath = ""
+	}
+
+	var position token.Position
+	// For upstream objects, we need to look up the local position cache for correct positions.
+	if key.Object().Pkg() != nil && p.pass.Pkg != key.Object().Pkg() {
+		// Correct upstream information may not always be in the cache: we may not even have it
+		// since we skipped analysis for standard and 3rd party libraries.
+		if p, ok := p.upstreamObjPositions[pkgRepr+"."+string(objPath)]; ok {
+			// config.WriteToLog(fmt.Sprintf("found position cache for %s.%s: %v", pkgRepr, string(objPath), p))
+			position = p
+		} //else {
+		// config.WriteToLog(fmt.Sprintf("did not find position cache for %s.%s", pkgRepr, string(objPath)))
+		//}
+	}
+
+	// Default case (local objects or objects from skipped upstream packages), we can simply use
+	// their Object.Pos() and retrieve the position information. However, we must trim the bazel
+	// sandbox prefix from the filenames for cross-package references.
+	if !position.IsValid() {
+		position = p.pass.Fset.Position(key.Object().Pos())
+		if name, err := filepath.Rel(p.execRoot, position.Filename); err == nil {
+			position.Filename = name
+		}
+	}
+
+	site := PrimitiveSite{
+		PkgRepr:    pkgRepr,
+		Repr:       key.String(),
+		IsDeep:     isDeep,
+		Exported:   key.Object().Exported(),
+		ObjectPath: objPath,
+		Position:   position,
+	}
+
+	//if objPath != "" {
+	// config.WriteToLog(fmt.Sprintf("objpath: %s.%s for site %v", pkgRepr, objPath, site))
+	//}
+
+	return site
+}
+
+// sitePos takes the primitive site (with accurate position information) and converts it to a
+// token.Pos that is relative to local Fset for reporting purposes.
+func (p *Primitivizer) sitePos(site PrimitiveSite) token.Pos {
+	// Retrieve the file from cache.
+	info, ok := p.files[site.Position.Filename]
+	if !ok {
+		panic(fmt.Sprintf("file does not exist in downstream analysis: %q", site.Position.Filename))
+	}
+
+	// For local files, we can accurate restore the token.Pos.
+	if info.isLocal {
+		return info.file.Pos(site.Position.Offset)
+	}
+
+	// However, files in upstream packages are conceptually 65535 * '\n' (see docs on Primitivizer
+	// for more details), therefore, we can only restore a local token.Pos that accurately tracks
+	// the line, but not the column.
+	return info.file.LineStart(site.Position.Line)
 }


### PR DESCRIPTION
Code changes of this PR includes the general changes that support cross-package for NilAway. However, that part is not migrated to GitHub yet so I can only rebase onto [zzq/function-contracts/general-nonnil](https://github.com/uber-go/nilaway/tree/zzq/function-contracts/general-nonnil). Ideally we should have another PR for the general changes to support cross-package between and rebase this PR to the PR.

What was done:
1. Pass around function contracts analyzed across packages.
2. Stop modifying the full triggers passed into inference engine; instead of having a new type Implication (which is exportable as package facts) to carry information from a FullTrigger and then adapt the engine to digest this new type.
3. Export and import contracts for full triggers of contracted functions across packages, in the form of implications.

Future work:
The current implementation does not work sometimes, because it creates a primitivizer in function analyzer but the position information this primitivizer obtains will be conflicting with those obtained from the primitivizer in accumulation analyzer.

Function analyzer cannot get the column number for every object from upstream, because unlike InferredMap exported in accumuulation analyzer, the Implication exported in function analyzer does not contain every exported object in upstream (We store only duplicable implications there)

Thus, a entirely new implementation is needed. We have to move all the logic of duplicating full triggers from function analyzer to accumalation analyzer (i.e., inference phase), so we maintain only one primitivizer and the position information (column number) of upstream objects can be obtained from upstream packages correctly.

PS:
Did not find integration tests here so I did not migrate integration cross-packge tests but they can be found in the internal version of this pull request.