### PR TITLE
Enable struct object creation to be safe without struct init analysis

### DIFF
--- a/assertion/function/assertiontree/var_assertion_node.go
+++ b/assertion/function/assertiontree/var_assertion_node.go
@@ -66,8 +66,8 @@ func (v *varAssertionNode) DefaultTrigger() annotation.ProducingAnnotationTrigge
 	//  preprocessing phase
 	if !util.TypeIsDeeplyPtr(v.decl.Type()) {
 		if structType := util.TypeAsDeeplyStruct(v.decl.Type()); structType != nil {
-			builtExpr := v.BuildExpr(v.Root().Pass(), nil)
 			if v.Root().functionContext.isDepthOneFieldCheck() {
+				builtExpr := v.BuildExpr(v.Root().Pass(), nil)
 				v.Root().addProductionForVarFieldNode(v, builtExpr)
 			}
 			return annotation.ProduceTriggerNever{} // indicating that the struct object itself is not nil

--- a/assertion/function/assertiontree/var_assertion_node.go
+++ b/assertion/function/assertiontree/var_assertion_node.go
@@ -67,8 +67,7 @@ func (v *varAssertionNode) DefaultTrigger() annotation.ProducingAnnotationTrigge
 	if !util.TypeIsDeeplyPtr(v.decl.Type()) {
 		if structType := util.TypeAsDeeplyStruct(v.decl.Type()); structType != nil {
 			if v.Root().functionContext.isDepthOneFieldCheck() {
-				builtExpr := v.BuildExpr(v.Root().Pass(), nil)
-				v.Root().addProductionForVarFieldNode(v, builtExpr)
+				v.Root().addProductionForVarFieldNode(v, v.BuildExpr(v.Root().Pass(), nil))
 			}
 			return annotation.ProduceTriggerNever{} // indicating that the struct object itself is not nil
 		}

--- a/assertion/function/assertiontree/var_assertion_node.go
+++ b/assertion/function/assertiontree/var_assertion_node.go
@@ -63,14 +63,14 @@ func (v *varAssertionNode) DefaultTrigger() annotation.ProducingAnnotationTrigge
 	// if `v` is a struct (e.g., var s S), not a struct pointer, then analyze it for its fields. Note that here we don't
 	// want to analyze fields of an unassigned struct pointer, since at this point the pointer itself is nil.
 	// TODO: below logic won't be required once we standardize the expression `var s S` by replacing it with `S{}` in the
-	//  preprocessing phase after  is implemented
-	if v.Root().functionContext.isDepthOneFieldCheck() {
-		if !util.TypeIsDeeplyPtr(v.decl.Type()) {
-			if structType := util.TypeAsDeeplyStruct(v.decl.Type()); structType != nil {
-				builtExpr := v.BuildExpr(v.Root().Pass(), nil)
+	//  preprocessing phase
+	if !util.TypeIsDeeplyPtr(v.decl.Type()) {
+		if structType := util.TypeAsDeeplyStruct(v.decl.Type()); structType != nil {
+			builtExpr := v.BuildExpr(v.Root().Pass(), nil)
+			if v.Root().functionContext.isDepthOneFieldCheck() {
 				v.Root().addProductionForVarFieldNode(v, builtExpr)
-				return annotation.ProduceTriggerNever{} // indicating that the struct object itself is not nil
 			}
+			return annotation.ProduceTriggerNever{} // indicating that the struct object itself is not nil
 		}
 	}
 

--- a/testdata/src/go.uber.org/nilabletypes/nilabletypes.go
+++ b/testdata/src/go.uber.org/nilabletypes/nilabletypes.go
@@ -21,7 +21,9 @@ these cases no diagnostics are emitted
 */
 package nilabletypes
 
-type A struct{}
+type A struct {
+	f int
+}
 
 type A2 A
 
@@ -91,6 +93,46 @@ func nilableTypesTest() interface{} {
 		return mp1 //want "nilable value returned"
 	case 22:
 		return mp2 //want "nilable value returned"
+	case 23:
+		var x A
+		y := &x
+		return y
+	case 24:
+		var x A
+		y := &x
+		return y.f
+	case 25:
+		var x A
+		return x
+	case 26:
+		var x A
+		return x.f
+	case 27:
+		var x A
+		y := &x
+		return *y
+	case 28:
+		var x A
+		return *(&x)
+	case 29:
+		var x A
+		return (&(*(&(*(&x)))))
+	case 30:
+		var x *A
+		y := *x //want "read from a variable that was never assigned to"
+		return &y
+	case 31:
+		var x *A
+		return &x //want "read from a variable that was never assigned to"
+	case 32:
+		var x *A
+		return x.f //want "read from a variable that was never assigned to"
+	case 33:
+		var x *A
+		return &(*x) //want "read from a variable that was never assigned to"
+	case 34:
+		var x *A
+		return (*(&(*(&(*x))))) //want "read from a variable that was never assigned to"
 	default:
 		return nilableTypesTest()
 	}


### PR DESCRIPTION
This PR allows struct object creation `var s S` to be considered safe (i.e., nonnil), avoiding reporting of false positives due to incorrect marking of `s` as uninitialized. This support was already added in NilAway, but was guarded by the struct init flag. This PR removes that restriction, allowing this support to be generally available.

[Closes #53]