### PR TITLE
Fix multi-package inference algorithm which incorrectly uses token.Pos for injectivity

### DIFF
--- a/accumulation/analyzer.go
+++ b/accumulation/analyzer.go
@@ -135,14 +135,13 @@ func run(pass *analysis.Pass) (result interface{}, _ error) {
 		// determining local and upstream sites in the process. This is guaranteed not to determine any
 		// sites unless we really have a reason they have to be determined.
 		inferenceEngine.ObservePackage(assertionsResult.FullTriggers)
-		inferredMap = inferenceEngine.InferredMap()
-		diagnostics = diagnosticEngine.Diagnostics(true /* grouping */)
+		inferredMap, diagnostics = inferenceEngine.InferredMap(), diagnosticEngine.Diagnostics(true /* grouping */)
 
 	case inference.NoInfer:
 		// In non-inference case - use the classical assertionNode.CheckErrors method to determine error outputs
 		inferredMap = inferenceEngine.InferredMap()
 		checkErrors(assertionsResult.FullTriggers, inferredMap, diagnosticEngine)
-		// Retrieve the diagnostics from the engine. Note that we should not group the
+		// Retrieve the diagnostics from the engine. Note that we do not need to group the
 		// diagnostics for easier unit testing.
 		diagnostics = diagnosticEngine.Diagnostics(false /* grouping */)
 

--- a/accumulation/analyzer.go
+++ b/accumulation/analyzer.go
@@ -135,13 +135,14 @@ func run(pass *analysis.Pass) (result interface{}, _ error) {
 		// determining local and upstream sites in the process. This is guaranteed not to determine any
 		// sites unless we really have a reason they have to be determined.
 		inferenceEngine.ObservePackage(assertionsResult.FullTriggers)
-		inferredMap, diagnostics = inferenceEngine.InferredMap(), diagnosticEngine.Diagnostics(true /* grouping */)
+		inferredMap = inferenceEngine.InferredMap()
+		diagnostics = diagnosticEngine.Diagnostics(true /* grouping */)
 
 	case inference.NoInfer:
 		// In non-inference case - use the classical assertionNode.CheckErrors method to determine error outputs
 		inferredMap = inferenceEngine.InferredMap()
 		checkErrors(assertionsResult.FullTriggers, inferredMap, diagnosticEngine)
-		// Retrieve the diagnostics from the engine. Note that we do not need to group the
+		// Retrieve the diagnostics from the engine. Note that we should not group the
 		// diagnostics for easier unit testing.
 		diagnostics = diagnosticEngine.Diagnostics(false /* grouping */)
 

--- a/diagnostic/engine.go
+++ b/diagnostic/engine.go
@@ -18,9 +18,9 @@
 package diagnostic
 
 import (
+	"fmt"
 	"go/token"
 	"os"
-	"fmt"
 	"path/filepath"
 
 	"go.uber.org/nilaway/annotation"

--- a/diagnostic/engine.go
+++ b/diagnostic/engine.go
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package diagnostic hosts the diagnostic engine, which is responsible for collecting the
+// conflicts from annotation-based checks (no-infer mode) and/or inference (full-infer mode) and
+// generating user-friendly diagnostics from those conflicts.
 package diagnostic
 
 import (

--- a/diagnostic/engine.go
+++ b/diagnostic/engine.go
@@ -46,7 +46,7 @@ func (e *Engine) Diagnostics(grouping bool) []analysis.Diagnostic {
 	}
 
 	// build diagnostics from conflicts
-	var diagnostics []analysis.Diagnostic
+	diagnostics := make([]analysis.Diagnostic, 0, len(conflicts))
 	for _, c := range conflicts {
 		diagnostics = append(diagnostics, analysis.Diagnostic{
 			Pos:     c.pos,

--- a/diagnostic/engine.go
+++ b/diagnostic/engine.go
@@ -18,21 +18,79 @@
 package diagnostic
 
 import (
+	"go/token"
+	"os"
+	"fmt"
+	"path/filepath"
+
 	"go.uber.org/nilaway/annotation"
 	"go.uber.org/nilaway/inference"
 	"go.uber.org/nilaway/util"
 	"golang.org/x/tools/go/analysis"
 )
 
+// fileInfo bundles the token.File object and auxiliary information about it, e.g., whether it is
+// a fake file (i.e., imported from archive), for uses in primitivizer.
+type fileInfo struct {
+	file   *token.File
+	isFake bool
+}
+
 // Engine is the main engine for generating diagnostics from conflicts.
 type Engine struct {
 	pass      *analysis.Pass
 	conflicts []conflict
+	// files maps the file name (modulo the possible build-system prefix) to the token.File object
+	// for faster lookup when converting correct upstream position back to local token.Pos for
+	// reporting purposes.
+	files map[string]fileInfo
 }
 
 // NewEngine creates a new diagnostic engine.
 func NewEngine(pass *analysis.Pass) *Engine {
-	return &Engine{pass: pass}
+	// Find the current working directory (e.g., random sandbox prefix) for trimming the file names.
+	cwd, err := os.Getwd()
+	if err != nil {
+		panic(fmt.Sprintf("cannot get current working directory: %v", err))
+	}
+
+	// Iterate all files within the Fset (which includes upstream and current-package files), and
+	// store the mapping between its file name (modulo the possible build-system prefix) and the
+	// token.File object. This is needed for converting correct upstream position back to local
+	// incorrect token.Pos for error reporting purposes.
+	files := make(map[string]fileInfo)
+	pass.Fset.Iterate(func(file *token.File) bool {
+		name, err := filepath.Rel(cwd, file.Name())
+		if err != nil {
+			// For files that are not in the execroot (e.g., stdlib files start with "$GOROOT", and
+			// upstream files that do not have the build-system prefix), we can simply use the
+			// original file name.
+			name = file.Name()
+		}
+
+		// The file will be fake (conceptually "\n" * 65535) if it is imported from archive. So we
+		// check if there are any gaps between the line starts to determine if the file is fake.
+		// TODO: Go 1.21 introduced a new "token.File.Lines()" API to directly get the underlying
+		//  lines slice, which should allow faster checks since calling "token.File.LineStart"
+		//  repeatedly is slow due to locks/unlocks.
+		isFake := true
+		var prev token.Pos
+		for i := 1; i <= file.LineCount(); i++ {
+			p := file.LineStart(i)
+			if prev.IsValid() && p-prev > 1 {
+				isFake = false
+				break
+			}
+			prev = p
+		}
+		files[name] = fileInfo{
+			file:   file,
+			isFake: isFake,
+		}
+		return true
+	})
+
+	return &Engine{pass: pass, files: files}
 }
 
 // Diagnostics generates diagnostics from the internally-stored conflicts. The grouping parameter
@@ -70,7 +128,7 @@ func (e *Engine) AddSingleAssertionConflict(trigger annotation.FullTrigger) {
 
 // AddOverconstraintConflict adds a new overconstraint conflict to the engine.
 func (e *Engine) AddOverconstraintConflict(nilReason, nonnilReason inference.ExplainedBool) {
-	c := conflict{}
+	flow := nilFlow{}
 
 	// Build nil path by traversing the inference graph from `nilReason` part of the overconstraint failure.
 	// (Note that this traversal gives us a backward path from point of conflict to the source of nilability. Hence, we
@@ -81,11 +139,11 @@ func (e *Engine) AddOverconstraintConflict(nilReason, nonnilReason inference.Exp
 		// 1. No annotation present (i.e., full inference): we have producer and consumer explanations available; use them directly
 		// 2: Annotation present (i.e., no inference): we construct the reason from the annotation string
 		if producer != nil && consumer != nil {
-			c.flow.addNilPathNode(producer, consumer)
+			flow.addNilPathNode(producer, consumer)
 		} else {
-			c.flow.addNilPathNode(annotation.LocatedPrestring{
+			flow.addNilPathNode(annotation.LocatedPrestring{
 				Contained: r,
-				Location:  util.TruncatePosition(e.pass.Fset.Position(r.Pos())),
+				Location:  util.TruncatePosition(r.Position()),
 			}, nil)
 		}
 	}
@@ -96,22 +154,80 @@ func (e *Engine) AddOverconstraintConflict(nilReason, nonnilReason inference.Exp
 	// Different from building the nil path above, here we also want to deduce the position where the error should be reported,
 	// i.e., the point of dereference where the nil panic would occur. In NilAway's context this is the last node
 	// in the non-nil path. Therefore, we keep updating `c.pos` until we reach the end of the non-nil path.
+	var reportPosition token.Position
 	for r := nonnilReason; r != nil; r = r.DeeperReason() {
 		producer, consumer := r.TriggerReprs()
+		position := r.Position()
 		// Similar to above, we have two cases here:
 		// 1. No annotation present (i.e., full inference): we have producer and consumer explanations available; use them directly
 		// 2: Annotation present (i.e., no inference): we construct the reason from the annotation string
 		if producer != nil && consumer != nil {
-			c.flow.addNonNilPathNode(producer, consumer)
-			c.pos = r.Pos()
+			flow.addNonNilPathNode(producer, consumer)
+			reportPosition = position
 		} else {
-			c.flow.addNonNilPathNode(annotation.LocatedPrestring{
+			flow.addNonNilPathNode(annotation.LocatedPrestring{
 				Contained: r,
-				Location:  util.TruncatePosition(e.pass.Fset.Position(r.Pos())),
+				Location:  util.TruncatePosition(r.Position()),
 			}, nil)
-			c.pos = r.Pos()
+			reportPosition = position
 		}
 	}
 
-	e.conflicts = append(e.conflicts, c)
+	e.conflicts = append(e.conflicts, conflict{
+		pos:  e.toPos(reportPosition),
+		flow: flow,
+	})
+}
+
+// _fakeFileMaxLines is the maximum number of lines that the archive importer will add to a (fake)
+// file when it imports a package. See [the importer code] for more details. We use this to create
+// more fake files when necessary (see [primitivizer.sitePos]).
+// [the importer code]: https://cs.opensource.google/go/x/tools/+/master:internal/gcimporter/bimport.go;l=34;bpv=0;bpt=1
+const _fakeFileMaxLines = 64 * 1024
+
+// toPos converts the token.Position back to a token.Pos that is relative to local Fset for
+// reporting purposes _only_. Note that the input position could be obtained from facts or
+// inference, so the position might not exist in the local Fset. In such cases, we pad the local
+// Fset for correct reporting.
+func (e *Engine) toPos(position token.Position) token.Pos {
+	info, ok := e.files[position.Filename]
+	if !ok {
+		// For incremental build systems like bazel, the pass.Fset contains only the files in
+		// current and _directly_ imported packages (see [gcexportdata] for more details). However,
+		// analyzer facts are imported transitively from all imported packages, and NilAway is able
+		// to operate across all those packages. As a result, if NilAway ever needs to report an
+		// error on a file from a transitively imported package, we need to create a fake file in
+		// the file set.
+		// [gcexportdata]: https://pkg.go.dev/golang.org/x/tools/go/gcexportdata
+		file := e.pass.Fset.AddFile(position.Filename, e.pass.Fset.Base(), _fakeFileMaxLines)
+		// Set up fake lines for the fake file.
+		fakeLines := make([]int, position.Line)
+		for i := range fakeLines {
+			fakeLines[i] = i
+		}
+		file.SetLines(fakeLines)
+		info = fileInfo{file: file, isFake: true}
+		e.files[position.Filename] = info
+	}
+
+	if info.isFake {
+		// If the file is fake (imported from archive), it may not contain fake lines for unexported
+		// objects (as an "optimization", see [importer code]). However, NilAway may report errors
+		// on unexported objects due to multi-package inference. In such cases, we pad the file with
+		// more fake lines.
+		// [importer code]: https://cs.opensource.google/go/x/tools/+/refs/tags/v0.12.0:internal/gcimporter/bimport.go;l=36-69;drc=ad74ff6345e3663a8f1a4ba5c6e85d54a6fd5615
+		if position.Line > info.file.LineCount() {
+			// We are adding offsets to fake lines here, and offset == fake line number - 1. So we
+			// can start from the current max line number to the desired line number - 1.
+			for i := info.file.LineCount(); i < position.Line; i++ {
+				info.file.AddLine(i)
+			}
+		}
+
+		// For fake files, we can only report accurate line number but not column number.
+		return info.file.LineStart(position.Line)
+	}
+
+	// For non-fake files, the position is accurate.
+	return info.file.Pos(position.Offset)
 }

--- a/diagnostic/engine.go
+++ b/diagnostic/engine.go
@@ -48,7 +48,8 @@ type Engine struct {
 
 // NewEngine creates a new diagnostic engine.
 func NewEngine(pass *analysis.Pass) *Engine {
-	// Find the current working directory (e.g., random sandbox prefix) for trimming the file names.
+	// Find the current working directory (e.g., random sandbox prefix if using bazel) for trimming
+	// the file names.
 	cwd, err := os.Getwd()
 	if err != nil {
 		panic(fmt.Sprintf("cannot get current working directory: %v", err))
@@ -57,7 +58,8 @@ func NewEngine(pass *analysis.Pass) *Engine {
 	// Iterate all files within the Fset (which includes upstream and current-package files), and
 	// store the mapping between its file name (modulo the possible build-system prefix) and the
 	// token.File object. This is needed for converting correct upstream position back to local
-	// incorrect token.Pos for error reporting purposes.
+	// incorrect token.Pos for error reporting purposes. Also see
+	// [inference.primitivizer.toPosition] for more detailed explanations.
 	files := make(map[string]fileInfo)
 	pass.Fset.Iterate(func(file *token.File) bool {
 		name, err := filepath.Rel(cwd, file.Name())

--- a/diagnostic/engine.go
+++ b/diagnostic/engine.go
@@ -18,10 +18,6 @@
 package diagnostic
 
 import (
-	"fmt"
-	"go/token"
-	"strings"
-
 	"go.uber.org/nilaway/annotation"
 	"go.uber.org/nilaway/inference"
 	"go.uber.org/nilaway/util"
@@ -40,7 +36,8 @@ func NewEngine(pass *analysis.Pass) *Engine {
 }
 
 // Diagnostics generates diagnostics from the internally-stored conflicts. The grouping parameter
-// controls whether the conflicts with the same nil path are grouped together for concise reporting.
+// controls whether the conflicts with the same nil flow -- the part in the complete nil flow going
+// from a nilable source point to the conflict point -- are grouped together for concise reporting.
 func (e *Engine) Diagnostics(grouping bool) []analysis.Diagnostic {
 	conflicts := e.conflicts
 	if grouping {
@@ -117,167 +114,4 @@ func (e *Engine) AddOverconstraintConflict(nilReason, nonnilReason inference.Exp
 	}
 
 	e.conflicts = append(e.conflicts, c)
-}
-
-type conflict struct {
-	pos              token.Pos   // stores position where the error should be reported (note that this field is used only within the current, and should NOT be exported)
-	flow             nilFlow     // stores nil flow from source to dereference point
-	similarConflicts []*conflict // stores other conflicts that are similar to this one
-}
-
-type nilFlow struct {
-	nilPath    []node // stores nil path of the flow from nilable source to conflict point
-	nonnilPath []node // stores non-nil path of the flow from conflict point to dereference point
-}
-
-type node struct {
-	producerPosition token.Position
-	consumerPosition token.Position
-	producerRepr     string
-	consumerRepr     string
-}
-
-// newNode creates a new node object from the given producer and consumer Prestrings.
-// LocatedPrestring contains accurate information about the position and the reason why NilAway deemed that position
-// to be nilable. We use it if available, else we use the raw string representation available from the Prestring.
-func newNode(p annotation.Prestring, c annotation.Prestring) node {
-	nodeObj := node{}
-
-	// get producer representation string
-	if l, ok := p.(annotation.LocatedPrestring); ok {
-		nodeObj.producerPosition = l.Location
-		nodeObj.producerRepr = l.Contained.String()
-	} else if p != nil {
-		nodeObj.producerRepr = p.String()
-	}
-
-	// get consumer representation string
-	if l, ok := c.(annotation.LocatedPrestring); ok {
-		nodeObj.consumerPosition = l.Location
-		nodeObj.consumerRepr = l.Contained.String()
-	} else if c != nil {
-		nodeObj.consumerRepr = c.String()
-	}
-
-	return nodeObj
-}
-
-func (n *node) String() string {
-	posStr := "<no pos info>"
-	reasonStr := ""
-	if n.consumerPosition.IsValid() {
-		posStr = n.consumerPosition.String()
-	}
-
-	if len(n.producerRepr) > 0 {
-		reasonStr += n.producerRepr
-	}
-	if len(n.consumerRepr) > 0 {
-		if len(n.producerRepr) > 0 {
-			reasonStr += " "
-		}
-		reasonStr += n.consumerRepr
-	}
-
-	return fmt.Sprintf("\t-> %s: %s", posStr, reasonStr)
-}
-
-// addNilPathNode adds a new node to the nil path.
-func (n *nilFlow) addNilPathNode(p annotation.Prestring, c annotation.Prestring) {
-	nodeObj := newNode(p, c)
-
-	// Note that in the implication graph, we traverse backwards from the point of conflict to the source of nilability.
-	// Therefore, they are added in reverse order from what the program flow would look like. To account for this we
-	// prepend the new node to nilPath because we want to print the program flow in its correct (forward) order.
-	// TODO: instead of prepending here, we can reverse the nilPath slice while printing.
-	n.nilPath = append([]node{nodeObj}, n.nilPath...)
-}
-
-// addNonNilPathNode adds a new node to the non-nil path
-func (n *nilFlow) addNonNilPathNode(p annotation.Prestring, c annotation.Prestring) {
-	nodeObj := newNode(p, c)
-	n.nonnilPath = append(n.nonnilPath, nodeObj)
-}
-
-// String converts a nilFlow to a string representation, where each entry is the flow of the form: `<pos>: <reason>`
-func (n *nilFlow) String() string {
-	var allNodes []node
-	allNodes = append(allNodes, n.nilPath...)
-	allNodes = append(allNodes, n.nonnilPath...)
-
-	var flow []string
-	for _, nodeObj := range allNodes {
-		flow = append(flow, nodeObj.String())
-	}
-	return "\n" + strings.Join(flow, "\n")
-}
-
-func (c *conflict) String() string {
-	// build string for similar conflicts (i.e., conflicts with the same nil path)
-	similarConflictsString := ""
-	if len(c.similarConflicts) > 0 {
-		similarPos := make([]string, len(c.similarConflicts))
-		for i, s := range c.similarConflicts {
-			similarPos[i] = fmt.Sprintf("\"%s\"", s.flow.nonnilPath[len(s.flow.nonnilPath)-1].consumerPosition.String())
-		}
-
-		posString := strings.Join(similarPos[:len(similarPos)-1], ", ")
-		if len(similarPos) > 1 {
-			posString = posString + ", and "
-		}
-		posString = posString + similarPos[len(similarPos)-1]
-
-		similarConflictsString = fmt.Sprintf("\n\n(Same nil source could also cause potential nil panic(s) at %d "+
-			"other place(s): %s.)", len(c.similarConflicts), posString)
-	}
-
-	return fmt.Sprintf("Potential nil panic detected. Observed nil flow from "+
-		"source to dereference point: %s%s\n", c.flow.String(), similarConflictsString)
-}
-
-func (c *conflict) addSimilarConflict(conflict conflict) {
-	c.similarConflicts = append(c.similarConflicts, &conflict)
-}
-
-func pathString(nodes []node) string {
-	path := ""
-	for _, n := range nodes {
-		path += n.String()
-	}
-	return path
-}
-
-// groupConflicts groups conflicts with the same nil path together and update conflicts list.
-func groupConflicts(allConflicts []conflict) []conflict {
-	conflictsMap := make(map[string]int)  // key: nil path string, value: index in `allConflicts`
-	indicesToIgnore := make(map[int]bool) // indices of conflicts to be ignored from `allConflicts`, since they are grouped with other conflicts
-
-	for i, c := range allConflicts {
-		key := pathString(c.flow.nilPath)
-
-		// Handle the case of single assertion conflict separately
-		if len(c.flow.nilPath) == 0 && len(c.flow.nonnilPath) == 1 {
-			// This is the case of single assertion conflict. Use producer position and repr from the non-nil path as the key.
-			if p := c.flow.nonnilPath[0]; p.producerPosition.IsValid() {
-				key = p.producerPosition.String() + ": " + p.producerRepr
-			}
-		}
-
-		if existingConflictIndex, ok := conflictsMap[key]; ok {
-			// Grouping condition satisfied. Add new conflict to `similarConflicts` in `existingConflict`, and update groupedConflicts map
-			allConflicts[existingConflictIndex].addSimilarConflict(c)
-			indicesToIgnore[i] = true
-		} else {
-			conflictsMap[key] = i
-		}
-	}
-
-	// update groupedConflicts list with grouped groupedConflicts
-	var groupedConflicts []conflict
-	for i, c := range allConflicts {
-		if _, ok := indicesToIgnore[i]; !ok {
-			groupedConflicts = append(groupedConflicts, c)
-		}
-	}
-	return groupedConflicts
 }

--- a/inference/engine.go
+++ b/inference/engine.go
@@ -244,7 +244,7 @@ func (e *Engine) buildFromSingleFullTrigger(trigger annotation.FullTrigger) {
 	pSite, cSite := trigger.Producer.Annotation.UnderlyingSite(), trigger.Consumer.Annotation.UnderlyingSite()
 	// NilAway does not know that (kind == Conditional || DeepConditional) => (site != nil),
 	// so we have to add some redundant checks in the corresponding cases to give some hints.
-	// TODO: remove this redundant check.
+	// TODO: remove those redundant nilness checks for sites.
 	switch {
 	case pKind == annotation.Always && cKind == annotation.Always:
 		// Producer always produces nilable value -> consumer always consumes nonnil value.

--- a/inference/engine.go
+++ b/inference/engine.go
@@ -60,7 +60,8 @@ func NewEngine(pass *analysis.Pass, diagnosticEngine conflictHandler) *Engine {
 	}
 }
 
-// InferredMap returns the current inferred annotation map.
+// InferredMap returns the current inferred annotation map, callers must treat this map as
+// read-only and do not directly modify it. Any further updates must be made via the Engine.
 func (e *Engine) InferredMap() *InferredMap {
 	return e.inferredMap
 }

--- a/inference/engine.go
+++ b/inference/engine.go
@@ -46,7 +46,7 @@ type Engine struct {
 	// generates proper diagnostics from those conflicts.
 	diagnosticEngine conflictHandler
 	// primitive is the primitivizer that is able to convert full triggers and annotation sites to
-	// their primitive forms.
+	// their primitive forms (see primitive.go).
 	primitive *primitivizer
 	// controlledTriggersBySite stores the set of controlled triggers for each site if the site
 	// controls any triggers. This field is for internal use in the struct only and should not be

--- a/inference/engine.go
+++ b/inference/engine.go
@@ -58,9 +58,9 @@ type Engine struct {
 func NewEngine(pass *analysis.Pass, diagnosticEngine conflictHandler) *Engine {
 	primitive := newPrimitivizer(pass)
 	return &Engine{
-		pass:        pass,
-		primitive: primitive,
-		inferredMap: newInferredMap(primitive),
+		pass:             pass,
+		primitive:        primitive,
+		inferredMap:      newInferredMap(primitive),
 		diagnosticEngine: diagnosticEngine,
 	}
 }
@@ -123,9 +123,9 @@ func (e *Engine) ObserveAnnotations(pkgAnnotations *annotation.ObservedMap, mode
 	pkgAnnotations.Range(func(key annotation.Key, isDeep bool, val bool) {
 		site := e.primitive.site(key, isDeep)
 		if val {
-			e.observeSiteExplanation(site, TrueBecauseAnnotation{AnnotationPos: site.Pos})
+			e.observeSiteExplanation(site, TrueBecauseAnnotation{AnnotationPos: site.Position})
 		} else {
-			e.observeSiteExplanation(site, FalseBecauseAnnotation{AnnotationPos: site.Pos})
+			e.observeSiteExplanation(site, FalseBecauseAnnotation{AnnotationPos: site.Position})
 		}
 	}, mode != NoInfer)
 }

--- a/inference/engine.go
+++ b/inference/engine.go
@@ -60,8 +60,7 @@ func NewEngine(pass *analysis.Pass, diagnosticEngine conflictHandler) *Engine {
 	}
 }
 
-// InferredMap returns the current inferred annotation map, callers must treat this map as
-// read-only and do not directly modify it. Any further updates must be made via the Engine.
+// InferredMap returns the current inferred annotation map.
 func (e *Engine) InferredMap() *InferredMap {
 	return e.inferredMap
 }

--- a/inference/engine.go
+++ b/inference/engine.go
@@ -218,7 +218,7 @@ func (e *Engine) buildPkgInferenceMap(triggers []annotation.FullTrigger) {
 		// controller is an CallSiteParamAnnotationKey, which must be enclosed in a ArgPass
 		// consumer, which Kind() method returns Conditional which is not deep. Thus, we pass false
 		// here.
-		site := newPrimitiveSite(*trigger.Controller, false)
+		site := e.primitive.site(*trigger.Controller, false)
 		ts, ok := controlledTgsBySite[site]
 		if !ok {
 			ts = map[annotation.FullTrigger]bool{}

--- a/inference/engine.go
+++ b/inference/engine.go
@@ -240,8 +240,6 @@ func (e *Engine) buildPkgInferenceMap(triggers []annotation.FullTrigger) {
 }
 
 func (e *Engine) buildFromSingleFullTrigger(trigger annotation.FullTrigger) {
-	primitiveAssertion := e.primitive.fullTrigger(trigger)
-
 	pKind, cKind := trigger.Producer.Annotation.Kind(), trigger.Consumer.Annotation.Kind()
 	pSite, cSite := trigger.Producer.Annotation.UnderlyingSite(), trigger.Consumer.Annotation.UnderlyingSite()
 	// NilAway does not know that (kind == Conditional || DeepConditional) => (site != nil),
@@ -261,7 +259,7 @@ func (e *Engine) buildFromSingleFullTrigger(trigger annotation.FullTrigger) {
 		}
 		site := e.primitive.site(cSite, cKind == annotation.DeepConditional)
 		e.observeSiteExplanation(site, TrueBecauseShallowConstraint{
-			ExternalAssertion: primitiveAssertion,
+			ExternalAssertion: e.primitive.fullTrigger(trigger),
 		})
 
 	case (pKind == annotation.Conditional || pKind == annotation.DeepConditional) && (cKind == annotation.Always):
@@ -272,7 +270,7 @@ func (e *Engine) buildFromSingleFullTrigger(trigger annotation.FullTrigger) {
 		}
 		site := e.primitive.site(pSite, pKind == annotation.DeepConditional)
 		e.observeSiteExplanation(site, FalseBecauseShallowConstraint{
-			ExternalAssertion: primitiveAssertion,
+			ExternalAssertion: e.primitive.fullTrigger(trigger),
 		})
 
 	case (pKind == annotation.Conditional || pKind == annotation.DeepConditional) &&
@@ -285,7 +283,7 @@ func (e *Engine) buildFromSingleFullTrigger(trigger annotation.FullTrigger) {
 		producer := e.primitive.site(pSite, pKind == annotation.DeepConditional)
 		consumer := e.primitive.site(cSite, cKind == annotation.DeepConditional)
 
-		e.observeImplication(producer, consumer, primitiveAssertion)
+		e.observeImplication(producer, consumer, e.primitive.fullTrigger(trigger))
 	}
 }
 

--- a/inference/explained_bool.go
+++ b/inference/explained_bool.go
@@ -31,7 +31,7 @@ type ExplainedBool interface {
 	fmt.Stringer
 
 	Val() bool
-	Pos() token.Pos
+	Position() token.Position
 	TriggerReprs() (producer fmt.Stringer, consumer fmt.Stringer)
 	DeeperReason() ExplainedBool
 }
@@ -69,9 +69,9 @@ func (t TrueBecauseShallowConstraint) String() string {
 		t.ExternalAssertion.ConsumerRepr, t.ExternalAssertion.ProducerRepr)
 }
 
-// Pos is the position of underlying site.
-func (t TrueBecauseShallowConstraint) Pos() token.Pos {
-	return t.ExternalAssertion.Pos
+// Position is the position of underlying site.
+func (t TrueBecauseShallowConstraint) Position() token.Position {
+	return t.ExternalAssertion.Position
 }
 
 // TriggerReprs returns the compact representation structs for the producer and consumer.
@@ -102,9 +102,9 @@ func (f FalseBecauseShallowConstraint) String() string {
 		f.ExternalAssertion.ProducerRepr, f.ExternalAssertion.ConsumerRepr)
 }
 
-// Pos is the position of underlying site.
-func (f FalseBecauseShallowConstraint) Pos() token.Pos {
-	return f.ExternalAssertion.Pos
+// Position is the position of underlying site.
+func (f FalseBecauseShallowConstraint) Position() token.Position {
+	return f.ExternalAssertion.Position
 }
 
 // TriggerReprs returns the compact representation structs for the producer and consumer.
@@ -134,9 +134,9 @@ func (t TrueBecauseDeepConstraint) String() string {
 		t.InternalAssertion.ConsumerRepr, t.InternalAssertion.ProducerRepr, t.DeeperExplanation.String())
 }
 
-// Pos is the position of underlying site.
-func (t TrueBecauseDeepConstraint) Pos() token.Pos {
-	return t.InternalAssertion.Pos
+// Position is the position of underlying site.
+func (t TrueBecauseDeepConstraint) Position() token.Position {
+	return t.InternalAssertion.Position
 }
 
 // TriggerReprs returns the compact representation structs for the producer and consumer.
@@ -166,9 +166,9 @@ func (f FalseBecauseDeepConstraint) String() string {
 		f.InternalAssertion.ProducerRepr, f.InternalAssertion.ConsumerRepr, f.DeeperExplanation.String())
 }
 
-// Pos is the position of underlying site.
-func (f FalseBecauseDeepConstraint) Pos() token.Pos {
-	return f.InternalAssertion.Pos
+// Position is the position of underlying site.
+func (f FalseBecauseDeepConstraint) Position() token.Position {
+	return f.InternalAssertion.Position
 }
 
 // TriggerReprs returns the compact representation structs for the producer and consumer.
@@ -186,15 +186,15 @@ func (f FalseBecauseDeepConstraint) DeeperReason() ExplainedBool {
 // has been discovered - forcing that site to be nilable.
 type TrueBecauseAnnotation struct {
 	ExplainedTrue
-	AnnotationPos token.Pos
+	AnnotationPos token.Position
 }
 
 func (TrueBecauseAnnotation) String() string {
 	return "NILABLE because it is annotated as so"
 }
 
-// Pos is the position of underlying site.
-func (t TrueBecauseAnnotation) Pos() token.Pos {
+// Position is the position of underlying site.
+func (t TrueBecauseAnnotation) Position() token.Position {
 	return t.AnnotationPos
 }
 
@@ -213,15 +213,15 @@ func (TrueBecauseAnnotation) DeeperReason() ExplainedBool {
 // has been discovered - forcing that site to be nonnil.
 type FalseBecauseAnnotation struct {
 	ExplainedFalse
-	AnnotationPos token.Pos
+	AnnotationPos token.Position
 }
 
 func (FalseBecauseAnnotation) String() string {
 	return "NONNIL because it is annotated as so"
 }
 
-// Pos is the position of underlying site.
-func (f FalseBecauseAnnotation) Pos() token.Pos {
+// Position is the position of underlying site.
+func (f FalseBecauseAnnotation) Position() token.Position {
 	return f.AnnotationPos
 }
 

--- a/inference/explained_bool.go
+++ b/inference/explained_bool.go
@@ -69,18 +69,14 @@ func (t TrueBecauseShallowConstraint) String() string {
 		t.ExternalAssertion.ConsumerRepr, t.ExternalAssertion.ProducerRepr)
 }
 
-// Pos is the position of underlying site.
 func (t TrueBecauseShallowConstraint) Pos() token.Pos {
 	return t.ExternalAssertion.Pos
 }
 
-// TriggerReprs returns the compact representation structs for the producer and consumer.
 func (t TrueBecauseShallowConstraint) TriggerReprs() (fmt.Stringer, fmt.Stringer) {
 	return t.ExternalAssertion.ProducerRepr, t.ExternalAssertion.ConsumerRepr
 }
 
-// DeeperReason returns another ExplainedBool that marks the deeper reason of this constraint.
-// It is only nonnil for deep constraints.
 func (t TrueBecauseShallowConstraint) DeeperReason() ExplainedBool {
 	return nil
 }
@@ -102,18 +98,14 @@ func (f FalseBecauseShallowConstraint) String() string {
 		f.ExternalAssertion.ProducerRepr, f.ExternalAssertion.ConsumerRepr)
 }
 
-// Pos is the position of underlying site.
 func (f FalseBecauseShallowConstraint) Pos() token.Pos {
 	return f.ExternalAssertion.Pos
 }
 
-// TriggerReprs returns the compact representation structs for the producer and consumer.
 func (f FalseBecauseShallowConstraint) TriggerReprs() (fmt.Stringer, fmt.Stringer) {
 	return f.ExternalAssertion.ProducerRepr, f.ExternalAssertion.ConsumerRepr
 }
 
-// DeeperReason returns another ExplainedBool that marks the deeper reason of this constraint.
-// It is only nonnil for deep constraints.
 func (f FalseBecauseShallowConstraint) DeeperReason() ExplainedBool {
 	return nil
 }
@@ -134,18 +126,14 @@ func (t TrueBecauseDeepConstraint) String() string {
 		t.InternalAssertion.ConsumerRepr, t.InternalAssertion.ProducerRepr, t.DeeperExplanation.String())
 }
 
-// Pos is the position of underlying site.
 func (t TrueBecauseDeepConstraint) Pos() token.Pos {
 	return t.InternalAssertion.Pos
 }
 
-// TriggerReprs returns the compact representation structs for the producer and consumer.
 func (t TrueBecauseDeepConstraint) TriggerReprs() (fmt.Stringer, fmt.Stringer) {
 	return t.InternalAssertion.ProducerRepr, t.InternalAssertion.ConsumerRepr
 }
 
-// DeeperReason returns another ExplainedBool that marks the deeper reason of this constraint.
-// It is only nonnil for deep constraints.
 func (t TrueBecauseDeepConstraint) DeeperReason() ExplainedBool {
 	return t.DeeperExplanation
 }
@@ -166,18 +154,14 @@ func (f FalseBecauseDeepConstraint) String() string {
 		f.InternalAssertion.ProducerRepr, f.InternalAssertion.ConsumerRepr, f.DeeperExplanation.String())
 }
 
-// Pos is the position of underlying site.
 func (f FalseBecauseDeepConstraint) Pos() token.Pos {
 	return f.InternalAssertion.Pos
 }
 
-// TriggerReprs returns the compact representation structs for the producer and consumer.
 func (f FalseBecauseDeepConstraint) TriggerReprs() (fmt.Stringer, fmt.Stringer) {
 	return f.InternalAssertion.ProducerRepr, f.InternalAssertion.ConsumerRepr
 }
 
-// DeeperReason returns another ExplainedBool that marks the deeper reason of this constraint.
-// It is only nonnil for deep constraints.
 func (f FalseBecauseDeepConstraint) DeeperReason() ExplainedBool {
 	return f.DeeperExplanation
 }
@@ -193,18 +177,14 @@ func (TrueBecauseAnnotation) String() string {
 	return "NILABLE because it is annotated as so"
 }
 
-// Pos is the position of underlying site.
 func (t TrueBecauseAnnotation) Pos() token.Pos {
 	return t.AnnotationPos
 }
 
-// TriggerReprs simply returns nil, nil since this constraint is the result of an annotation.
 func (TrueBecauseAnnotation) TriggerReprs() (fmt.Stringer, fmt.Stringer) {
 	return nil, nil
 }
 
-// DeeperReason returns another ExplainedBool that marks the deeper reason of this constraint.
-// It is only nonnil for deep constraints.
 func (TrueBecauseAnnotation) DeeperReason() ExplainedBool {
 	return nil
 }
@@ -220,18 +200,14 @@ func (FalseBecauseAnnotation) String() string {
 	return "NONNIL because it is annotated as so"
 }
 
-// Pos is the position of underlying site.
 func (f FalseBecauseAnnotation) Pos() token.Pos {
 	return f.AnnotationPos
 }
 
-// TriggerReprs simply returns nil, nil since this constraint is the result of an annotation.
 func (FalseBecauseAnnotation) TriggerReprs() (fmt.Stringer, fmt.Stringer) {
 	return nil, nil
 }
 
-// DeeperReason returns another ExplainedBool that marks the deeper reason of this constraint.
-// It is only nonnil for deep constraints.
 func (f FalseBecauseAnnotation) DeeperReason() ExplainedBool {
 	return nil
 }

--- a/inference/explained_bool.go
+++ b/inference/explained_bool.go
@@ -69,14 +69,18 @@ func (t TrueBecauseShallowConstraint) String() string {
 		t.ExternalAssertion.ConsumerRepr, t.ExternalAssertion.ProducerRepr)
 }
 
+// Pos is the position of underlying site.
 func (t TrueBecauseShallowConstraint) Pos() token.Pos {
 	return t.ExternalAssertion.Pos
 }
 
+// TriggerReprs returns the compact representation structs for the producer and consumer.
 func (t TrueBecauseShallowConstraint) TriggerReprs() (fmt.Stringer, fmt.Stringer) {
 	return t.ExternalAssertion.ProducerRepr, t.ExternalAssertion.ConsumerRepr
 }
 
+// DeeperReason returns another ExplainedBool that marks the deeper reason of this constraint.
+// It is only nonnil for deep constraints.
 func (t TrueBecauseShallowConstraint) DeeperReason() ExplainedBool {
 	return nil
 }
@@ -98,14 +102,18 @@ func (f FalseBecauseShallowConstraint) String() string {
 		f.ExternalAssertion.ProducerRepr, f.ExternalAssertion.ConsumerRepr)
 }
 
+// Pos is the position of underlying site.
 func (f FalseBecauseShallowConstraint) Pos() token.Pos {
 	return f.ExternalAssertion.Pos
 }
 
+// TriggerReprs returns the compact representation structs for the producer and consumer.
 func (f FalseBecauseShallowConstraint) TriggerReprs() (fmt.Stringer, fmt.Stringer) {
 	return f.ExternalAssertion.ProducerRepr, f.ExternalAssertion.ConsumerRepr
 }
 
+// DeeperReason returns another ExplainedBool that marks the deeper reason of this constraint.
+// It is only nonnil for deep constraints.
 func (f FalseBecauseShallowConstraint) DeeperReason() ExplainedBool {
 	return nil
 }
@@ -126,14 +134,18 @@ func (t TrueBecauseDeepConstraint) String() string {
 		t.InternalAssertion.ConsumerRepr, t.InternalAssertion.ProducerRepr, t.DeeperExplanation.String())
 }
 
+// Pos is the position of underlying site.
 func (t TrueBecauseDeepConstraint) Pos() token.Pos {
 	return t.InternalAssertion.Pos
 }
 
+// TriggerReprs returns the compact representation structs for the producer and consumer.
 func (t TrueBecauseDeepConstraint) TriggerReprs() (fmt.Stringer, fmt.Stringer) {
 	return t.InternalAssertion.ProducerRepr, t.InternalAssertion.ConsumerRepr
 }
 
+// DeeperReason returns another ExplainedBool that marks the deeper reason of this constraint.
+// It is only nonnil for deep constraints.
 func (t TrueBecauseDeepConstraint) DeeperReason() ExplainedBool {
 	return t.DeeperExplanation
 }
@@ -154,14 +166,18 @@ func (f FalseBecauseDeepConstraint) String() string {
 		f.InternalAssertion.ProducerRepr, f.InternalAssertion.ConsumerRepr, f.DeeperExplanation.String())
 }
 
+// Pos is the position of underlying site.
 func (f FalseBecauseDeepConstraint) Pos() token.Pos {
 	return f.InternalAssertion.Pos
 }
 
+// TriggerReprs returns the compact representation structs for the producer and consumer.
 func (f FalseBecauseDeepConstraint) TriggerReprs() (fmt.Stringer, fmt.Stringer) {
 	return f.InternalAssertion.ProducerRepr, f.InternalAssertion.ConsumerRepr
 }
 
+// DeeperReason returns another ExplainedBool that marks the deeper reason of this constraint.
+// It is only nonnil for deep constraints.
 func (f FalseBecauseDeepConstraint) DeeperReason() ExplainedBool {
 	return f.DeeperExplanation
 }
@@ -177,14 +193,18 @@ func (TrueBecauseAnnotation) String() string {
 	return "NILABLE because it is annotated as so"
 }
 
+// Pos is the position of underlying site.
 func (t TrueBecauseAnnotation) Pos() token.Pos {
 	return t.AnnotationPos
 }
 
+// TriggerReprs simply returns nil, nil since this constraint is the result of an annotation.
 func (TrueBecauseAnnotation) TriggerReprs() (fmt.Stringer, fmt.Stringer) {
 	return nil, nil
 }
 
+// DeeperReason returns another ExplainedBool that marks the deeper reason of this constraint.
+// It is only nonnil for deep constraints.
 func (TrueBecauseAnnotation) DeeperReason() ExplainedBool {
 	return nil
 }
@@ -200,14 +220,18 @@ func (FalseBecauseAnnotation) String() string {
 	return "NONNIL because it is annotated as so"
 }
 
+// Pos is the position of underlying site.
 func (f FalseBecauseAnnotation) Pos() token.Pos {
 	return f.AnnotationPos
 }
 
+// TriggerReprs simply returns nil, nil since this constraint is the result of an annotation.
 func (FalseBecauseAnnotation) TriggerReprs() (fmt.Stringer, fmt.Stringer) {
 	return nil, nil
 }
 
+// DeeperReason returns another ExplainedBool that marks the deeper reason of this constraint.
+// It is only nonnil for deep constraints.
 func (f FalseBecauseAnnotation) DeeperReason() ExplainedBool {
 	return nil
 }

--- a/inference/inferred_map.go
+++ b/inference/inferred_map.go
@@ -156,7 +156,7 @@ func (i *InferredMap) Export(pass *analysis.Pass) {
 	}
 
 	if len(exported) > 0 {
-		// We do not need to encode the primitiver since it is just a helper for the analysis of
+		// We do not need to encode the primitivizer since it is just a helper for the analysis of
 		// the current package.
 		m := newInferredMap(nil /* primitive */)
 		m.mapping = exported

--- a/inference/inferred_map.go
+++ b/inference/inferred_map.go
@@ -38,13 +38,15 @@ import (
 // inferredValDiff on shared keys is used to ensure that only
 // information present in `Mapping` but not `UpstreamMapping` is exported.
 type InferredMap struct {
+	primitive       *primitivizer
 	upstreamMapping map[primitiveSite]InferredVal
 	mapping         map[primitiveSite]InferredVal
 }
 
 // newInferredMap returns a new, empty InferredMap.
-func newInferredMap() *InferredMap {
+func newInferredMap(primitive *primitivizer) *InferredMap {
 	return &InferredMap{
+		primitive:       primitive,
 		upstreamMapping: make(map[primitiveSite]InferredVal),
 		mapping:         make(map[primitiveSite]InferredVal),
 	}
@@ -154,7 +156,9 @@ func (i *InferredMap) Export(pass *analysis.Pass) {
 	}
 
 	if len(exported) > 0 {
-		m := newInferredMap()
+		// We do not need to encode the primitiver since it is just a helper for the analysis of
+		// the current package.
+		m := newInferredMap(nil /* primitive */)
 		m.mapping = exported
 		pass.ExportPackageFact(m)
 	}
@@ -289,8 +293,8 @@ func (i *InferredMap) CheckFuncCallSiteRetAnn(key annotation.CallSiteRetAnnotati
 }
 
 func (i *InferredMap) checkAnnotationKey(key annotation.Key) (annotation.Val, bool) {
-	shallowKey := newPrimitiveSite(key, false)
-	deepKey := newPrimitiveSite(key, true)
+	shallowKey := i.primitive.site(key, false)
+	deepKey := i.primitive.site(key, true)
 
 	shallowVal, shallowOk := i.mapping[shallowKey]
 	deepVal, deepOk := i.mapping[deepKey]

--- a/inference/primitive.go
+++ b/inference/primitive.go
@@ -120,7 +120,7 @@ func (s *primitiveSite) String() string {
 // [archive importer]: https://github.com/golang/tools/blob/fa12f34b4218307705bf0365ab7df7c119b3653a/internal/gcimporter/bimport.go#L59-L69
 type primitivizer struct {
 	pass *analysis.Pass
-	// upstreamObjPositions maps "<pkg repr>.<object path>" to the correct position.
+	// upstreamObjPositions maps "<pkg path>.<object path>" to the correct position.
 	upstreamObjPositions map[string]token.Position
 	// curDir is the current working directory, which is used to trim the prefix (e.g., bazel
 	// random sandbox prefix) from the file names for cross-package references.

--- a/inference/primitive.go
+++ b/inference/primitive.go
@@ -58,12 +58,6 @@ type primitiveFullTrigger struct {
 // encoded into `Fact`s so frequently that artifact sizes would explode if these got too large.
 // This means no extensive string representations, and no deep structs.
 type primitiveSite struct {
-	// PkgRepr is the string representation of the package this site resides in.
-	PkgRepr string
-	// Repr is the string representation of the site itself.
-	Repr string
-	// IsDeep is used to differentiate shallow and deep nilabilities of the same sites.
-	IsDeep bool
 	// Position stores the complete position information (filename, offset, line, column) of the
 	// site. It is essential in maintaining the injectivities of the sites since Repr only encodes
 	// minimal information for error printing purposes. For example, the first return value of two
@@ -71,6 +65,12 @@ type primitiveSite struct {
 	// "Result 0 of function foo"). Note that any random filename prefixes added by the build
 	// system (e.g., bazel sandbox prefix) must be trimmed for cross-package reference.
 	Position token.Position
+	// PkgRepr is the string representation of the package this site resides in.
+	PkgRepr string
+	// Repr is the string representation of the site itself.
+	Repr string
+	// IsDeep is used to differentiate shallow and deep nilabilities of the same sites.
+	IsDeep bool
 	// Exported indicates whether this site is exported in the package or not.
 	Exported bool
 	// ObjectPath is an opaque name that identifies a types.Object relative to its package (see

--- a/inference/primitive.go
+++ b/inference/primitive.go
@@ -153,7 +153,8 @@ func newPrimitivizer(pass *analysis.Pass) *primitivizer {
 			if existing, ok := upstreamObjPositions[objRepr]; ok && existing != site.Position {
 				panic(fmt.Sprintf(
 					"conflicting position information on upstream object %q: existing: %v, got: %v",
-					objRepr, existing, site.Position))
+					objRepr, existing, site.Position,
+				))
 			}
 			upstreamObjPositions[objRepr] = site.Position
 			return true

--- a/inference/primitive.go
+++ b/inference/primitive.go
@@ -15,10 +15,16 @@
 package inference
 
 import (
+	"fmt"
 	"go/token"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
 
 	"go.uber.org/nilaway/annotation"
 	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/types/objectpath"
 )
 
 // A primitiveFullTrigger is a reduced version of an annotation.FullTrigger that can embedded into an
@@ -33,35 +39,21 @@ import (
 // static type information necessary to format that minimal information into a full string
 // representation without needing to encode it all when using Gob encodings through the Facts mechanism
 type primitiveFullTrigger struct {
+	// ProducerRepr stores the struct that can produce a string representation of the producer.
 	ProducerRepr annotation.Prestring
+	// ProducerRepr stores the struct that can produce a string representation of the consumer.
 	ConsumerRepr annotation.Prestring
-	Pos          token.Pos
-}
-
-func fullTriggerAsPrimitive(pass *analysis.Pass, trigger annotation.FullTrigger) primitiveFullTrigger {
-	producer, consumer := trigger.Prestrings(pass)
-	return primitiveFullTrigger{
-		ProducerRepr: producer,
-		ConsumerRepr: consumer,
-		Pos:          trigger.Consumer.Expr.Pos(),
-	}
 }
 
 // A primitiveSite represents an atomic choice that may be made about annotations. It is
-// more specific than a Key only in factoring out information such as depth (deep annotation
-// or not that would make the choice anything other than a boolean).
-//
-// Triggers created by the assertions analyzer can either be reduced to a primitiveSite,
-// or they are a PrimitiveAlways or a PrimitiveNever
+// more specific than an annotation.Key only in factoring out information such as depth (deep
+// annotation or not that would make the choice anything other than a boolean).
 //
 // Equality on these structs is vital to correctness as they form the keys in the implication graphs
-// shared by inference (InferredAnnotationMaps). In particular, if the encoding through
-// newPrimitiveSite below is not injective, then learned facts about different annotation sites
-// will overwrite each other. Injectivity is currently guaranteed through the combination of `Pos` -
-// an integer offset within the file set analyzed, and `PkgStringRepr` - a string representation of
-// the package this site was found in.
+// shared by inference (InferredMap). In particular, if the encoding through primitiveSite below is
+// not injective, then learned facts about different annotation sites will overwrite each other.
 //
-// Further, the mapping from AnnotationKeys to PrimitiveAnnotationSites must be deterministic - or it
+// Further, the mapping from annotation.Key to primitiveSite must be deterministic - or it
 // is possible that information about a site will be missed because it is stored under a different
 // encoding.
 //
@@ -69,36 +61,226 @@ func fullTriggerAsPrimitive(pass *analysis.Pass, trigger annotation.FullTrigger)
 // encoded into `Fact`s so frequently that artifact sizes would explode if these got too large.
 // This means no extensive string representations, and no deep structs.
 type primitiveSite struct {
-	StringRepr    string
-	IsDeep        bool
-	Pos           token.Pos
-	PkgStringRepr string
-	Exported      bool
+	// PkgRepr is the string representation of the package this site resides in.
+	PkgRepr string
+	// Repr is the string representation of the site itself.
+	Repr string
+	// IsDeep is used to differentiate shallow and deep nilabilities of the same sites.
+	IsDeep bool
+	// Position stores the complete position information (filename, offset, line, column) of the
+	// site. It is essential in maintaining the injectivities of the sites since Repr only encodes
+	// minimal information for error printing purposes. For example, the first return value of two
+	// same-name methods for different structs could end up having the same Repr (e.g.,
+	// "Result 0 of function foo"). Any random prefixes added by the build system (e.g., bazel
+	// sandbox prefix) must be trimmed for cross-package reference.
+	Position token.Position
+	// Exported indicates whether this site is exported in the package or not.
+	Exported bool
+	// ObjectPath is an opaque name that identifies a types.Object relative to its package (see
+	// objectpath.Path for more details). This is essential in order to match upstream objects in
+	// downstream analysis. The position information of upstream objects is incomplete due to the
+	// way the nogo driver loads packages. As a result, the Position in this struct could differ in
+	// downstream analysis, even when referring to the same upstream object. ObjectPath here is
+	// useful in correctly matching the upstream objects, and subsequently fixing the Position in
+	// the primitivizer. Note that ObjectPath only exists for exported objects; otherwise it will
+	// be empty ("").
+	ObjectPath objectpath.Path
 }
 
-// newPrimitiveSite encodes a passed Key as a primitiveSite, needing a boolean `isDeep` to complete
-// the translation.
-// As discussed above for `primitiveSite`, it is vital that this function is injective,
-// deterministic, and produces minimized output. Multi Package inference relies on all of these
-// properties.
-func newPrimitiveSite(key annotation.Key, isDeep bool) primitiveSite {
-	pkgStringRepr := ""
-	if pkg := key.Object().Pkg(); pkg != nil {
-		pkgStringRepr = pkg.Path()
-	}
-	return primitiveSite{
-		StringRepr:    key.String(),
-		IsDeep:        isDeep,
-		Pos:           key.Object().Pos(),
-		PkgStringRepr: pkgStringRepr,
-		Exported:      key.Object().Exported(),
-	}
-}
-
-func (s primitiveSite) String() string {
+// String returns the string representation of the primitive site for debugging purposes _only_.
+func (s *primitiveSite) String() string {
 	deepStr := ""
 	if s.IsDeep {
 		deepStr = "Deep "
 	}
-	return deepStr + s.StringRepr
+	return deepStr + s.Repr
+}
+
+type fileInfo struct {
+	file    *token.File
+	isLocal bool
+}
+
+// primitivizer is able to convert full triggers and annotation sites to their primitive forms. It
+// is useful for getting the correct primitive sites and positions for upstream objects due to the
+// lack of complete position information in downstream analysis. For example:
+//
+// upstream/main.go:
+// const GlobalVar *int
+//
+// downstream/main.go:
+// func main() { print(*upstream.GlobalVar) }
+//
+// Here, when analyzing the upstream package we will export a primitive site for `GlobalVar` that
+// encodes the package and site representations, and more importantly, the position information to
+// uniquely identify the site. However, when analyzing the downstream package, the
+// `upstream/main.go` file in the `analysis.Pass.Fset` will not have complete line and column
+// information. Instead, the [importer] injects 65535 fake "lines" into the file, and the object
+// we get for `upstream.GlobalVar` will contain completely different position information due to
+// this hack (in practice, we have observed that the lines for the objects are correct, but not
+// others). This leads to mismatches in our inference engine: we cannot find nilabilities of
+// upstream objects in the imported InferredMap since their Position fields in the primitive sites
+// are different. The primitivizer here contains logic to fix such discrepancies so that the
+// returned primitive sites for the same objects always contain correct (and same) Position information.
+//
+// [importer]: https://cs.opensource.google/go/x/tools/+/refs/tags/v0.7.0:go/internal/gcimporter/bimport.go;l=375-385;drc=c1dd25e80b559a5b0e8e2dd7d5bd1e946aa996a0;bpv=0;bpt=0
+type primitivizer struct {
+	pass *analysis.Pass
+	// upstreamObjPositions maps "pkg repr + object path" to the correct position.
+	upstreamObjPositions map[string]token.Position
+	files                map[string]fileInfo
+	// execRoot is the cached bazel sandbox prefix for trimming the filenames.
+	execRoot string
+}
+
+// newPrimitivizer returns a new primitivizer.
+func newPrimitivizer(pass *analysis.Pass) *primitivizer {
+	// To tackle the position discrepancies for upstream sites, we have added an ObjectPath field,
+	// which can be used to uniquely identify an exported object relative to the package. Then,
+	// we can simply cache the correct position information when importing InferredMaps, since the
+	// positions collected in the upstream analysis are always correct. Later when querying upstream
+	// objects in downstream analysis, we can look up the cache and fill in the correct position in
+	// the returned primitive site instead.
+
+	// Create a cache for upstream object positions.
+	upstreamObjPositions := make(map[string]token.Position)
+	for _, packageFact := range pass.AllPackageFacts() {
+		importedMap, ok := packageFact.Fact.(*InferredMap)
+		if !ok {
+			continue
+		}
+		importedMap.Range(func(site primitiveSite, _ InferredVal) bool {
+			if site.ObjectPath == "" {
+				return true
+			}
+
+			objRepr := site.PkgRepr + "." + string(site.ObjectPath)
+			if existing, ok := upstreamObjPositions[objRepr]; ok && existing != site.Position {
+				/*config.WriteToLog(fmt.Sprintf(
+				"conflicting position information on upstream object %q: existing: %v, got: %v",
+				objRepr, existing, site.Position))*/
+				panic(fmt.Sprintf(
+					"conflicting position information on upstream object %q: existing: %v, got: %v",
+					objRepr, existing, site.Position))
+			}
+			upstreamObjPositions[objRepr] = site.Position
+			return true
+		})
+	}
+
+	// Find the bazel execroot (i.e., random sandbox prefix) for trimming the file names.
+	execRoot, err := os.Getwd()
+	if err != nil {
+		panic("cannot get current working directory")
+	}
+	// config.WriteToLog(fmt.Sprintf("exec root: %q", execRoot))
+
+	// Iterate all files within the Fset (which includes upstream and current package files), and
+	// store the mapping between its file name (modulo the bazel prefix) and the token.File object.
+	files := make(map[string]fileInfo)
+	pass.Fset.Iterate(func(file *token.File) bool {
+		name, err := filepath.Rel(execRoot, file.Name())
+		if err != nil {
+			// For files in standard libraries, there is no bazel sandbox prefix, so we can just
+			// keep the original name.
+			name = file.Name()
+		}
+		files[name] = fileInfo{
+			file:    file,
+			isLocal: strings.HasSuffix(path.Dir(name), pass.Pkg.Path()),
+		}
+		return true
+	})
+
+	return &primitivizer{
+		pass:                 pass,
+		upstreamObjPositions: upstreamObjPositions,
+		files:                files,
+		execRoot:             execRoot,
+	}
+}
+
+// fullTrigger returns the primitive version of the full trigger.
+func (p *primitivizer) fullTrigger(trigger annotation.FullTrigger) primitiveFullTrigger {
+	// Expr is always nonnil, but our struct init analysis is capped at depth 1 so NilAway does not
+	// know this fact. Here, we explicitly guard against such cases to provide a hint.
+	if trigger.Consumer.Expr == nil {
+		panic(fmt.Sprintf("consume trigger %v has a nil Expr", trigger.Consumer))
+	}
+
+	producer, consumer := trigger.Prestrings(p.pass)
+	return primitiveFullTrigger{
+		ProducerRepr: producer,
+		ConsumerRepr: consumer,
+	}
+}
+
+// site returns the primitive version of the annotation site.
+func (p *primitivizer) site(key annotation.Key, isDeep bool) primitiveSite {
+	pkgRepr := ""
+	if pkg := key.Object().Pkg(); pkg != nil {
+		pkgRepr = pkg.Path()
+	}
+
+	objPath, err := objectpath.For(key.Object())
+	if err != nil {
+		// An error will occur when trying to get object path for unexported objects, in which case
+		// we simply assign an empty object path.
+		objPath = ""
+	}
+
+	var position token.Position
+	// For upstream objects, we need to look up the local position cache for correct positions.
+	if key.Object().Pkg() != nil && p.pass.Pkg != key.Object().Pkg() {
+		// Correct upstream information may not always be in the cache: we may not even have it
+		// since we skipped analysis for standard and 3rd party libraries.
+		if p, ok := p.upstreamObjPositions[pkgRepr+"."+string(objPath)]; ok {
+			position = p
+		}
+	}
+
+	// Default case (local objects or objects from skipped upstream packages), we can simply use
+	// their Object.Pos() and retrieve the position information. However, we must trim the bazel
+	// sandbox prefix from the filenames for cross-package references.
+	if !position.IsValid() {
+		position = p.pass.Fset.Position(key.Object().Pos())
+		if name, err := filepath.Rel(p.execRoot, position.Filename); err == nil {
+			position.Filename = name
+		}
+	}
+
+	site := primitiveSite{
+		PkgRepr:    pkgRepr,
+		Repr:       key.String(),
+		IsDeep:     isDeep,
+		Exported:   key.Object().Exported(),
+		ObjectPath: objPath,
+		Position:   position,
+	}
+
+	/*if objPath != "" {
+		// config.WriteToLog(fmt.Sprintf("objpath: %s.%s for site %v", pkgRepr, objPath, site))
+	}*/
+
+	return site
+}
+
+// sitePos takes the primitive site (with accurate position information) and converts it to a
+// token.Pos that is relative to local Fset for reporting purposes.
+func (p *primitivizer) sitePos(site primitiveSite) token.Pos {
+	// Retrieve the file from cache.
+	info, ok := p.files[site.Position.Filename]
+	if !ok {
+		panic(fmt.Sprintf("file does not exist in downstream analysis: %q", site.Position.Filename))
+	}
+
+	// For local files, we can accurate restore the token.Pos.
+	if info.isLocal {
+		return info.file.Pos(site.Position.Offset)
+	}
+
+	// However, files in upstream packages are conceptually 65535 * '\n' (see docs on primitivizer
+	// for more details), therefore, we can only restore a local token.Pos that accurately tracks
+	// the line, but not the column.
+	return info.file.LineStart(site.Position.Line)
 }

--- a/inference/primitive.go
+++ b/inference/primitive.go
@@ -1,3 +1,17 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package inference
 
 import (

--- a/inference/primitive.go
+++ b/inference/primitive.go
@@ -65,8 +65,8 @@ type primitiveSite struct {
 	// "Result 0 of function foo"). Note that any random filename prefixes added by the build
 	// system (e.g., bazel sandbox prefix) must be trimmed for cross-package reference.
 	Position token.Position
-	// PkgRepr is the string representation of the package this site resides in.
-	PkgRepr string
+	// PkgPath is the string representation of the package this site resides in.
+	PkgPath string
 	// Repr is the string representation of the site itself.
 	Repr string
 	// IsDeep is used to differentiate shallow and deep nilabilities of the same sites.
@@ -149,7 +149,7 @@ func newPrimitivizer(pass *analysis.Pass) *primitivizer {
 				return true
 			}
 
-			objRepr := site.PkgRepr + "." + string(site.ObjectPath)
+			objRepr := site.PkgPath + "." + string(site.ObjectPath)
 			if existing, ok := upstreamObjPositions[objRepr]; ok && existing != site.Position {
 				panic(fmt.Sprintf(
 					"conflicting position information on upstream object %q: existing: %v, got: %v",
@@ -221,7 +221,7 @@ func (p *primitivizer) site(key annotation.Key, isDeep bool) primitiveSite {
 	}
 
 	return primitiveSite{
-		PkgRepr:    pkgRepr,
+		PkgPath:    pkgRepr,
 		Repr:       key.String(),
 		IsDeep:     isDeep,
 		Exported:   key.Object().Exported(),

--- a/inference/primitive.go
+++ b/inference/primitive.go
@@ -307,11 +307,14 @@ func (p *primitivizer) sitePos(site primitiveSite) token.Pos {
 		// error on a file from a transitively imported package, we need to create a fake file in
 		// the file set.
 		// [gcexportdata]: https://pkg.go.dev/golang.org/x/tools/go/gcexportdata
-		info = fileInfo{
-			// Fake lines will be padded later.
-			file:   p.pass.Fset.AddFile(site.Position.Filename, p.pass.Fset.Base(), _fakeFileMaxLines),
-			isFake: true,
+		file := p.pass.Fset.AddFile(site.Position.Filename, p.pass.Fset.Base(), _fakeFileMaxLines)
+		// Set up fake lines for the fake file.
+		fakeLines := make([]int, site.Position.Line)
+		for i := range fakeLines {
+			fakeLines[i] = i
 		}
+		file.SetLines(fakeLines)
+		info = fileInfo{file: file, isFake: true}
 		p.files[site.Position.Filename] = info
 	}
 


### PR DESCRIPTION
Our multi-package inference algorithm is broken in practice for incremental build systems like bazel:

In order to incur minimal overhead to storage, we store a stripped down version of annotation site (i.e., `inference.primitiveSite`) in the inference map that compactly describes the annotation site. In this struct, we are also storing `token.Pos` as position information of the site for injectivity.

(`token.Pos` is simply an integer that cleverly and compactly encodes the position information in a given file set, so that you don’t have to store `(filename, line, column)` inside each AST node to reduce memory consumption. Whenever you need to access this information, you can convert by querying the file set `Fset.Position(p Pos)` . To put differently, `token.Pos` means nothing without the `Fset` context.)

Now, let's say we have analyzed upstream package, exported `NilableValue` in the inferred map (which includes a `token.Pos` that only makes sense in the context of the upstream package’s `Fset` ). When analyzing the downstream package, we will first import the `NilableValue` annotation site (with a `token.Pos` that is only meaningful during analysis of the upstream package) and its value in our map, and then check the dereference `upstream.NilableValue`. However, the `token.Pos` for the dereference point is for the downstream package and could be completely different - we won’t find it in the map, no conflicts => no errors.

In this PR, we replace `token.Pos` with `token.Position` (i.e., a tuple of filename, offset, line, column) to make it package-independent. However, this still does not fix the whole problem since we won't have complete position information about upstream sites when analyzing downstream packages. More specifically, the upstream file in the `analysis.Pass.Fset` will not have complete line and column  information. Instead, the [importer](https://cs.opensource.google/go/x/tools/+/refs/tags/v0.7.0:go/internal/gcimporter/bimport.go;l=375-385;drc=c1dd25e80b559a5b0e8e2dd7d5bd1e946aa996a0;bpv=0;bpt=0) injects 65535 fake "lines" into the file, and the object we get for dereference `upstream.NilableValue` will still contain completely different position information due to this hack (in practice, we have observed that the lines for the objects are correct, but not others). This leads to mismatches in our inference engine: we still cannot find nilabilities of upstream objects in the imported `InferredMap` since their Position fields in the primitive sites are different. 

Therefore, in addition to the package-independent `token.Position`, we have also added an `ObjectPath` field to the exported site, that is an opaque name that identifies a `types.Object` relative to its package (see [objectpath](https://pkg.go.dev/golang.org/x/tools/go/types/objectpath) package for more details). This is then used to match the corresponding upstream objects in downstream analysis, and fix the positions information according to the imported positions from upstream analyses.

Implementation-wise, this PR contains the following changes:

* We replace `token.Pos` with `token.Position` and add an `ObjectPath` field in primitive sites.
* We add a `primitivizer` struct that handles caching, and fixing logic for upstream objects. Whenever we need to convert full trigger or annotation sites to their primitive forms, we _must_ call methods on this struct to get the correct primitive sites.
* We trim the bazel-specific prefix of `filename` in `token.Position` in primitive sites since bazel will create a sandbox with a random prefix for each build.

Depends on PR #63