### PR TITLE
Fix panics when ranging over arrays

### DIFF
--- a/testdata/src/go.uber.org/arrays/arrays.go
+++ b/testdata/src/go.uber.org/arrays/arrays.go
@@ -162,7 +162,7 @@ type blocks [42]int
 
 type blockSlice []int
 
-// nonnil(aPtr) nonnil(a) nonnil(bPtr) nonnil(b)
+// nonnil(aPtr, a, bPtr, b)
 func testArrayAliasPtr(aPtr *blocks, a blocks, bPtr *blockSlice, b blockSlice) {
 	// blocks is an alias for arrays, and the [language specs] states that it is possible to range
 	// over an array or a pointer to an array. Interestingly, you cannot range over a pointer to

--- a/testdata/src/go.uber.org/arrays/arrays.go
+++ b/testdata/src/go.uber.org/arrays/arrays.go
@@ -155,3 +155,32 @@ func test2dArrayAssignment() *int {
 	twodArr = nilableTwodArr // TODO: an error should be reported here since we are assigning a (default) deeply nilable array 'nilableTwodArr' into a declared deeply nonnil array 'twodArr'
 	return twodArr[0][0]     //want "returned"
 }
+
+// Test a case where we declare a type alias for an array and then range over it.
+
+type blocks [42]int
+
+type blockSlice []int
+
+// nonnil(aPtr) nonnil(a) nonnil(bPtr) nonnil(b)
+func testArrayAliasPtr(aPtr *blocks, a blocks, bPtr *blockSlice, b blockSlice) {
+	// blocks is an alias for arrays, and the [language specs] states that it is possible to range
+	// over an array or a pointer to an array. Interestingly, you cannot range over a pointer to
+	// a slice.
+	// [language specs]: https://go.dev/ref/spec#RangeClause
+
+	// Range over a pointer to array alias. OK
+	for range aPtr {
+	}
+
+	// Range over an array alias. OK
+	for range a {
+	}
+
+	// Range over a pointer to slice alias. Disallowed!
+	// for range bPtr {}
+
+	// Range over a slice alias. OK
+	for range b {
+	}
+}

--- a/util/util.go
+++ b/util/util.go
@@ -72,11 +72,11 @@ func TypeIsSlice(t types.Type) bool {
 // TypeIsDeeplyArray returns true if `t` is of array type, including
 // transitively through Named types
 func TypeIsDeeplyArray(t types.Type) bool {
-	if _, ok := t.(*types.Array); ok {
+	switch tt := UnwrapPtr(t).(type) {
+	case *types.Array:
 		return true
-	}
-	if t, ok := t.(*types.Named); ok {
-		return TypeIsDeeplyArray(t.Underlying())
+	case *types.Named:
+		return TypeIsDeeplyArray(tt.Underlying())
 	}
 	return false
 }


### PR DESCRIPTION
This PR fixes a case where we are not unwrapping the pointer when checking if the range operand is deeply an array. This is causing panics since we have a safeguard on unknown types being ranged over, for example:

```
backpropagation across node (/opt/homebrew/Cellar/go/1.21.0/libexec/src/runtime/proc_test.go:599:6) of type *ast.AssignStmt failed for reason: unrecognized type of rhs in range statement: *[8192]byte
```

Depends on #71