### PR TITLE
Fix backprop panic when ranging over a generic slice

### DIFF
--- a/assertion/function/assertiontree/backprop.go
+++ b/assertion/function/assertiontree/backprop.go
@@ -404,6 +404,13 @@ func backpropAcrossRange(rootNode *RootAssertionNode, lhs []ast.Expr, rhs ast.Ex
 			// still result in deeply produced lhs values
 			return nil
 		}
+		if _, ok := rhsType.(*types.TypeParam); ok {
+			// We could be ranging over a generic slice (where rhsType is a *types.TypeParam) but
+			// we do not handle generics yet. Here we just assume generic slices are all deeply
+			// nonnil, i.e., we return nil producers for the elements.
+			// TODO: handle that.
+			return nil
+		}
 		return fmt.Errorf("unrecognized type of rhs in range statement: %s", rootNode.Pass().TypesInfo.Types[rhs].Type)
 	default:
 		return fmt.Errorf("unexpected LHS found in assignment to 'range' operator")

--- a/testdata/src/go.uber.org/generics/generics.go
+++ b/testdata/src/go.uber.org/generics/generics.go
@@ -109,3 +109,18 @@ func defineInFunc(p1 any, p2 fooT1) {
 	// underlying type is the same.
 	_ = GenericStruct[*A, int64, *int](p2)
 }
+
+// Test for a case where we have a generic slice.
+func GenericSlice[S ~[]*E, E any](s S) int {
+	for _, element := range s {
+		// TODO: we do not really handle generics for now, so the elements inside any
+		//  generic slices are considered nonnil. We should handle that properly.
+		print(*element) // False negative.
+	}
+	return -1
+}
+
+func callGenericSlice() {
+	a := []*int{nil, nil, nil}
+	GenericSlice(a)
+}


### PR DESCRIPTION
This PR fixes a panic when the code is ranging over a generic slice due to our safeguard on unhandled types.

Since we do not have proper support on generics yet, we are treating all generics slices as always being deeply nonnil. 

Depends on #72