### PR TITLE
Support for handling interface fields in affiliations analysis

### DIFF
--- a/assertion/affiliation/affiliation.go
+++ b/assertion/affiliation/affiliation.go
@@ -181,14 +181,14 @@ func (a *Affiliation) computeTriggersForCastingSites(pass *analysis.Pass, upstre
 					switch nodeType := node.Type.(type) {
 					case *ast.ArrayType:
 						// A slice (or array) declared of type interface, and initialized with a struct
-						// e.g., var i I = []I{&S{}}
+						// e.g., _ = []I{&S{}}
 						lhsType := util.TypeOf(pass, nodeType.Elt)
 						for _, elt := range node.Elts {
 							appendTypeToTypeTriggers(lhsType, util.TypeOf(pass, elt))
 						}
 					case *ast.MapType:
 						// Key, value, or both of a map declared of type interface, and initialized with a struct
-						// e.g., var i I = map[int]I{0: &S{}}
+						// e.g., _ = map[int]I{0: &S{}}
 						keyType := util.TypeOf(pass, nodeType.Key)
 						valueType := util.TypeOf(pass, nodeType.Value)
 						for _, elt := range node.Elts {
@@ -205,11 +205,11 @@ func (a *Affiliation) computeTriggersForCastingSites(pass *analysis.Pass, upstre
 						for i, elt := range node.Elts {
 							var lhsType, rhsType types.Type
 							if kv, ok := elt.(*ast.KeyValueExpr); ok {
-								// In this case the initialization is key-value based. E.g. a = &A{f: &B{}}
+								// In this case the initialization is key-value based. E.g. s = &S{t: &T{}}
 								lhsType = util.TypeOf(pass, kv.Key)
 								rhsType = util.TypeOf(pass, kv.Value)
 							} else {
-								// In this case the initialization is serial. E.g. a = &A{&B{}}
+								// In this case the initialization is serial. E.g. s = &S{&T{}}
 								if sObj := util.TypeAsDeeplyStruct(util.TypeOf(pass, node)); sObj != nil {
 									lhsType = sObj.Field(i).Type()
 									rhsType = util.TypeOf(pass, elt)

--- a/assertion/affiliation/affiliation.go
+++ b/assertion/affiliation/affiliation.go
@@ -63,7 +63,7 @@ func (a *Affiliation) extractAffiliations(pass *analysis.Pass) {
 
 	// populate upstreamCache by importing entries passed from upstream packages
 	facts := pass.AllPackageFacts()
-	if facts != nil && len(facts) > 0 {
+	if len(facts) > 0 {
 		for _, f := range facts {
 			switch c := f.Fact.(type) {
 			case *AffliliationCache:

--- a/assertion/affiliation/affiliation.go
+++ b/assertion/affiliation/affiliation.go
@@ -63,7 +63,7 @@ func (a *Affiliation) extractAffiliations(pass *analysis.Pass) {
 
 	// populate upstreamCache by importing entries passed from upstream packages
 	facts := pass.AllPackageFacts()
-	if len(facts) > 0 {
+	if facts != nil && len(facts) > 0 {
 		for _, f := range facts {
 			switch c := f.Fact.(type) {
 			case *AffliliationCache:
@@ -178,48 +178,51 @@ func (a *Affiliation) computeTriggersForCastingSites(pass *analysis.Pass, upstre
 					}
 
 				case *ast.CompositeLit:
-					nodeType := util.TypeOf(pass, node.Type)
-
-					// If the composite is initializing a map, then check for possible pseudo-assignments
-					// for keys and values. For instance, if the type of value of the map is an interface
-					// but a struct is added to the map.
-					if mpType, ok := nodeType.(*types.Map); ok {
-						elemType := mpType.Elem()
-						keyType := mpType.Key()
-						// Iterate through each element in the composite
+					switch nodeType := node.Type.(type) {
+					case *ast.ArrayType:
+						// A slice (or array) declared of type interface, and initialized with a struct
+						// e.g., var i I = []I{&S{}}
+						lhsType := util.TypeOf(pass, nodeType.Elt)
 						for _, elt := range node.Elts {
-							// This should be true as we have already checked that the composite is for a map
+							appendTypeToTypeTriggers(lhsType, util.TypeOf(pass, elt))
+						}
+					case *ast.MapType:
+						// Key, value, or both of a map declared of type interface, and initialized with a struct
+						// e.g., var i I = map[int]I{0: &S{}}
+						keyType := util.TypeOf(pass, nodeType.Key)
+						valueType := util.TypeOf(pass, nodeType.Value)
+						for _, elt := range node.Elts {
 							if kv, ok := elt.(*ast.KeyValueExpr); ok {
-								appendTypeToTypeTriggers(elemType, util.TypeOf(pass, kv.Value))
 								appendTypeToTypeTriggers(keyType, util.TypeOf(pass, kv.Key))
+								appendTypeToTypeTriggers(valueType, util.TypeOf(pass, kv.Value))
 							}
 						}
-					}
-
-					// If the composite is used for initializing an array or a slice, then check for possible
-					// pseudo-assignments through the initialized values of the elements in arrays/slice
-					var elemType types.Type
-
-					if slcType, ok := nodeType.(*types.Slice); ok {
-						elemType = slcType.Elem()
-					}
-
-					if arrType, ok := nodeType.(*types.Array); ok {
-						elemType = arrType.Elem()
-					}
-
-					if elemType != nil {
-						// Iterate through each element in the composite
-						for _, elt := range node.Elts {
-							// This should be true as we have already checked that the composite is for an array/slice
-							if un, ok := elt.(*ast.UnaryExpr); ok {
-								appendTypeToTypeTriggers(elemType, util.TypeOf(pass, un))
+					case *ast.Ident:
+						// A struct field (embedded or explicit) declared of type interface, and initialized with a struct
+						// e.g., var i I = S{t:&T{}}, where `type S struct { t J }`. (Here I and J are interfaces,
+						// and S and T are structs implementing them, respectively.)
+						// Similarly, embedding is also supported. E.g., var i I = &S{&T{}}, where `type S struct { J }`.
+						for i, elt := range node.Elts {
+							var lhsType, rhsType types.Type
+							if kv, ok := elt.(*ast.KeyValueExpr); ok {
+								// In this case the initialization is key-value based. E.g. a = &A{f: &B{}}
+								lhsType = util.TypeOf(pass, kv.Key)
+								rhsType = util.TypeOf(pass, kv.Value)
+							} else {
+								// In this case the initialization is serial. E.g. a = &A{&B{}}
+								if sObj := util.TypeAsDeeplyStruct(util.TypeOf(pass, node)); sObj != nil {
+									lhsType = sObj.Field(i).Type()
+									rhsType = util.TypeOf(pass, elt)
+								}
+							}
+							if lhsType != nil && rhsType != nil {
+								appendTypeToTypeTriggers(lhsType, rhsType)
 							}
 						}
 					}
 				case *ast.FuncLit:
 					// TODO: Nilability analysis support for anonymous functions is currently not
-					//       implemented (tracked in , so here we completely skip
+					//       implemented (tracked in PROGSYS-559), so here we completely skip
 					//       the affiliation analysis for them.
 					return false
 				}
@@ -240,7 +243,7 @@ func (a *Affiliation) computeTriggersForTypes(lhsType types.Type, rhsType types.
 		return nil
 	}
 	rhsObj, ok := util.UnwrapPtr(rhsType).(*types.Named)
-	if !ok || rhsObj.NumMethods() <= 0 {
+	if !ok {
 		return nil
 	}
 
@@ -257,18 +260,15 @@ func (a *Affiliation) computeTriggersForTypes(lhsType types.Type, rhsType types.
 	currentCache[key] = true
 
 	var triggers []annotation.FullTrigger
-	declaredMethods := a.getDeclaredMethods(lhsObj)
-	implementedMethods := a.getImplementedMethods(rhsObj)
-	for _, dm := range declaredMethods {
-		for _, im := range implementedMethods {
-			// early return if the interface and its implementation is out of scope
-			if (dm.Pkg() != nil && !a.conf.IsPkgInScope(dm.Pkg())) && (im.Pkg() != nil && !a.conf.IsPkgInScope(im.Pkg())) {
-				return triggers
-			}
-
-			if dm.Name() == im.Name() {
-				triggers = append(triggers, a.createFunctionTriggers(im, dm)...)
-			}
+	// for each method declared in the interface, find its corresponding concrete implementation
+	for i := 0; i < lhsObj.NumMethods(); i++ {
+		interfaceMethod := lhsObj.Method(i)
+		implementedMethodObj, _, _ := types.LookupFieldOrMethod(rhsType, false, rhsObj.Obj().Pkg(), interfaceMethod.Name())
+		if implementedMethodObj == nil || !a.conf.IsPkgInScope(interfaceMethod.Pkg()) || !a.conf.IsPkgInScope(implementedMethodObj.Pkg()) {
+			continue
+		}
+		if implementedMethod, ok := implementedMethodObj.(*types.Func); ok {
+			triggers = append(triggers, createFunctionTriggers(implementedMethod, interfaceMethod)...)
 		}
 	}
 	return triggers
@@ -307,27 +307,9 @@ func computeAfflitiationCacheKey(interfaceObj *types.Interface, concreteObj *typ
 	}
 }
 
-// getDeclaredMethods returns all the methods declared by the interface "t"
-func (*Affiliation) getDeclaredMethods(t *types.Interface) []*types.Func {
-	methods := make([]*types.Func, 0)
-	for i := 0; i < t.NumMethods(); i++ {
-		methods = append(methods, t.Method(i))
-	}
-	return methods
-}
-
-// getImplementedMethods returns all the methods implemented by the struct "t"
-func (*Affiliation) getImplementedMethods(t *types.Named) []*types.Func {
-	methods := make([]*types.Func, 0)
-	for i := 0; i < t.NumMethods(); i++ {
-		methods = append(methods, t.Method(i))
-	}
-	return methods
-}
-
 // createFunctionTriggers verifies the nilability annotations of the concrete implementation of a method
 // against its interface declaration for covariant return types and contravariant parameter types
-func (*Affiliation) createFunctionTriggers(implementingMethod *types.Func, interfaceMethod *types.Func) []annotation.FullTrigger {
+func createFunctionTriggers(implementingMethod *types.Func, interfaceMethod *types.Func) []annotation.FullTrigger {
 	triggers := make([]annotation.FullTrigger, 0)
 
 	methodSig := implementingMethod.Type().(*types.Signature)

--- a/assertion/affiliation/affiliation.go
+++ b/assertion/affiliation/affiliation.go
@@ -182,6 +182,8 @@ func (a *Affiliation) computeTriggersForCastingSites(pass *analysis.Pass, upstre
 					case *ast.ArrayType:
 						// A slice (or array) declared of type interface, and initialized with a struct
 						// e.g., _ = []I{&S{}}
+						// TODO: currently, nested composite literal for ArrayType is not supported (e.g., _ = [][]I{{&A1{}}}).
+						//  Tracked in issue #46.
 						lhsType := util.TypeOf(pass, nodeType.Elt)
 						for _, elt := range node.Elts {
 							appendTypeToTypeTriggers(lhsType, util.TypeOf(pass, elt))
@@ -222,7 +224,7 @@ func (a *Affiliation) computeTriggersForCastingSites(pass *analysis.Pass, upstre
 					}
 				case *ast.FuncLit:
 					// TODO: Nilability analysis support for anonymous functions is currently not
-					//       implemented (tracked in PROGSYS-559), so here we completely skip
+					//       implemented (tracked in issue #52), so here we completely skip
 					//       the affiliation analysis for them.
 					return false
 				}

--- a/assertion/function/assertiontree/assertion_node.go
+++ b/assertion/function/assertiontree/assertion_node.go
@@ -93,7 +93,7 @@ func (n *assertionNodeCommon) SetConsumeTriggers(triggers []*annotation.ConsumeT
 
 // nilable(node, result 0)
 func (n *assertionNodeCommon) Root() *RootAssertionNode {
-	if n == nil {
+	if n == nil || n.parent == nil {
 		return nil
 	}
 	return n.parent.Root()

--- a/assertion/function/assertiontree/assertion_node.go
+++ b/assertion/function/assertiontree/assertion_node.go
@@ -31,7 +31,6 @@ type AssertionNode interface {
 	Children() []AssertionNode
 	ConsumeTriggers() []*annotation.ConsumeTrigger
 
-	// nilable(param 0)
 	SetParent(AssertionNode)
 	SetChildren([]AssertionNode)
 	SetConsumeTriggers([]*annotation.ConsumeTrigger)
@@ -91,7 +90,6 @@ func (n *assertionNodeCommon) SetConsumeTriggers(triggers []*annotation.ConsumeT
 	n.consumeTriggers = triggers
 }
 
-// nilable(node, result 0)
 func (n *assertionNodeCommon) Root() *RootAssertionNode {
 	if n == nil || n.parent == nil {
 		return nil

--- a/assertion/function/assertiontree/backprop_util.go
+++ b/assertion/function/assertiontree/backprop_util.go
@@ -719,7 +719,7 @@ func exprAsDeepProducer(rootNode *RootAssertionNode, expr ast.Expr) annotation.P
 	if len(parsedExpr) > 1 {
 		panic("multiply returning function passed where a deep producer is expected - tuple types are not deep")
 	}
-	if len(parsedExpr) == 0 || !parsedExpr[0].IsDeep() {
+	if len(parsedExpr) == 0 || !parsedExpr[0].IsDeep() || parsedExpr[0].GetDeep() == nil {
 		// the expr is not deeply nilable
 		return annotation.ProduceTriggerNever{}
 	}

--- a/assertion/function/assertiontree/util.go
+++ b/assertion/function/assertiontree/util.go
@@ -61,6 +61,10 @@ func RootNodeSlicesString(name string, rootNodes []*RootAssertionNode) string {
 // this combines each of the special-cased deep nilability introspectors to give a method that
 // determines a deep nilability trigger for an arbitrary assertion node
 func deepNilabilityTriggerOf(node AssertionNode) annotation.ProducingAnnotationTrigger {
+	if node == nil {
+		panic("deepNilabilityTriggerOf should not be called on nil node")
+	}
+
 	switch node := node.(type) {
 	case *varAssertionNode:
 		if node.Root() == nil {
@@ -109,6 +113,9 @@ func (t TrackableExpr) MinimalString() string {
 }
 
 func detachFromParent(node AssertionNode, whichChild int) {
+	if node.Parent() == nil {
+		panic("passed assertion node has no parent - cannot detach")
+	}
 	if len(node.Parent().Children()) <= whichChild {
 		panic(fmt.Sprintf("passed assertion node only has %d children - "+
 			"cannot remove child %d", len(node.Parent().Children()), whichChild))

--- a/nilaway_test.go
+++ b/nilaway_test.go
@@ -171,7 +171,7 @@ func TestMethodImplementation(t *testing.T) {
 	t.Parallel()
 
 	testdata := analysistest.TestData()
-	analysistest.Run(t, testdata, Analyzer, "go.uber.org/methodimplementation", "go.uber.org/methodimplementation/mergedDependencies", "go.uber.org/methodimplementation/chainedDependencies", "go.uber.org/methodimplementation/multipackage")
+	analysistest.Run(t, testdata, Analyzer, "go.uber.org/methodimplementation", "go.uber.org/methodimplementation/mergedDependencies", "go.uber.org/methodimplementation/chainedDependencies", "go.uber.org/methodimplementation/multipackage", "go.uber.org/methodimplementation/embedding")
 
 }
 

--- a/testdata/src/go.uber.org/methodimplementation/embedding/embedding.go
+++ b/testdata/src/go.uber.org/methodimplementation/embedding/embedding.go
@@ -1,0 +1,306 @@
+/*
+This is a test for checking nilability-type variance for struct embedding (i.e., embedded and anonymous fields).
+
+<nilaway no inference>
+*/
+package embedding
+
+type I interface {
+	// nilable(x)
+	foo(x *int) *int
+}
+
+// below test checks struct embedding at depth 1 (T embeds S)
+type A1 struct{}
+
+func (A1) foo(x *int) *int { //want "nilable value could be passed as param"
+	return x
+}
+
+type B1 struct {
+	A1
+}
+
+func testEmbeddingDepth1() *int {
+	var i I
+	i = B1{}
+	return i.foo(nil) // (error reported at A1.foo() definition)
+}
+
+// below test checks struct embedding at arbitrary depth (e.g., depth = 5, A2 embeds B2 embeds C2 embeds D2 embeds E2)
+type A2 struct {
+	B2
+}
+
+type B2 struct {
+	C2
+}
+
+type C2 struct {
+	D2
+}
+
+type D2 struct {
+	E2
+}
+
+type E2 struct {
+	f *int
+}
+
+func (e *E2) foo(x *int) *int { //want "nilable value could be passed as param"
+	if e.f != nil {
+		return e.f
+	}
+	return x
+}
+
+func testEmbeddingDepth5() {
+	var i I = &A2{}
+	_ = i.foo(nil) // (error reported at E2.foo() definition)
+}
+
+// below test checks overriding of struct methods. A3 implements I.foo() violating the contravariance property of parameters.
+// Now B3 embeds A3 and overrides the implementation of foo() by making it contravariance safe. Now instantiating I with B3
+// should not report an error, while instantiating I with A3 should report an error as demonstrated below.
+type A3 struct {
+	f *int
+}
+
+func (A3) foo(x *int) *int { //want "nilable value could be passed as param"
+	return x
+}
+
+type B3 struct {
+	A3
+}
+
+// nilable(x)
+func (B3) foo(x *int) *int {
+	if x == nil {
+		z := 0
+		return &z
+	}
+	return x
+}
+
+func testOverridding() {
+	var i1 I = &B3{}
+	i1.foo(nil) // safe, since B3.foo() accepts a nilable parameter
+
+	var i2 I = &A3{}
+	i2.foo(nil) // (error reported at A3.foo() definition)
+}
+
+// below test checks anonymous fields in structs
+type A4 struct{}
+
+func (A4) foo(x *int) *int {
+	return x
+}
+
+type B4 struct {
+	f int
+	A4
+}
+
+// nilable(x)
+func (b *B4) foo(x *int) *int {
+	if x == nil {
+		return &b.f
+	}
+	return x
+}
+
+func testAnonymousFields(cond bool) *int {
+	b := B4{}
+	if cond {
+		return b.A4.foo(nil) //want "nilable value passed as arg"
+	}
+	return b.foo(nil) // safe, since B4.foo() accepts a nilable parameter
+}
+
+// below test checks embedding of multiple structs
+type A5 struct {
+	B5
+	C5
+}
+
+type B5 struct{}
+
+func (B5) foo(x *int) *int {
+	return x
+}
+
+type C5 struct{}
+
+func (C5) foo(x *int) *int {
+	return x
+}
+
+func testEmbeddingMultipleStructs() {
+	a := &A5{}
+	_ = a.B5.foo(nil) //want "nilable value passed as arg"
+	_ = a.C5.foo(nil) //want "nilable value passed as arg"
+}
+
+// below test checks for recursive embedding of structs
+type A6 struct{}
+
+func (A6) foo(x *int) *int { //want "nilable value could be passed as param"
+	return x
+}
+
+type B6 struct {
+	A6
+	*B6
+}
+
+func testRecursion() *int {
+	var i I
+	i = B6{}
+	return i.foo(nil) // (error reported at A6.foo() definition)
+}
+
+// below test checks embedding of multiple interfaces within a struct, and embedding of interfaces within an interface
+type J interface {
+	bar() *int //want "nilable value could be returned" "nilable value could be returned"
+}
+
+type A9 struct {
+	I
+	J
+}
+
+type B9 struct{}
+
+func (B9) foo(x *int) *int { //want "nilable value could be passed as param"
+	return x
+}
+
+type C9 struct{}
+
+// nilable(result 0)
+func (*C9) bar() *int {
+	return nil
+}
+
+func testMultipleEmbeddedInterfaces() {
+	a9 := &A9{I: &B9{}, J: &C9{}}
+	_ = a9.foo(nil) // (error reported at B9.foo() definition)
+	_ = a9.bar()    // (error reported at J.bar() declaration)
+}
+
+type IandJ interface {
+	I
+	J
+}
+
+type A7 struct{}
+
+func (*A7) foo(x *int) *int { //want "nilable value could be passed as param"
+	return x
+}
+
+// nilable(result 0)
+func (*A7) bar() *int {
+	return nil
+}
+
+func testEmbeddingInterfaceInInterface() {
+	var i IandJ = &A7{}
+	_ = i.foo(nil) // (error reported at A7.foo() definition)
+	_ = i.bar()    // (error reported at J.bar() declaration)
+}
+
+// below test checks embedding of interface within a struct
+type A8 struct{}
+
+func (*A8) foo(x *int) *int { //want "nilable value could be passed as param"
+	return x
+}
+
+// B8 embeds I, but does not itself implement I.foo()
+type B8 struct {
+	I
+}
+
+// C8 embeds I, and implements I.foo()
+type C8 struct {
+	I
+}
+
+func (*C8) foo(x *int) *int { //want "nilable value could be passed as param"
+	return x
+}
+
+// D8 declares I as field g, but does not itself implement I.foo()
+type D8 struct {
+	g I
+}
+
+type E8 struct{}
+
+func (*E8) foo(x *int) *int { //want "nilable value could be passed as param"
+	return x
+}
+
+func testEmbeddingInterfaceInStruct(x int) *int {
+	switch x {
+	case 1:
+		// TODO: currently such "empty" implementations (meaning B8 does not actually implement the methods of I, but is
+		//  still considered to implement I since it embeds I) are not analyzed.
+		var i1 I = &B8{}
+		return i1.foo(nil)
+	case 2:
+		var i2 I = &B8{&A8{}}
+		return i2.foo(nil) // (error reported at A8.foo() definition)
+	case 3:
+		var i3 I = &C8{}
+		return i3.foo(nil) // (error reported at C8.foo() definition)
+	case 4:
+		d8 := &D8{g: &E8{}}
+		return d8.g.foo(nil) // (error reported at E8.foo() definition)
+	}
+	return &x
+}
+
+// below test checks a non-trivial case simulated from https://github.com/golang/go/pull/60823
+type Conn interface {
+	RemoteAddr() Addr //want "nilable value could be returned"
+}
+
+type Addr interface {
+	String() string
+}
+
+type httpConn struct {
+	rwc Conn
+}
+
+func (c *httpConn) serve() {
+	_ = c.rwc.RemoteAddr().String()
+}
+
+type netConn struct{}
+
+// nilable(result 0)
+func (c *netConn) RemoteAddr() Addr {
+	if true {
+		return nil
+	}
+	return &addrImpl{}
+}
+
+type addrImpl struct{}
+
+func (a *addrImpl) String() string {
+	return ""
+}
+
+func main() {
+	c := &httpConn{
+		rwc: &netConn{},
+	}
+	c.serve()
+}

--- a/testdata/src/go.uber.org/methodimplementation/embedding/embedding.go
+++ b/testdata/src/go.uber.org/methodimplementation/embedding/embedding.go
@@ -266,6 +266,30 @@ func testEmbeddingInterfaceInStruct(x int) *int {
 	return &x
 }
 
+// below test checks nested structs
+type A10 struct {
+	I
+}
+
+type B10 struct {
+	I
+}
+
+type C10 struct {
+	D10
+}
+
+type D10 struct{}
+
+func (*D10) foo(x *int) *int { //want "nilable value could be passed as param"
+	return x
+}
+
+func testNestedStructs() {
+	a := &A10{&B10{&C10{D10: D10{}}}}
+	_ = a.foo(nil) // (error reported at D10.foo() definition)
+}
+
 // below test checks a non-trivial case simulated from https://github.com/golang/go/pull/60823
 type Conn interface {
 	RemoteAddr() Addr //want "nilable value could be returned"

--- a/testdata/src/go.uber.org/methodimplementation/embedding/embedding.go
+++ b/testdata/src/go.uber.org/methodimplementation/embedding/embedding.go
@@ -1,5 +1,6 @@
 /*
-This is a test for checking nilability-type variance for struct embedding (i.e., embedded and anonymous fields).
+This is a test for checking affiliations anlysis for struct fields (embedded or explicit) declared as interfaces,
+and instantiated with structs that implement the interface.
 
 <nilaway no inference>
 */


### PR DESCRIPTION
This PR adds support for tracking an interface field of a struct as an affiliation site. The interface field could be embedded or declared as a normal field.

[closes #43 #44 ]