### PR TITLE
Separate the diagnostic processing engine from inference package

### DIFF
--- a/accumulation/analyzer.go
+++ b/accumulation/analyzer.go
@@ -135,13 +135,14 @@ func run(pass *analysis.Pass) (result interface{}, _ error) {
 		// determining local and upstream sites in the process. This is guaranteed not to determine any
 		// sites unless we really have a reason they have to be determined.
 		inferenceEngine.ObservePackage(assertionsResult.FullTriggers)
-		inferredMap, diagnostics = inferenceEngine.InferredMap(), diagnosticEngine.Diagnostics(true /* grouping */)
+		inferredMap = inferenceEngine.InferredMap()
+		diagnostics = diagnosticEngine.Diagnostics(true /* grouping */)
 
 	case inference.NoInfer:
 		// In non-inference case - use the classical assertionNode.CheckErrors method to determine error outputs
 		inferredMap = inferenceEngine.InferredMap()
 		checkErrors(assertionsResult.FullTriggers, inferredMap, diagnosticEngine)
-		// Retrieve the diagnostics from the engine. Note that we do not need to group the
+		// Retrieve the diagnostics from the engine. Note that we should not group the
 		// diagnostics for easier unit testing.
 		diagnostics = diagnosticEngine.Diagnostics(false /* grouping */)
 

--- a/accumulation/analyzer.go
+++ b/accumulation/analyzer.go
@@ -26,6 +26,7 @@ import (
 	"go.uber.org/nilaway/assertion"
 	"go.uber.org/nilaway/assertion/function/assertiontree"
 	"go.uber.org/nilaway/config"
+	"go.uber.org/nilaway/diagnostic"
 	"go.uber.org/nilaway/inference"
 	"golang.org/x/tools/go/analysis"
 )
@@ -110,17 +111,19 @@ func run(pass *analysis.Pass) (result interface{}, _ error) {
 		return errorsToDiagnostics(errs), nil
 	}
 
+	diagnosticEngine := diagnostic.NewEngine(pass)
+
+	// Create an inference engine and observe (load) information from upstream dependencies (i.e.,
+	// mappings between annotation sites and their inferred values).
+	inferenceEngine := inference.NewEngine(pass, diagnosticEngine)
+	inferenceEngine.ObserveUpstream()
+
 	// Determine inference type based on comments in package doc string.
 	mode := inference.DetermineMode(pass)
 
-	// Create an engine and observe (load) information from upstream dependencies (i.e., mappings
-	// between annotation sites and their inferred values).
-	engine := inference.NewEngine(pass)
-	engine.ObserveUpstream()
-
 	// First observe all annotations from annotationsResult (observes only syntactic annotations
 	// for FullInfer mode, otherwise all annotations for NoInfer)
-	engine.ObserveAnnotations(annotationsResult.AnnotationMap, mode)
+	inferenceEngine.ObserveAnnotations(annotationsResult.AnnotationMap, mode)
 
 	var (
 		inferredMap *inference.InferredMap
@@ -131,13 +134,16 @@ func run(pass *analysis.Pass) (result interface{}, _ error) {
 		// Incorporate assertions from this package one-by-one into the inferredAnnotationMap, possibly
 		// determining local and upstream sites in the process. This is guaranteed not to determine any
 		// sites unless we really have a reason they have to be determined.
-		engine.ObservePackage(assertionsResult.FullTriggers)
-		inferredMap, diagnostics = engine.InferredMapWithDiagnostics()
+		inferenceEngine.ObservePackage(assertionsResult.FullTriggers)
+		inferredMap, diagnostics = inferenceEngine.InferredMap(), diagnosticEngine.Diagnostics(true /* grouping */)
 
 	case inference.NoInfer:
 		// In non-inference case - use the classical assertionNode.CheckErrors method to determine error outputs
-		inferredMap, diagnostics = engine.InferredMapWithDiagnostics()
-		diagnostics = append(diagnostics, buildDiagnostics(pass, checkErrors(assertionsResult.FullTriggers, inferredMap))...)
+		inferredMap = inferenceEngine.InferredMap()
+		checkErrors(assertionsResult.FullTriggers, inferredMap, diagnosticEngine)
+		// Retrieve the diagnostics from the engine. Note that we do not need to group the
+		// diagnostics for easier unit testing.
+		diagnostics = diagnosticEngine.Diagnostics(false /* grouping */)
 
 	default:
 		panic("Invalid mode for running NilAway")
@@ -167,21 +173,13 @@ func errorsToDiagnostics(errs []error) []analysis.Diagnostic {
 	return diagnostics
 }
 
-// buildDiagnostics takes a list of FullTriggers, which are assumed to already have been checked
-// and are known to fail, and returns a slice of the appropriate diagnostics for all the triggers.
-func buildDiagnostics(pass *analysis.Pass, triggers []annotation.FullTrigger) []analysis.Diagnostic {
-	// setting NoGrouping to true since the no-infer mode is used via unit tests currently, and we actually want
-	// separate errors for better testability
-	conflicts := inference.ConflictList{NoGrouping: true}
-	for _, trigger := range triggers {
-		conflicts.AddSingleAssertionConflict(pass, trigger)
-	}
-	return conflicts.Diagnostics()
+type conflictHandler interface {
+	AddSingleAssertionConflict(trigger annotation.FullTrigger)
 }
 
 // checkErrors iterates over a set of full triggers, checking each one against a given annotation
 // map to see if it fails and if so appending it to the returned list.
-func checkErrors(triggers []annotation.FullTrigger, annMap annotation.Map) []annotation.FullTrigger {
+func checkErrors(triggers []annotation.FullTrigger, annMap annotation.Map, diagnosticEngine conflictHandler) {
 	// Filter triggers for error return handling -- inter-procedural and annotations-based (no inference).
 	// (Note that since we are using FilterTriggersForErrorReturn as a preprocessing step here, we can directly use its
 	// first output `filteredTriggers` to check and report errors. The second output of raw `deleted triggers` is not
@@ -198,15 +196,13 @@ func checkErrors(triggers []annotation.FullTrigger, annMap annotation.Map) []ann
 		},
 	)
 
-	var triggered []annotation.FullTrigger
 	for _, trigger := range filteredTriggers {
 		// Skip checking any full triggers we created by duplicating from contracted functions
 		// to the caller function.
 		if !trigger.CreatedFromDuplication && trigger.Check(annMap) {
-			triggered = append(triggered, trigger)
+			diagnosticEngine.AddSingleAssertionConflict(trigger)
 		}
 	}
-	return triggered
 }
 
 // This is required to use interface types in facts - see the implementation of GobRegister for the

--- a/diagnostic/conflict.go
+++ b/diagnostic/conflict.go
@@ -1,0 +1,75 @@
+package diagnostic
+
+import (
+	"fmt"
+	"go/token"
+	"strings"
+)
+
+type conflict struct {
+	pos              token.Pos   // stores position where the error should be reported (note that this field is used only within the current, and should NOT be exported)
+	flow             nilFlow     // stores nil flow from source to dereference point
+	similarConflicts []*conflict // stores other conflicts that are similar to this one
+}
+
+func (c *conflict) String() string {
+	// build string for similar conflicts (i.e., conflicts with the same nil path)
+	similarConflictsString := ""
+	if len(c.similarConflicts) > 0 {
+		similarPos := make([]string, len(c.similarConflicts))
+		for i, s := range c.similarConflicts {
+			similarPos[i] = fmt.Sprintf("\"%s\"", s.flow.nonnilPath[len(s.flow.nonnilPath)-1].consumerPosition.String())
+		}
+
+		posString := strings.Join(similarPos[:len(similarPos)-1], ", ")
+		if len(similarPos) > 1 {
+			posString = posString + ", and "
+		}
+		posString = posString + similarPos[len(similarPos)-1]
+
+		similarConflictsString = fmt.Sprintf("\n\n(Same nil source could also cause potential nil panic(s) at %d "+
+			"other place(s): %s.)", len(c.similarConflicts), posString)
+	}
+
+	return fmt.Sprintf("Potential nil panic detected. Observed nil flow from "+
+		"source to dereference point: %s%s\n", c.flow.String(), similarConflictsString)
+}
+
+func (c *conflict) addSimilarConflict(conflict conflict) {
+	c.similarConflicts = append(c.similarConflicts, &conflict)
+}
+
+// groupConflicts groups conflicts with the same nil path together and update conflicts list.
+func groupConflicts(allConflicts []conflict) []conflict {
+	conflictsMap := make(map[string]int)  // key: nil path string, value: index in `allConflicts`
+	indicesToIgnore := make(map[int]bool) // indices of conflicts to be ignored from `allConflicts`, since they are grouped with other conflicts
+
+	for i, c := range allConflicts {
+		key := pathString(c.flow.nilPath)
+
+		// Handle the case of single assertion conflict separately
+		if len(c.flow.nilPath) == 0 && len(c.flow.nonnilPath) == 1 {
+			// This is the case of single assertion conflict. Use producer position and repr from the non-nil path as the key.
+			if p := c.flow.nonnilPath[0]; p.producerPosition.IsValid() {
+				key = p.producerPosition.String() + ": " + p.producerRepr
+			}
+		}
+
+		if existingConflictIndex, ok := conflictsMap[key]; ok {
+			// Grouping condition satisfied. Add new conflict to `similarConflicts` in `existingConflict`, and update groupedConflicts map
+			allConflicts[existingConflictIndex].addSimilarConflict(c)
+			indicesToIgnore[i] = true
+		} else {
+			conflictsMap[key] = i
+		}
+	}
+
+	// update groupedConflicts list with grouped groupedConflicts
+	var groupedConflicts []conflict
+	for i, c := range allConflicts {
+		if _, ok := indicesToIgnore[i]; !ok {
+			groupedConflicts = append(groupedConflicts, c)
+		}
+	}
+	return groupedConflicts
+}

--- a/diagnostic/engine.go
+++ b/diagnostic/engine.go
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package diagnostic hosts the diagnostic engine, which is responsible for collecting the
+// conflicts from annotation-based checks (no-infer mode) and/or inference (full-infer mode) and
+// generating user-friendly diagnostics from those conflicts.
 package diagnostic
 
 import (

--- a/diagnostic/engine.go
+++ b/diagnostic/engine.go
@@ -46,7 +46,7 @@ func (e *Engine) Diagnostics(grouping bool) []analysis.Diagnostic {
 	}
 
 	// build diagnostics from conflicts
-	var diagnostics []analysis.Diagnostic
+	diagnostics := make([]analysis.Diagnostic, 0, len(conflicts))
 	for _, c := range conflicts {
 		diagnostics = append(diagnostics, analysis.Diagnostic{
 			Pos:     c.pos,

--- a/diagnostic/engine.go
+++ b/diagnostic/engine.go
@@ -18,10 +18,6 @@
 package diagnostic
 
 import (
-	"fmt"
-	"go/token"
-	"strings"
-
 	"go.uber.org/nilaway/annotation"
 	"go.uber.org/nilaway/inference"
 	"go.uber.org/nilaway/util"
@@ -40,7 +36,8 @@ func NewEngine(pass *analysis.Pass) *Engine {
 }
 
 // Diagnostics generates diagnostics from the internally-stored conflicts. The grouping parameter
-// controls whether the conflicts with the same nil path are grouped together for concise reporting.
+// controls whether the conflicts with the same nil flow -- the part in the complete nil flow going
+// from a nilable source point to the conflict point -- are grouped together for concise reporting.
 func (e *Engine) Diagnostics(grouping bool) []analysis.Diagnostic {
 	conflicts := e.conflicts
 	if grouping {
@@ -117,167 +114,4 @@ func (e *Engine) AddOverconstraintConflict(nilReason, nonnilReason inference.Exp
 	}
 
 	e.conflicts = append(e.conflicts, c)
-}
-
-type conflict struct {
-	pos              token.Pos   // stores position where the error should be reported (note that this field is used only within the current, and should NOT be exported)
-	flow             nilFlow     // stores nil flow from source to dereference point
-	similarConflicts []*conflict // stores other conflicts that are similar to this one
-}
-
-type nilFlow struct {
-	nilPath    []node // stores nil path of the flow from nilable source to conflict point
-	nonnilPath []node // stores non-nil path of the flow from conflict point to dereference point
-}
-
-type node struct {
-	producerPosition token.Position
-	consumerPosition token.Position
-	producerRepr     string
-	consumerRepr     string
-}
-
-// newNode creates a new node object from the given producer and consumer Prestrings.
-// LocatedPrestring contains accurate information about the position and the reason why NilAway deemed that position
-// to be nilable. We use it if available, else we use the raw string representation available from the Prestring.
-func newNode(p annotation.Prestring, c annotation.Prestring) node {
-	nodeObj := node{}
-
-	// get producer representation string
-	if l, ok := p.(annotation.LocatedPrestring); ok {
-		nodeObj.producerPosition = l.Location
-		nodeObj.producerRepr = l.Contained.String()
-	} else if p != nil {
-		nodeObj.producerRepr = p.String()
-	}
-
-	// get consumer representation string
-	if l, ok := c.(annotation.LocatedPrestring); ok {
-		nodeObj.consumerPosition = l.Location
-		nodeObj.consumerRepr = l.Contained.String()
-	} else if c != nil {
-		nodeObj.consumerRepr = c.String()
-	}
-
-	return nodeObj
-}
-
-func (n *node) String() string {
-	posStr := "<no pos info>"
-	reasonStr := ""
-	if n.consumerPosition.IsValid() {
-		posStr = n.consumerPosition.String()
-	}
-
-	if len(n.producerRepr) > 0 {
-		reasonStr += n.producerRepr
-	}
-	if len(n.consumerRepr) > 0 {
-		if len(n.producerRepr) > 0 {
-			reasonStr += " "
-		}
-		reasonStr += n.consumerRepr
-	}
-
-	return fmt.Sprintf("\t-> %s: %s", posStr, reasonStr)
-}
-
-// addNilPathNode adds a new node to the nil path.
-func (n *nilFlow) addNilPathNode(p annotation.Prestring, c annotation.Prestring) {
-	nodeObj := newNode(p, c)
-
-	// Note that in the implication graph, we traverse backwards from the point of conflict to the source of nilability.
-	// Therefore, they are added in reverse order from what the program flow would look like. To account for this we
-	// prepend the new node to nilPath because we want to print the program flow in its correct (forward) order.
-	// TODO: instead of prepending here, we can reverse the nilPath slice while printing.
-	n.nilPath = append([]node{nodeObj}, n.nilPath...)
-}
-
-// addNonNilPathNode adds a new node to the non-nil path
-func (n *nilFlow) addNonNilPathNode(p annotation.Prestring, c annotation.Prestring) {
-	nodeObj := newNode(p, c)
-	n.nonnilPath = append(n.nonnilPath, nodeObj)
-}
-
-// String converts a nilFlow to a string representation, where each entry is the flow of the form: `<pos>: <reason>`
-func (n *nilFlow) String() string {
-	var allNodes []node
-	allNodes = append(allNodes, n.nilPath...)
-	allNodes = append(allNodes, n.nonnilPath...)
-
-	var flow []string
-	for _, nodeObj := range allNodes {
-		flow = append(flow, nodeObj.String())
-	}
-	return "\n" + strings.Join(flow, "\n")
-}
-
-func (c *conflict) String() string {
-	// build string for similar conflicts (i.e., conflicts with the same nil path)
-	similarConflictsString := ""
-	if len(c.similarConflicts) > 0 {
-		similarPos := make([]string, len(c.similarConflicts))
-		for i, s := range c.similarConflicts {
-			similarPos[i] = fmt.Sprintf("\"%s\"", s.flow.nonnilPath[len(s.flow.nonnilPath)-1].consumerPosition.String())
-		}
-
-		posString := strings.Join(similarPos[:len(similarPos)-1], ", ")
-		if len(similarPos) > 1 {
-			posString = posString + ", and "
-		}
-		posString = posString + similarPos[len(similarPos)-1]
-
-		similarConflictsString = fmt.Sprintf("\n\n(Same nil source could also cause potential nil panic(s) at %d "+
-			"other place(s): %s.)", len(c.similarConflicts), posString)
-	}
-
-	return fmt.Sprintf("Potential nil panic detected. Observed nil flow from "+
-		"source to dereference point: %s%s\n", c.flow.String(), similarConflictsString)
-}
-
-func (c *conflict) addSimilarConflict(conflict conflict) {
-	c.similarConflicts = append(c.similarConflicts, &conflict)
-}
-
-func pathString(nodes []node) string {
-	path := ""
-	for _, n := range nodes {
-		path += n.String()
-	}
-	return path
-}
-
-// groupConflicts groups conflicts with the same nil path together and update conflicts list.
-func groupConflicts(allConflicts []conflict) []conflict {
-	conflictsMap := make(map[string]int)  // key: nil path string, value: index in `allConflicts`
-	indicesToIgnore := make(map[int]bool) // indices of conflicts to be ignored from `allConflicts`, since they are grouped with other conflicts
-
-	for i, c := range allConflicts {
-		key := pathString(c.flow.nilPath)
-
-		// Handle the case of single assertion conflict separately
-		if len(c.flow.nilPath) == 0 && len(c.flow.nonnilPath) == 1 {
-			// This is the case of single assertion conflict. Use producer position and repr from the non-nil path as the key.
-			if p := c.flow.nonnilPath[0]; p.producerPosition.IsValid() {
-				key = p.producerPosition.String() + ": " + p.producerRepr
-			}
-		}
-
-		if existingConflictIndex, ok := conflictsMap[key]; ok {
-			// Grouping condition satisfied. Add new conflict to `similarConflicts` in `existingConflict`, and update groupedConflicts map
-			allConflicts[existingConflictIndex].addSimilarConflict(c)
-			indicesToIgnore[i] = true
-		} else {
-			conflictsMap[key] = i
-		}
-	}
-
-	// update groupedConflicts list with grouped groupedConflicts
-	var groupedConflicts []conflict
-	for i, c := range allConflicts {
-		if _, ok := indicesToIgnore[i]; !ok {
-			groupedConflicts = append(groupedConflicts, c)
-		}
-	}
-	return groupedConflicts
 }

--- a/diagnostic/nilflow.go
+++ b/diagnostic/nilflow.go
@@ -1,0 +1,104 @@
+package diagnostic
+
+import (
+	"fmt"
+	"go/token"
+	"strings"
+
+	"go.uber.org/nilaway/annotation"
+)
+
+type nilFlow struct {
+	nilPath    []node // stores nil path of the flow from nilable source to conflict point
+	nonnilPath []node // stores non-nil path of the flow from conflict point to dereference point
+}
+
+// addNilPathNode adds a new node to the nil path.
+func (n *nilFlow) addNilPathNode(p annotation.Prestring, c annotation.Prestring) {
+	nodeObj := newNode(p, c)
+
+	// Note that in the implication graph, we traverse backwards from the point of conflict to the source of nilability.
+	// Therefore, they are added in reverse order from what the program flow would look like. To account for this we
+	// prepend the new node to nilPath because we want to print the program flow in its correct (forward) order.
+	// TODO: instead of prepending here, we can reverse the nilPath slice while printing.
+	n.nilPath = append([]node{nodeObj}, n.nilPath...)
+}
+
+// addNonNilPathNode adds a new node to the non-nil path
+func (n *nilFlow) addNonNilPathNode(p annotation.Prestring, c annotation.Prestring) {
+	nodeObj := newNode(p, c)
+	n.nonnilPath = append(n.nonnilPath, nodeObj)
+}
+
+// String converts a nilFlow to a string representation, where each entry is the flow of the form: `<pos>: <reason>`
+func (n *nilFlow) String() string {
+	var allNodes []node
+	allNodes = append(allNodes, n.nilPath...)
+	allNodes = append(allNodes, n.nonnilPath...)
+
+	var flow []string
+	for _, nodeObj := range allNodes {
+		flow = append(flow, nodeObj.String())
+	}
+	return "\n" + strings.Join(flow, "\n")
+}
+
+type node struct {
+	producerPosition token.Position
+	consumerPosition token.Position
+	producerRepr     string
+	consumerRepr     string
+}
+
+// newNode creates a new node object from the given producer and consumer Prestrings.
+// LocatedPrestring contains accurate information about the position and the reason why NilAway deemed that position
+// to be nilable. We use it if available, else we use the raw string representation available from the Prestring.
+func newNode(p annotation.Prestring, c annotation.Prestring) node {
+	nodeObj := node{}
+
+	// get producer representation string
+	if l, ok := p.(annotation.LocatedPrestring); ok {
+		nodeObj.producerPosition = l.Location
+		nodeObj.producerRepr = l.Contained.String()
+	} else if p != nil {
+		nodeObj.producerRepr = p.String()
+	}
+
+	// get consumer representation string
+	if l, ok := c.(annotation.LocatedPrestring); ok {
+		nodeObj.consumerPosition = l.Location
+		nodeObj.consumerRepr = l.Contained.String()
+	} else if c != nil {
+		nodeObj.consumerRepr = c.String()
+	}
+
+	return nodeObj
+}
+
+func (n *node) String() string {
+	posStr := "<no pos info>"
+	reasonStr := ""
+	if n.consumerPosition.IsValid() {
+		posStr = n.consumerPosition.String()
+	}
+
+	if len(n.producerRepr) > 0 {
+		reasonStr += n.producerRepr
+	}
+	if len(n.consumerRepr) > 0 {
+		if len(n.producerRepr) > 0 {
+			reasonStr += " "
+		}
+		reasonStr += n.consumerRepr
+	}
+
+	return fmt.Sprintf("\t-> %s: %s", posStr, reasonStr)
+}
+
+func pathString(nodes []node) string {
+	path := ""
+	for _, n := range nodes {
+		path += n.String()
+	}
+	return path
+}

--- a/inference/engine.go
+++ b/inference/engine.go
@@ -60,7 +60,8 @@ func NewEngine(pass *analysis.Pass, diagnosticEngine conflictHandler) *Engine {
 	}
 }
 
-// InferredMap returns the current inferred annotation map.
+// InferredMap returns the current inferred annotation map, callers must treat this map as
+// read-only and do not directly modify it. Any further updates must be made via the Engine.
 func (e *Engine) InferredMap() *InferredMap {
 	return e.inferredMap
 }

--- a/inference/engine.go
+++ b/inference/engine.go
@@ -26,19 +26,25 @@ import (
 	"golang.org/x/tools/go/analysis"
 )
 
+// conflictHandler defines the interface that handles the conflicts encountered during inference.
+// This makes the inference engine independent of the diagnostic generation logic.
+type conflictHandler interface {
+	AddSingleAssertionConflict(trigger annotation.FullTrigger)
+	AddOverconstraintConflict(nilExplanation, nonnilExplanation ExplainedBool)
+}
+
 // Engine is the structure responsible for running the inference: it contains methods to run
 // various tasks for the inference and stores an internal map that can be obtained by calling
-// Engine.InferredMapWithDiagnostics.
+// Engine.InferredMap.
 type Engine struct {
 	pass *analysis.Pass
 	// inferredMap is the internal inferred map that the engine writes to, it is initialized on the
 	// construction of the engine and populated by the "Observe*" methods of the engine. Users
-	// should use the Engine.InferredMapWithDiagnostics() method to obtain the current inferred map.
+	// should use the Engine.InferredMap() method to obtain the current inferred map.
 	inferredMap *InferredMap
-	// conflicts stores conflicts encountered during the observations. It will be
-	// converted to diagnostics and returned along with the current inferred map whenever users
-	// request it.
-	conflicts *ConflictList
+	// diagnosticEngine receives all encountered conflicts during inference and eventually
+	// generates proper diagnostics from those conflicts.
+	diagnosticEngine conflictHandler
 	// controlledTriggersBySite stores the set of controlled triggers for each site if the site
 	// controls any triggers. This field is for internal use in the struct only and should not be
 	// accessed elsewhere.
@@ -46,18 +52,17 @@ type Engine struct {
 }
 
 // NewEngine constructs an inference engine that is ready to run inference.
-func NewEngine(pass *analysis.Pass) *Engine {
+func NewEngine(pass *analysis.Pass, diagnosticEngine conflictHandler) *Engine {
 	return &Engine{
-		pass:        pass,
-		inferredMap: newInferredMap(),
-		conflicts:   &ConflictList{},
+		pass:             pass,
+		inferredMap:      newInferredMap(),
+		diagnosticEngine: diagnosticEngine,
 	}
 }
 
-// InferredMapWithDiagnostics returns the current inferred annotation map and a slice of diagnostics
-// generated during inference.
-func (e *Engine) InferredMapWithDiagnostics() (*InferredMap, []analysis.Diagnostic) {
-	return e.inferredMap, e.conflicts.Diagnostics()
+// InferredMap returns the current inferred annotation map.
+func (e *Engine) InferredMap() *InferredMap {
+	return e.inferredMap
 }
 
 // ObserveUpstream imports all information from upstream dependencies. Specifically, it iterates
@@ -112,9 +117,9 @@ func (e *Engine) ObserveAnnotations(pkgAnnotations *annotation.ObservedMap, mode
 	pkgAnnotations.Range(func(key annotation.Key, isDeep bool, val bool) {
 		site := newPrimitiveSite(key, isDeep)
 		if val {
-			e.observeSiteExplanation(site, TrueBecauseAnnotation{Pos: site.Pos})
+			e.observeSiteExplanation(site, TrueBecauseAnnotation{AnnotationPos: site.Pos})
 		} else {
-			e.observeSiteExplanation(site, FalseBecauseAnnotation{Pos: site.Pos})
+			e.observeSiteExplanation(site, FalseBecauseAnnotation{AnnotationPos: site.Pos})
 		}
 	}, mode != NoInfer)
 }
@@ -240,7 +245,7 @@ func (e *Engine) buildFromSingleFullTrigger(trigger annotation.FullTrigger) {
 	case pKind == annotation.Always && cKind == annotation.Always:
 		// Producer always produces nilable value -> consumer always consumes nonnil value.
 		// We simply generate a failure for this case.
-		e.conflicts.AddSingleAssertionConflict(e.pass, trigger)
+		e.diagnosticEngine.AddSingleAssertionConflict(trigger)
 
 	case pKind == annotation.Always && (cKind == annotation.Conditional || cKind == annotation.DeepConditional):
 		// Producer always produces nilable value -> consumer unknown.
@@ -281,7 +286,7 @@ func (e *Engine) buildFromSingleFullTrigger(trigger annotation.FullTrigger) {
 // observeSiteExplanation augments inferred map with a definite value for the passed
 // site `site` - the definite value being given as the ExplainedBool `siteExplained`. Any conflicts
 // encountered during the inference are stored internally and will be available when the inferred
-// map is retrieved via `Engine.InferredMapWithDiagnostics`.There are three cases for what can happen when this
+// map is retrieved via `Engine.InferredMap`.There are three cases for what can happen when this
 // call is made. If the site is not already mapped to an InferredVal of any kind, then a mapping to
 // an DeterminedVal for the passed ExplainedBool is simply added - indicating that we now we have
 // fixed the value of this site. If the site is already mapped to an DeterminedVal, then we check
@@ -323,7 +328,7 @@ func (e *Engine) observeSiteExplanation(site primitiveSite, siteExplained Explai
 		if !v.Bool.Val() {
 			trueExplanation, falseExplanation = falseExplanation, trueExplanation
 		}
-		e.conflicts.AddOverconstraintConflict(trueExplanation, falseExplanation, e.pass)
+		e.diagnosticEngine.AddOverconstraintConflict(trueExplanation, falseExplanation)
 
 		// Even though we have a conflict, we still need to make sure to activate any controlled
 		// triggers that are waiting on this site, so that we would not miss processing any

--- a/inference/explained_bool.go
+++ b/inference/explained_bool.go
@@ -69,14 +69,18 @@ func (t TrueBecauseShallowConstraint) String() string {
 		t.ExternalAssertion.ConsumerRepr, t.ExternalAssertion.ProducerRepr)
 }
 
+// Pos is the position of underlying site.
 func (t TrueBecauseShallowConstraint) Pos() token.Pos {
 	return t.ExternalAssertion.Pos
 }
 
+// TriggerReprs returns the compact representation structs for the producer and consumer.
 func (t TrueBecauseShallowConstraint) TriggerReprs() (fmt.Stringer, fmt.Stringer) {
 	return t.ExternalAssertion.ProducerRepr, t.ExternalAssertion.ConsumerRepr
 }
 
+// DeeperReason returns another ExplainedBool that marks the deeper reason of this constraint.
+// It is only nonnil for deep constraints.
 func (t TrueBecauseShallowConstraint) DeeperReason() ExplainedBool {
 	return nil
 }
@@ -98,14 +102,18 @@ func (f FalseBecauseShallowConstraint) String() string {
 		f.ExternalAssertion.ProducerRepr, f.ExternalAssertion.ConsumerRepr)
 }
 
+// Pos is the position of underlying site.
 func (f FalseBecauseShallowConstraint) Pos() token.Pos {
 	return f.ExternalAssertion.Pos
 }
 
+// TriggerReprs returns the compact representation structs for the producer and consumer.
 func (f FalseBecauseShallowConstraint) TriggerReprs() (fmt.Stringer, fmt.Stringer) {
 	return f.ExternalAssertion.ProducerRepr, f.ExternalAssertion.ConsumerRepr
 }
 
+// DeeperReason returns another ExplainedBool that marks the deeper reason of this constraint.
+// It is only nonnil for deep constraints.
 func (f FalseBecauseShallowConstraint) DeeperReason() ExplainedBool {
 	return nil
 }
@@ -126,14 +134,18 @@ func (t TrueBecauseDeepConstraint) String() string {
 		t.InternalAssertion.ConsumerRepr, t.InternalAssertion.ProducerRepr, t.DeeperExplanation.String())
 }
 
+// Pos is the position of underlying site.
 func (t TrueBecauseDeepConstraint) Pos() token.Pos {
 	return t.InternalAssertion.Pos
 }
 
+// TriggerReprs returns the compact representation structs for the producer and consumer.
 func (t TrueBecauseDeepConstraint) TriggerReprs() (fmt.Stringer, fmt.Stringer) {
 	return t.InternalAssertion.ProducerRepr, t.InternalAssertion.ConsumerRepr
 }
 
+// DeeperReason returns another ExplainedBool that marks the deeper reason of this constraint.
+// It is only nonnil for deep constraints.
 func (t TrueBecauseDeepConstraint) DeeperReason() ExplainedBool {
 	return t.DeeperExplanation
 }
@@ -154,14 +166,18 @@ func (f FalseBecauseDeepConstraint) String() string {
 		f.InternalAssertion.ProducerRepr, f.InternalAssertion.ConsumerRepr, f.DeeperExplanation.String())
 }
 
+// Pos is the position of underlying site.
 func (f FalseBecauseDeepConstraint) Pos() token.Pos {
 	return f.InternalAssertion.Pos
 }
 
+// TriggerReprs returns the compact representation structs for the producer and consumer.
 func (f FalseBecauseDeepConstraint) TriggerReprs() (fmt.Stringer, fmt.Stringer) {
 	return f.InternalAssertion.ProducerRepr, f.InternalAssertion.ConsumerRepr
 }
 
+// DeeperReason returns another ExplainedBool that marks the deeper reason of this constraint.
+// It is only nonnil for deep constraints.
 func (f FalseBecauseDeepConstraint) DeeperReason() ExplainedBool {
 	return f.DeeperExplanation
 }
@@ -177,14 +193,18 @@ func (TrueBecauseAnnotation) String() string {
 	return "NILABLE because it is annotated as so"
 }
 
+// Pos is the position of underlying site.
 func (t TrueBecauseAnnotation) Pos() token.Pos {
 	return t.AnnotationPos
 }
 
+// TriggerReprs simply returns nil, nil since this constraint is the result of an annotation.
 func (TrueBecauseAnnotation) TriggerReprs() (fmt.Stringer, fmt.Stringer) {
 	return nil, nil
 }
 
+// DeeperReason returns another ExplainedBool that marks the deeper reason of this constraint.
+// It is only nonnil for deep constraints.
 func (TrueBecauseAnnotation) DeeperReason() ExplainedBool {
 	return nil
 }
@@ -200,14 +220,18 @@ func (FalseBecauseAnnotation) String() string {
 	return "NONNIL because it is annotated as so"
 }
 
+// Pos is the position of underlying site.
 func (f FalseBecauseAnnotation) Pos() token.Pos {
 	return f.AnnotationPos
 }
 
+// TriggerReprs simply returns nil, nil since this constraint is the result of an annotation.
 func (FalseBecauseAnnotation) TriggerReprs() (fmt.Stringer, fmt.Stringer) {
 	return nil, nil
 }
 
+// DeeperReason returns another ExplainedBool that marks the deeper reason of this constraint.
+// It is only nonnil for deep constraints.
 func (f FalseBecauseAnnotation) DeeperReason() ExplainedBool {
 	return nil
 }


### PR DESCRIPTION
We now have enough logic in our conflict handling logic (i.e., collecting conflicts and generating user-friendly diagnostics from them). For easier maintenance and future development, this PR separates the logic out from the inference package.

After this PR, we will have three major components in NilAway: analyzer engine(that generates full triggers), inference engine (that generates inferred maps and conflicts), and the diagnostic engine (that collects the conflicts and generate friendly diagnostics).

The top-level accumulation analyzer will still orchestrate these three engines, where the diagnostic engine acts like a conflict collector for both no-infer (`checkErrors`) and full-infer (`inference.Engine`) mode.

This PR also contains a few simple refactors and optimizations for the diagnostic engine for readability and performance.

Closes #55