### PR TITLE
Revert affiliation support for tracking struct fields temporarily

### DIFF
--- a/assertion/affiliation/affiliation.go
+++ b/assertion/affiliation/affiliation.go
@@ -199,7 +199,9 @@ func (a *Affiliation) computeTriggersForCastingSites(pass *analysis.Pass, upstre
 								appendTypeToTypeTriggers(valueType, util.TypeOf(pass, kv.Value))
 							}
 						}
-					case *ast.Ident:
+						// TODO: uncomment below piece of code after thorough performance testing, and add "want" strings in
+						// testdata/methodimplementation/embedding/embedding.go.
+						/*case *ast.Ident:
 						// A struct field (embedded or explicit) declared of type interface, and initialized with a struct
 						// e.g., var i I = S{t:&T{}}, where `type S struct { t J }`. (Here I and J are interfaces,
 						// and S and T are structs implementing them, respectively.)
@@ -220,7 +222,7 @@ func (a *Affiliation) computeTriggersForCastingSites(pass *analysis.Pass, upstre
 							if lhsType != nil && rhsType != nil {
 								appendTypeToTypeTriggers(lhsType, rhsType)
 							}
-						}
+						}*/
 					}
 				case *ast.FuncLit:
 					// TODO: Nilability analysis support for anonymous functions is currently not

--- a/testdata/src/go.uber.org/methodimplementation/embedding/embedding.go
+++ b/testdata/src/go.uber.org/methodimplementation/embedding/embedding.go
@@ -165,7 +165,7 @@ func testRecursion() *int {
 
 // below test checks embedding of multiple interfaces within a struct, and embedding of interfaces within an interface
 type J interface {
-	bar() *int //want "returned" "returned"
+	bar() *int //want "returned"
 }
 
 type A9 struct {
@@ -175,7 +175,7 @@ type A9 struct {
 
 type B9 struct{}
 
-func (B9) foo(x *int) *int { //want "passed as parameter"
+func (B9) foo(x *int) *int {
 	return x
 }
 
@@ -217,7 +217,7 @@ func testEmbeddingInterfaceInInterface() {
 // below test checks embedding of interface within a struct
 type A8 struct{}
 
-func (*A8) foo(x *int) *int { //want "passed as parameter"
+func (*A8) foo(x *int) *int {
 	return x
 }
 
@@ -242,7 +242,7 @@ type D8 struct {
 
 type E8 struct{}
 
-func (*E8) foo(x *int) *int { //want "passed as parameter"
+func (*E8) foo(x *int) *int {
 	return x
 }
 
@@ -281,7 +281,7 @@ type C10 struct {
 
 type D10 struct{}
 
-func (*D10) foo(x *int) *int { //want "passed as parameter"
+func (*D10) foo(x *int) *int {
 	return x
 }
 
@@ -292,7 +292,7 @@ func testNestedStructs() {
 
 // below test checks a non-trivial case simulated from https://github.com/golang/go/pull/60823
 type Conn interface {
-	RemoteAddr() Addr //want "returned"
+	RemoteAddr() Addr
 }
 
 type Addr interface {


### PR DESCRIPTION
This PR is to temporarily disable and revert the affiliation support implemented in [https://github.com/uber-go/nilaway/commit/2a6b18c0969c9bf8cf7b948203d90c00bf17f402](https://github.com/uber-go/nilaway/commit/2a6b18c0969c9bf8cf7b948203d90c00bf17f402) temporarily. After doing thorough performance testing, we plan to bring back this support.