### PR TITLE
Apply S2 compression when exporting the facts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/google/go-cmp v0.5.9
+	github.com/klauspost/compress v1.17.0
 	github.com/stretchr/testify v1.8.4
 	go.uber.org/goleak v1.2.1
 	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/klauspost/compress v1.17.0 h1:Rnbp4K9EjcDuVuHtd0dgA4qNuv9yKDYKK1ulpJwgrqM=
+github.com/klauspost/compress v1.17.0/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=

--- a/inference/inferred_map_test.go
+++ b/inference/inferred_map_test.go
@@ -34,9 +34,9 @@ func TestEncoding_Size(t *testing.T) {
 
 	out := buf.Bytes()
 	require.NotEmpty(t, out)
-	require.Less(t, len(out), 250_000,
+	require.Less(t, len(out), 30_000,
 		"The gob encoding of a test inferred map is too large. We expect the encoded "+
-			"map to be less than 250KB. This heavily affects the artifact sizes of the facts NilAway "+
+			"map to be less than 30KB. This heavily affects the artifact sizes of the facts NilAway "+
 			"produces, so the cap should only be increased with justification and thorough testing.",
 	)
 }


### PR DESCRIPTION
NilAway is writing a lot of data when exporting `inference.InferredMap` via the [Fact mechanism](https://pkg.go.dev/golang.org/x/tools/go/analysis#hdr-Modular_analysis_with_Facts) since we are storing information about the nilability values / chains about both exported / unexported sites.

While we try our best to limit the total amount of data written (e.g., storing compact structs in Facts and restore only when we need to report errors), we are still seeing ~3% artifact size overhead in our internal evaluation on a large repository.

This PR applies a fast and effective compression algorithm S2 when we serialize the inferred map via Gob Encoding. Our internal evaluation shows that the artifact size overhead decreases from ~3% down to ~0.4%, while the build time overhead increases from ~2% to ~2.9%. This seems a good compromise to make for future development, especially for enabling struct initialization support, where we expect a lot more triggers to be generated and hence more implication edges to be stored.

Depends on #73.