### PR TITLE
Extend support for `Equal` in trusted func framework

### DIFF
--- a/assertion/function/assertiontree/trusted_func.go
+++ b/assertion/function/assertiontree/trusted_func.go
@@ -183,7 +183,7 @@ var requireComparators action = func(call *ast.CallExpr, startIndex int, pass *a
 
 	// We now find the actual and expected expressions, where expected is the constant value that actual expression is
 	// compared against. For example, in `Equal(1, len(s))`, expected is 1, and actual is `len(s)`. However, the position
-	// pf the actual and expected expressions can be swapped, e.g., `Equal(len(s), 1)`. We handle both cases below,
+	// of the actual and expected expressions can be swapped, e.g., `Equal(len(s), 1)`. We handle both cases below,
 	// searching for the slice expression, the other will be treated as length expression.
 
 	// The constant (enum) values below represent the possible values of the expected expression

--- a/assertion/function/assertiontree/trusted_func.go
+++ b/assertion/function/assertiontree/trusted_func.go
@@ -164,10 +164,8 @@ func newNilBinaryExpr(arg ast.Expr, op token.Token) *ast.BinaryExpr {
 	}
 }
 
-// requireComparators handles a slightly more sophisticated case for asserting the length of a
-// slice, e.g., length of a slice is greater than 0 implies the slice is not nil.
-// We currently support:
-// - slice length comparison (e.g., `Equal(1, len(s))`) and
+// requireComparators handles slightly more sophisticated cases of comparisons. We currently support:
+// - slice length comparison (e.g., `Equal(1, len(s))`, implying len(s) > 0, meaning s is nonnil)
 // - nil comparison (e.g., `Equal(nil, err)`).
 var requireComparators action = func(call *ast.CallExpr, startIndex int, pass *analysis.Pass) any {
 	// Comparator function calls must have at least two arguments.

--- a/testdata/src/go.uber.org/testing/trustedfuncs.go
+++ b/testdata/src/go.uber.org/testing/trustedfuncs.go
@@ -775,3 +775,26 @@ func testLen(t *testing.T, i int, a []int) {
 		print(a[0]) //want "sliced into"
 	}
 }
+
+// import "go.uber.org/testing/github.com/stretchr/testify/suite"
+//
+// type S struct {
+// 	suite.Suite
+// }
+//
+// type myErr struct{}
+//
+// func (myErr) Error() string { return "myErr message" }
+//
+// func ret() (*int, error) {
+// 	if false {
+// 		return nil, &myErr{}
+// 	}
+// 	return new(int), nil
+// }
+//
+// func (s *S) test() {
+// 	v, err := ret()
+// 	s.Equal(nil, err)
+// 	_ = *v // False positive reported here
+// }

--- a/testdata/src/go.uber.org/testing/trustedfuncs.go
+++ b/testdata/src/go.uber.org/testing/trustedfuncs.go
@@ -605,7 +605,7 @@ func testLongerAccessPath(w *W) any {
 }
 
 // nilable(a)
-func testEqual(t *testing.T, i int, a []int) {
+func testEqual(t *testing.T, i int, a []int) interface{} {
 	switch i {
 	case 0:
 		require.Equal(t, len(a), 1)
@@ -642,7 +642,51 @@ func testEqual(t *testing.T, i int, a []int) {
 	case 7:
 		require.Equalf(t, 1, len(a), "mymsg: %s", "arg")
 		print(a[0])
+
+	case 8:
+		x, err := errs()
+		require.Equal(t, err, nil)
+		return x
+
+	case 9:
+		x, err := errs()
+		require.Equal(t, nil, err)
+		return x
+
+	case 10:
+		x, err := errs()
+		require.NotEqual(t, err, nil)
+		return x //want "result 0 of `errs.*` lacking guarding"
+
+	case 11:
+		x, err := errs()
+		require.NotEqual(t, nil, err)
+		return x //want "result 0 of `errs.*` lacking guarding"
+
+	// test with suite.Suite
+	case 12:
+		x, err := errs()
+		s := &testSetupEmbeddedDepth1{}
+		s.Equal(nil, err)
+		return x
+
+	case 13:
+		x, err := errs()
+		s := &testSetupEmbeddedDepth1{}
+		s.NotEqual(err, nil)
+		return x //want "result 0 of `errs.*` lacking guarding"
+
+	case 14:
+		var x *int
+		require.NotEqual(t, nil, x)
+		print(*x)
+
+	case 15:
+		var x *int
+		require.Equal(t, nil, x)
+		print(*x) //want "unassigned variable `x` dereferenced"
 	}
+	return 0
 }
 
 // nilable(a)
@@ -775,26 +819,3 @@ func testLen(t *testing.T, i int, a []int) {
 		print(a[0]) //want "sliced into"
 	}
 }
-
-// import "go.uber.org/testing/github.com/stretchr/testify/suite"
-//
-// type S struct {
-// 	suite.Suite
-// }
-//
-// type myErr struct{}
-//
-// func (myErr) Error() string { return "myErr message" }
-//
-// func ret() (*int, error) {
-// 	if false {
-// 		return nil, &myErr{}
-// 	}
-// 	return new(int), nil
-// }
-//
-// func (s *S) test() {
-// 	v, err := ret()
-// 	s.Equal(nil, err)
-// 	_ = *v // False positive reported here
-// }

--- a/testdata/src/go.uber.org/testing/trustedfuncs.go
+++ b/testdata/src/go.uber.org/testing/trustedfuncs.go
@@ -643,6 +643,31 @@ func testEqual(t *testing.T, i int, a []int) interface{} {
 		require.Equalf(t, 1, len(a), "mymsg: %s", "arg")
 		print(a[0])
 
+	// The NotEqual variant should also be supported.
+	case 81:
+		require.NotEqual(t, len(a), 0)
+		print(a[0])
+
+	case 83:
+		// Swapping the positions of args should not affect the analysis.
+		require.NotEqual(t, 0, len(a))
+		print(a[0])
+
+	case 84:
+		// Using a constant is also OK.
+		const zero = 0
+		require.NotEqual(t, zero, len(a))
+
+	case 82:
+		// `len(a) != 1` implies that len(a) can be 0, hence we should report an error.
+		require.NotEqual(t, len(a), 1)
+		print(a[0]) //want "sliced into"
+
+	case 85:
+		require.NotEqual(t, len(a), 1)
+		print(a[0]) //want "sliced into"
+
+	// Equal/NotEqual with nil should also be supported.
 	case 8:
 		x, err := errs()
 		require.Equal(t, err, nil)

--- a/testdata/src/go.uber.org/testing/trustedfuncs.go
+++ b/testdata/src/go.uber.org/testing/trustedfuncs.go
@@ -710,6 +710,16 @@ func testEqual(t *testing.T, i int, a []int) interface{} {
 		var x *int
 		require.Equal(t, nil, x)
 		print(*x) //want "unassigned variable `x` dereferenced"
+
+	case 16:
+		var x *int
+		require.Equal(t, x, nil)
+		print(*x) //want "unassigned variable `x` dereferenced"
+
+	case 17:
+		var x *int
+		require.NotEqual(t, x, nil)
+		print(*x)
 	}
 	return 0
 }


### PR DESCRIPTION
`Equal` support was limited to only handling slice length comparison (e.g., `Equal(0, len(s))`). This PR extends this  `Equal` support also handle nil comparisons (e.g., `Equal(nil, err)`). Specifically, this PR makes the following changes:
- Refactors existing `requireComparators` code to accommodate the extension
- Add support for nil comparison in `requireComparators`
- Adds test cases for nil comparison
- Adds `NotEqual` in trusted funcs list and specific test cases for the slice comparison case as well


[Closes #64 ]