### PR TITLE
Fix panic in handling global variables

### DIFF
--- a/assertion/global/globalvarinit.go
+++ b/assertion/global/globalvarinit.go
@@ -124,7 +124,7 @@ func getGlobalProducer(pass *analysis.Pass, valspec *ast.ValueSpec, lid int, rid
 func getProducerForVar(pass *analysis.Pass, rhs *ast.Ident) *annotation.ProduceTrigger {
 	rhsVar, ok := pass.TypesInfo.ObjectOf(rhs).(*types.Var)
 	if !ok || !annotation.VarIsGlobal(rhsVar) {
-		// If rhs is not a global variable, we ignore it.
+		// If rhs is not a global variable (e.g., a constant), we ignore it.
 		return nil
 	}
 

--- a/assertion/global/globalvarinit.go
+++ b/assertion/global/globalvarinit.go
@@ -139,7 +139,11 @@ func getProducerForVar(pass *analysis.Pass, rhs *ast.Ident) *annotation.ProduceT
 }
 
 func getProducerForField(pass *analysis.Pass, rhs *ast.Ident) *annotation.ProduceTrigger {
-	rhsVar := pass.TypesInfo.ObjectOf(rhs).(*types.Var)
+	rhsVar, ok := pass.TypesInfo.ObjectOf(rhs).(*types.Var)
+	if !ok {
+		// If rhs is not a variable (e.g., a constant from an upstream package), we ignore it.
+		return nil
+	}
 	return &annotation.ProduceTrigger{
 		Annotation: annotation.FldRead{
 			TriggerIfNilable: annotation.TriggerIfNilable{

--- a/assertion/global/globalvarinit.go
+++ b/assertion/global/globalvarinit.go
@@ -109,10 +109,9 @@ func getGlobalProducer(pass *analysis.Pass, valspec *ast.ValueSpec, lid int, rid
 				Annotation: annotation.ConstNil{},
 				Expr:       rhs,
 			}
-		} else {
-			// if rhs is another global
-			return getProducerForVar(pass, rhs)
 		}
+		// if rhs is another global
+		return getProducerForVar(pass, rhs)
 	case *ast.SelectorExpr:
 		// Struct field access
 		return getProducerForField(pass, rhs.Sel)

--- a/testdata/src/go.uber.org/globalvars/globalvarinit.go
+++ b/testdata/src/go.uber.org/globalvars/globalvarinit.go
@@ -19,6 +19,8 @@ These tests check if the nonnil global variables are initialized
 */
 package globalvars
 
+import "go.uber.org/globalvars/upstream"
+
 var x = 3
 
 // This should throw an error since it is not initialized
@@ -97,13 +99,11 @@ func foo() *int {
 
 // Now we test a corner case where a constant is assigned to a global variable.
 
-// ErrorNo is an uint32 type that implements error interface.
-type ErrorNo uint32
-
-func (e ErrorNo) Error() string { return "error!" }
-
 // ErrorNoFailure is a constant marking a failure.
-const ErrorNoFailure = ErrorNo(42)
+const ErrorNoFailure = upstream.ErrorNo(42)
 
 // Now, we can assign the (nonnil) constant ErrorNoFailure to a global variable.
 var invalidSyscall error = ErrorNoFailure
+
+// Assign it again, but from an upstream package.
+var invalidSyscallUpstream error = upstream.ErrorNoFailure

--- a/testdata/src/go.uber.org/globalvars/globalvarinit.go
+++ b/testdata/src/go.uber.org/globalvars/globalvarinit.go
@@ -97,7 +97,7 @@ func foo() *int {
 	return nil
 }
 
-// Now we test a corner case where a constant is assigned to a global variable.
+// Below test checks when a constant is assigned to a global variable.
 
 // ErrorNoFailure is a constant marking a failure.
 const ErrorNoFailure = upstream.ErrorNo(42)

--- a/testdata/src/go.uber.org/globalvars/globalvarinit.go
+++ b/testdata/src/go.uber.org/globalvars/globalvarinit.go
@@ -94,3 +94,16 @@ func foo() *int {
 	print(multiNonNil, multiNil, nonnilMethod, assignedNilable)
 	return nil
 }
+
+// Now we test a corner case where a constant is assigned to a global variable.
+
+// ErrorNo is an uint32 type that implements error interface.
+type ErrorNo uint32
+
+func (e ErrorNo) Error() string { return "error!" }
+
+// ErrorNoFailure is a constant marking a failure.
+const ErrorNoFailure = ErrorNo(42)
+
+// Now, we can assign the (nonnil) constant ErrorNoFailure to a global variable.
+var invalidSyscall error = ErrorNoFailure

--- a/testdata/src/go.uber.org/globalvars/upstream/upstream.go
+++ b/testdata/src/go.uber.org/globalvars/upstream/upstream.go
@@ -1,0 +1,23 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upstream
+
+// ErrorNo is an uint32 type that implements error interface.
+type ErrorNo uint32
+
+func (e ErrorNo) Error() string { return "error!" }
+
+// ErrorNoFailure is a constant marking a failure.
+const ErrorNoFailure = ErrorNo(42)


### PR DESCRIPTION
This PR fixes two panics due to the assumption that the RHS of the global variable assignments are always variables, which isn't true when RHS is a constant (either defined in the current package, or referenced from upstream package)

We also take this opportunity to refactor the code a little bit to be more readable and maintainable.

Depends on #68