### PR TITLE
Add support for `Empty` in trusted functions framework

### DIFF
--- a/assertion/function/assertiontree/trusted_func.go
+++ b/assertion/function/assertiontree/trusted_func.go
@@ -243,13 +243,6 @@ var requireComparators action = func(call *ast.CallExpr, startIndex int, pass *a
 				actualExprIndex = argIndex
 				expectedExprValue = _nil
 			}
-		case *ast.Ident:
-			// Check if the expression is `nil`.
-			if expr.Name == "nil" {
-				actualExpr = call.Args[startIndex+1-argIndex]
-				actualExprIndex = argIndex
-				expectedExprValue = _nil
-			}
 		}
 	}
 

--- a/assertion/function/assertiontree/trusted_func.go
+++ b/assertion/function/assertiontree/trusted_func.go
@@ -353,16 +353,16 @@ var requireZeroComparators action = func(call *ast.CallExpr, index int, pass *an
 		return nil
 	}
 
-	exprType := util.TypeOf(pass, expr)
-
-	if util.TypeIsDeeplyPtr(exprType) || util.TypeIsErrorType(exprType) {
+	exprType := pass.TypesInfo.TypeOf(expr).Underlying()
+	switch t := exprType.(type) {
+	case *types.Pointer, *types.Interface:
 		return generateComparators(call, expr, index, _nil)
-	}
-	if util.TypeIsDeeplySlice(exprType) || util.TypeIsDeeplyMap(exprType) || util.TypeIsDeeplyChan(exprType) {
+	case *types.Slice, *types.Map, *types.Chan:
 		return generateComparators(call, expr, index, _zero)
-	}
-	if b, ok := exprType.(*types.Basic); ok && b.Kind() == types.Bool {
-		return generateComparators(call, expr, index, _false)
+	case *types.Basic:
+		if t.Kind() == types.Bool {
+			return generateComparators(call, expr, index, _false)
+		}
 	}
 
 	return nil

--- a/assertion/function/assertiontree/trusted_func.go
+++ b/assertion/function/assertiontree/trusted_func.go
@@ -243,6 +243,13 @@ var requireComparators action = func(call *ast.CallExpr, startIndex int, pass *a
 				actualExprIndex = argIndex
 				expectedExprValue = _nil
 			}
+		case *ast.Ident:
+			// Check if the expression is `nil`.
+			if expr.Name == "nil" {
+				actualExpr = call.Args[startIndex+1-argIndex]
+				actualExprIndex = argIndex
+				expectedExprValue = _nil
+			}
 		}
 	}
 

--- a/testdata/src/go.uber.org/testing/github.com/stretchr/testify/assert/assert.go
+++ b/testdata/src/go.uber.org/testing/github.com/stretchr/testify/assert/assert.go
@@ -175,3 +175,15 @@ func (*Assertions) Len(object interface{}, length int, msgAndArgs ...interface{}
 
 // nilable(object)
 func (*Assertions) Lenf(object interface{}, length int, msg string, args ...interface{}) {}
+
+// nilable(object)
+func Empty(object interface{}, msgAndArgs ...interface{}) bool { return true }
+
+// nilable(object)
+func Emptyf(object interface{}, msg string, args ...interface{}) bool { return true }
+
+// nilable(object)
+func NotEmpty(object interface{}, msgAndArgs ...interface{}) bool { return true }
+
+// nilable(object)
+func NotEmptyf(object interface{}, msg string, args ...interface{}) bool { return true }

--- a/testdata/src/go.uber.org/testing/github.com/stretchr/testify/assert/assert.go
+++ b/testdata/src/go.uber.org/testing/github.com/stretchr/testify/assert/assert.go
@@ -101,6 +101,18 @@ func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) 
 func Lenf(t TestingT, object interface{}, length int, msg string, args ...interface{}) {}
 
 // nilable(object)
+func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool { return true }
+
+// nilable(object)
+func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) bool { return true }
+
+// nilable(object)
+func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool { return true }
+
+// nilable(object)
+func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) bool { return true }
+
+// nilable(object)
 func (*Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) bool { return true }
 
 // nilable(object)
@@ -177,13 +189,13 @@ func (*Assertions) Len(object interface{}, length int, msgAndArgs ...interface{}
 func (*Assertions) Lenf(object interface{}, length int, msg string, args ...interface{}) {}
 
 // nilable(object)
-func Empty(object interface{}, msgAndArgs ...interface{}) bool { return true }
+func (*Assertions) Empty(object interface{}, msgAndArgs ...interface{}) bool { return true }
 
 // nilable(object)
-func Emptyf(object interface{}, msg string, args ...interface{}) bool { return true }
+func (*Assertions) Emptyf(object interface{}, msg string, args ...interface{}) bool { return true }
 
 // nilable(object)
-func NotEmpty(object interface{}, msgAndArgs ...interface{}) bool { return true }
+func (*Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) bool { return true }
 
 // nilable(object)
-func NotEmptyf(object interface{}, msg string, args ...interface{}) bool { return true }
+func (*Assertions) NotEmptyf(object interface{}, msg string, args ...interface{}) bool { return true }

--- a/testdata/src/go.uber.org/testing/github.com/stretchr/testify/require/require.go
+++ b/testdata/src/go.uber.org/testing/github.com/stretchr/testify/require/require.go
@@ -177,3 +177,15 @@ func (*Assertions) Len(object interface{}, length int, msgAndArgs ...interface{}
 
 // nilable(object)
 func (*Assertions) Lenf(object interface{}, length int, msg string, args ...interface{}) {}
+
+// nilable(object)
+func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool { return true }
+
+// nilable(object)
+func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) bool { return true }
+
+// nilable(object)
+func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool { return true }
+
+// nilable(object)
+func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) bool { return true }

--- a/testdata/src/go.uber.org/testing/trustedfuncs.go
+++ b/testdata/src/go.uber.org/testing/trustedfuncs.go
@@ -854,3 +854,26 @@ func testLen(t *testing.T, i int, a []int) {
 		print(a[0]) //want "sliced into"
 	}
 }
+
+// import "go.uber.org/testing/github.com/stretchr/testify/suite"
+//
+// type S struct {
+// 	suite.Suite
+// }
+//
+// type myErr struct{}
+//
+// func (myErr) Error() string { return "myErr message" }
+//
+// func ret() (*int, error) {
+// 	if false {
+// 		return nil, &myErr{}
+// 	}
+// 	return new(int), nil
+// }
+//
+// func (s *S) test() {
+// 	v, err := ret()
+// 	s.Equal(nil, err)
+// 	_ = *v // False positive reported here
+// }

--- a/testdata/src/go.uber.org/testing/trustedfuncs.go
+++ b/testdata/src/go.uber.org/testing/trustedfuncs.go
@@ -643,6 +643,31 @@ func testEqual(t *testing.T, i int, a []int) interface{} {
 		require.Equalf(t, 1, len(a), "mymsg: %s", "arg")
 		print(a[0])
 
+	// The NotEqual variant should also be supported.
+	case 81:
+		require.NotEqual(t, len(a), 0)
+		print(a[0])
+
+	case 83:
+		// Swapping the positions of args should not affect the analysis.
+		require.NotEqual(t, 0, len(a))
+		print(a[0])
+
+	case 84:
+		// Using a constant is also OK.
+		const zero = 0
+		require.NotEqual(t, zero, len(a))
+
+	case 82:
+		// `len(a) != 1` implies that len(a) can be 0, hence we should report an error.
+		require.NotEqual(t, len(a), 1)
+		print(a[0]) //want "sliced into"
+
+	case 85:
+		require.NotEqual(t, len(a), 1)
+		print(a[0]) //want "sliced into"
+
+	// Equal/NotEqual with nil should also be supported.
 	case 8:
 		x, err := errs()
 		require.Equal(t, err, nil)

--- a/testdata/src/go.uber.org/testing/trustedfuncs.go
+++ b/testdata/src/go.uber.org/testing/trustedfuncs.go
@@ -854,3 +854,15 @@ func testLen(t *testing.T, i int, a []int) {
 		print(a[0]) //want "sliced into"
 	}
 }
+
+// nilable(a)
+func testEmpty(t *testing.T, i int, a []int) {
+	switch i {
+	case 0:
+		require.Empty(t, 0, len(a))
+		print(a[0]) //want "sliced into"
+	case 1:
+		require.NotEmpty(t, 0, len(a))
+		print(a[0])
+	}
+}

--- a/testdata/src/go.uber.org/testing/trustedfuncs.go
+++ b/testdata/src/go.uber.org/testing/trustedfuncs.go
@@ -710,6 +710,16 @@ func testEqual(t *testing.T, i int, a []int) interface{} {
 		var x *int
 		require.Equal(t, nil, x)
 		print(*x) //want "unassigned variable `x` dereferenced"
+
+	case 16:
+		var x *int
+		require.Equal(t, x, nil)
+		print(*x) //want "unassigned variable `x` dereferenced"
+
+	case 17:
+		var x *int
+		require.NotEqual(t, x, nil)
+		print(*x)
 	}
 	return 0
 }

--- a/testdata/src/go.uber.org/testing/trustedfuncs.go
+++ b/testdata/src/go.uber.org/testing/trustedfuncs.go
@@ -856,13 +856,73 @@ func testLen(t *testing.T, i int, a []int) {
 }
 
 // nilable(a)
-func testEmpty(t *testing.T, i int, a []int) {
+func testEmpty(t *testing.T, i int, a []int, mp map[int]*int) interface{} {
 	switch i {
+	// zero value with slice len check should be supported
 	case 0:
-		require.Empty(t, 0, len(a))
+		require.Empty(t, a)
 		print(a[0]) //want "sliced into"
 	case 1:
-		require.NotEmpty(t, 0, len(a))
+		require.NotEmpty(t, a)
 		print(a[0])
+
+	// zero value of pointer check should be supported
+	case 2:
+		var x *int
+		require.NotEmpty(t, x)
+		print(*x)
+	case 3:
+		var x *int
+		require.Empty(t, x)
+		print(*x) //want "unassigned variable `x` dereferenced"
+	case 4:
+		x, err := errs()
+		require.Empty(t, err)
+		return x
+	case 5:
+		x, err := errs()
+		require.NotEmpty(t, err)
+		return x //want "result 0 of `errs.*` lacking guarding"
+
+	// zero value of boolean check should be supported
+	case 6:
+		v, ok := mp[0]
+		require.NotEmpty(t, ok)
+		print(*v)
+	case 7:
+		v, ok := mp[0]
+		require.Empty(t, ok)
+		print(*v) //want "deep read from parameter `mp` lacking guarding"
+
+	// The f variants should also be supported.
+	case 8:
+		require.Emptyf(t, a, "mymsg: %s", "arg")
+		print(a[0]) //want "sliced into"
+	case 9:
+		require.NotEmptyf(t, a, "mymsg: %s", "arg")
+		print(a[0])
+
+	// Calls with `suite.Suite` should also be supported.
+	case 10:
+		x, err := errs()
+		s := &testSetupEmbeddedDepth1{}
+		s.Empty(err)
+		return x
+	case 11:
+		var x *int
+		s := &testSetupEmbeddedDepth1{}
+		s.Empty(x)
+		print(*x) //want "unassigned variable `x` dereferenced"
+	case 12:
+		v, ok := mp[0]
+		s := &testSetupEmbeddedDepth1{}
+		s.Empty(ok)
+		print(*v) //want "deep read from parameter `mp` lacking guarding"
+	case 13:
+		s := &testSetupEmbeddedDepth1{}
+		s.Empty(a)
+		print(a[0]) //want "sliced into"
 	}
+
+	return 0
 }

--- a/testdata/src/go.uber.org/testing/trustedfuncs.go
+++ b/testdata/src/go.uber.org/testing/trustedfuncs.go
@@ -643,31 +643,6 @@ func testEqual(t *testing.T, i int, a []int) interface{} {
 		require.Equalf(t, 1, len(a), "mymsg: %s", "arg")
 		print(a[0])
 
-	// The NotEqual variant should also be supported.
-	case 81:
-		require.NotEqual(t, len(a), 0)
-		print(a[0])
-
-	case 83:
-		// Swapping the positions of args should not affect the analysis.
-		require.NotEqual(t, 0, len(a))
-		print(a[0])
-
-	case 84:
-		// Using a constant is also OK.
-		const zero = 0
-		require.NotEqual(t, zero, len(a))
-
-	case 82:
-		// `len(a) != 1` implies that len(a) can be 0, hence we should report an error.
-		require.NotEqual(t, len(a), 1)
-		print(a[0]) //want "sliced into"
-
-	case 85:
-		require.NotEqual(t, len(a), 1)
-		print(a[0]) //want "sliced into"
-
-	// Equal/NotEqual with nil should also be supported.
 	case 8:
 		x, err := errs()
 		require.Equal(t, err, nil)
@@ -710,16 +685,6 @@ func testEqual(t *testing.T, i int, a []int) interface{} {
 		var x *int
 		require.Equal(t, nil, x)
 		print(*x) //want "unassigned variable `x` dereferenced"
-
-	case 16:
-		var x *int
-		require.Equal(t, x, nil)
-		print(*x) //want "unassigned variable `x` dereferenced"
-
-	case 17:
-		var x *int
-		require.NotEqual(t, x, nil)
-		print(*x)
 	}
 	return 0
 }
@@ -854,26 +819,3 @@ func testLen(t *testing.T, i int, a []int) {
 		print(a[0]) //want "sliced into"
 	}
 }
-
-// import "go.uber.org/testing/github.com/stretchr/testify/suite"
-//
-// type S struct {
-// 	suite.Suite
-// }
-//
-// type myErr struct{}
-//
-// func (myErr) Error() string { return "myErr message" }
-//
-// func ret() (*int, error) {
-// 	if false {
-// 		return nil, &myErr{}
-// 	}
-// 	return new(int), nil
-// }
-//
-// func (s *S) test() {
-// 	v, err := ret()
-// 	s.Equal(nil, err)
-// 	_ = *v // False positive reported here
-// }


### PR DESCRIPTION
This PR models support for `Empty` function in the `testify` library, along with its variants: `NotEmpty`, `Emptyf`, and `NotEmptyf`. [Empty](https://pkg.go.dev/github.com/stretchr/testify/assert#Empty) is used to compare the passed object with its zero values (e.g., `Empty(err)`, implies `err == nil` check).

[Closes #74 ]