### PR TITLE
Use ordered map for inferred map

### DIFF
--- a/inference/engine.go
+++ b/inference/engine.go
@@ -84,7 +84,7 @@ func (e *Engine) ObserveUpstream() {
 		if !ok {
 			continue
 		}
-		importedMap.Range(func(site primitiveSite, val InferredVal) bool {
+		importedMap.OrderedRange(func(site primitiveSite, val InferredVal) bool {
 			switch v := val.(type) {
 			case *DeterminedVal:
 				// Fix as an Explained site any sites that `otherMap` knows are explained
@@ -108,7 +108,7 @@ func (e *Engine) ObserveUpstream() {
 	}
 
 	// copy imported maps into upstreamMapping field
-	e.inferredMap.Range(func(site primitiveSite, val InferredVal) bool {
+	e.inferredMap.OrderedRange(func(site primitiveSite, val InferredVal) bool {
 		e.inferredMap.upstreamMapping[site] = val.copy()
 		return true
 	})

--- a/inference/inferred_map.go
+++ b/inference/inferred_map.go
@@ -111,9 +111,10 @@ func (i *InferredMap) Export(pass *analysis.Pass) {
 	// like to export.
 	exported := orderedmap.New[primitiveSite, InferredVal]()
 	sitesToExport := i.chooseSitesToExport()
-	i.mapping.OrderedRange(func(site primitiveSite, val InferredVal) bool {
+	for _, p := range i.mapping.Pairs {
+		site, val := p.Key, p.Value
 		if !sitesToExport[site] {
-			return true
+			continue
 		}
 
 		if upstreamVal, upstreamPresent := i.upstreamMapping[site]; upstreamPresent {
@@ -124,8 +125,7 @@ func (i *InferredMap) Export(pass *analysis.Pass) {
 		} else {
 			exported.Store(site, val)
 		}
-		return true
-	})
+	}
 
 	if len(exported.Pairs) > 0 {
 		// We do not need to encode the primitivizer since it is just a helper for the analysis of
@@ -138,7 +138,6 @@ func (i *InferredMap) Export(pass *analysis.Pass) {
 
 // GobEncode encodes the inferred map via gob encoding.
 func (i *InferredMap) GobEncode() ([]byte, error) {
-	// Then, just encode the slim version of the map.
 	var buf bytes.Buffer
 	enc := gob.NewEncoder(&buf)
 	if err := enc.Encode(i.mapping); err != nil {

--- a/inference/inferred_map_test.go
+++ b/inference/inferred_map_test.go
@@ -41,6 +41,27 @@ func TestEncoding_Size(t *testing.T) {
 	)
 }
 
+func TestEncoding_Deterministic(t *testing.T) {
+	t.Parallel()
+
+	m := newBigInferredMap()
+	var previous []byte
+
+	// Encode the inferred map 10 times and check that the result is always the same.
+	for i := 0; i < 10; i++ {
+		var buf bytes.Buffer
+		err := gob.NewEncoder(&buf).Encode(m)
+		require.NoError(t, err)
+		require.NotEmpty(t, buf.Bytes())
+
+		if len(previous) == 0 {
+			previous = buf.Bytes()
+			continue
+		}
+		require.Equal(t, previous, buf.Bytes())
+	}
+}
+
 func TestDecoding(t *testing.T) {
 	t.Parallel()
 

--- a/inference/primitive.go
+++ b/inference/primitive.go
@@ -144,7 +144,7 @@ func newPrimitivizer(pass *analysis.Pass) *primitivizer {
 			continue
 		}
 
-		importedMap.Range(func(site primitiveSite, _ InferredVal) bool {
+		importedMap.OrderedRange(func(site primitiveSite, _ InferredVal) bool {
 			if site.ObjectPath == "" {
 				return true
 			}


### PR DESCRIPTION
In #66, we have created an ordered map data structure and used it for storing implication egdes.

This PR further refactors the `inference.InferredMap` to use the ordered map for deterministic evaluation of inferred maps.

This PR also adds another test for inferred map to check if the encoded binaries are the same over 10 iterations to catch nondeterminism in future development.

Depends on PR #66.