### PR TITLE
Delete `String()` methods

### DIFF
--- a/annotation/consume_trigger.go
+++ b/annotation/consume_trigger.go
@@ -40,7 +40,6 @@ type ConsumingAnnotationTrigger interface {
 	// for example - an `ArgPass` trigger triggers iff the corresponding function arg has
 	// nonNil type
 	CheckConsume(Map) bool
-	String() string
 	Prestring() Prestring
 
 	// Kind returns the kind of the trigger.
@@ -119,10 +118,6 @@ type PtrLoad struct {
 	ConsumeTriggerTautology
 }
 
-func (p PtrLoad) String() string {
-	return p.Prestring().String()
-}
-
 // Prestring returns this PtrLoad as a Prestring
 func (p PtrLoad) Prestring() Prestring {
 	return PtrLoadPrestring{}
@@ -140,10 +135,6 @@ func (PtrLoadPrestring) String() string {
 // note: this trigger is produced only if config.ErrorOnNilableMapRead == true
 type MapAccess struct {
 	ConsumeTriggerTautology
-}
-
-func (i MapAccess) String() string {
-	return i.Prestring().String()
 }
 
 // Prestring returns this MapAccess as a Prestring
@@ -164,10 +155,6 @@ type MapWrittenTo struct {
 	ConsumeTriggerTautology
 }
 
-func (m MapWrittenTo) String() string {
-	return m.Prestring().String()
-}
-
 // Prestring returns this MapWrittenTo as a Prestring
 func (m MapWrittenTo) Prestring() Prestring {
 	return MapWrittenToPrestring{}
@@ -183,10 +170,6 @@ func (MapWrittenToPrestring) String() string {
 // SliceAccess is when a slice value flows to a point where it is sliced, and thus must be non-nil
 type SliceAccess struct {
 	ConsumeTriggerTautology
-}
-
-func (s SliceAccess) String() string {
-	return s.Prestring().String()
 }
 
 // Prestring returns this SliceAccess as a Prestring
@@ -206,10 +189,6 @@ type FldAccess struct {
 	ConsumeTriggerTautology
 
 	Sel types.Object
-}
-
-func (f FldAccess) String() string {
-	return f.Prestring().String()
 }
 
 // Prestring returns this FldAccess as a Prestring
@@ -251,10 +230,6 @@ type UseAsErrorResult struct {
 	IsNamedReturn bool
 }
 
-func (u UseAsErrorResult) String() string {
-	return u.Prestring().String()
-}
-
 // Prestring returns this UseAsErrorResult as a Prestring
 func (u UseAsErrorResult) Prestring() Prestring {
 	retAnn := u.Ann.(RetAnnotationKey)
@@ -294,10 +269,6 @@ type FldAssign struct {
 	TriggerIfNonNil
 }
 
-func (f FldAssign) String() string {
-	return f.Prestring().String()
-}
-
 // Prestring returns this FldAssign as a Prestring
 func (f FldAssign) Prestring() Prestring {
 	fldAnn := f.Ann.(FieldAnnotationKey)
@@ -320,10 +291,6 @@ func (f FldAssignPrestring) String() string {
 type ArgFldPass struct {
 	TriggerIfNonNil
 	IsPassed bool
-}
-
-func (f ArgFldPass) String() string {
-	return f.Prestring().String()
 }
 
 // Prestring returns this ArgFldPass as a Prestring
@@ -369,10 +336,6 @@ type GlobalVarAssign struct {
 	TriggerIfNonNil
 }
 
-func (g GlobalVarAssign) String() string {
-	return g.Prestring().String()
-}
-
 // Prestring returns this GlobalVarAssign as a Prestring
 func (g GlobalVarAssign) Prestring() Prestring {
 	varAnn := g.Ann.(GlobalVarAnnotationKey)
@@ -398,10 +361,6 @@ func (g GlobalVarAssignPrestring) String() string {
 // duplicate the sites for context sensitivity.
 type ArgPass struct {
 	TriggerIfNonNil
-}
-
-func (a ArgPass) String() string {
-	return a.Prestring().String()
 }
 
 // Prestring returns this ArgPass as a Prestring
@@ -449,10 +408,6 @@ type RecvPass struct {
 	TriggerIfNonNil
 }
 
-func (a RecvPass) String() string {
-	return a.Prestring().String()
-}
-
 // Prestring returns this RecvPass as a Prestring
 func (a RecvPass) Prestring() Prestring {
 	recvAnn := a.Ann.(RecvAnnotationKey)
@@ -474,10 +429,6 @@ func (a RecvPassPrestring) String() string {
 type InterfaceResultFromImplementation struct {
 	TriggerIfNonNil
 	AffiliationPair
-}
-
-func (i InterfaceResultFromImplementation) String() string {
-	return i.Prestring().String()
 }
 
 // Prestring returns this InterfaceResultFromImplementation as a Prestring
@@ -506,10 +457,6 @@ func (i InterfaceResultFromImplementationPrestring) String() string {
 type MethodParamFromInterface struct {
 	TriggerIfNonNil
 	AffiliationPair
-}
-
-func (m MethodParamFromInterface) String() string {
-	return m.Prestring().String()
 }
 
 // Prestring returns this MethodParamFromInterface as a Prestring
@@ -561,10 +508,6 @@ type UseAsReturn struct {
 	TriggerIfNonNil
 	IsNamedReturn bool
 	RetStmt       *ast.ReturnStmt
-}
-
-func (u UseAsReturn) String() string {
-	return u.Prestring().String()
 }
 
 // Prestring returns this UseAsReturn as a Prestring
@@ -631,10 +574,6 @@ type UseAsFldOfReturn struct {
 	TriggerIfNonNil
 }
 
-func (u UseAsFldOfReturn) String() string {
-	return u.Prestring().String()
-}
-
 // Prestring returns this UseAsFldOfReturn as a Prestring
 func (u UseAsFldOfReturn) Prestring() Prestring {
 	retAnn := u.Ann.(RetFieldAnnotationKey)
@@ -697,10 +636,6 @@ type SliceAssign struct {
 	TriggerIfDeepNonNil
 }
 
-func (f SliceAssign) String() string {
-	return f.Prestring().String()
-}
-
 // Prestring returns this SliceAssign as a Prestring
 func (f SliceAssign) Prestring() Prestring {
 	fldAnn := f.Ann.(TypeNameAnnotationKey)
@@ -721,10 +656,6 @@ func (f SliceAssignPrestring) String() string {
 // ArrayAssign is when a value flows to a point where it is assigned into an array
 type ArrayAssign struct {
 	TriggerIfDeepNonNil
-}
-
-func (a ArrayAssign) String() string {
-	return a.Prestring().String()
 }
 
 // Prestring returns this ArrayAssign as a Prestring
@@ -749,10 +680,6 @@ type PtrAssign struct {
 	TriggerIfDeepNonNil
 }
 
-func (f PtrAssign) String() string {
-	return f.Prestring().String()
-}
-
 // Prestring returns this PtrAssign as a Prestring
 func (f PtrAssign) Prestring() Prestring {
 	fldAnn := f.Ann.(TypeNameAnnotationKey)
@@ -773,10 +700,6 @@ func (f PtrAssignPrestring) String() string {
 // MapAssign is when a value flows to a point where it is assigned into an annotated map
 type MapAssign struct {
 	TriggerIfDeepNonNil
-}
-
-func (f MapAssign) String() string {
-	return f.Prestring().String()
 }
 
 // Prestring returns this MapAssign as a Prestring
@@ -802,10 +725,6 @@ type DeepAssignPrimitive struct {
 	ConsumeTriggerTautology
 }
 
-func (d DeepAssignPrimitive) String() string {
-	return d.Prestring().String()
-}
-
 // Prestring returns this Prestring as a Prestring
 func (DeepAssignPrimitive) Prestring() Prestring {
 	return DeepAssignPrimitivePrestring{}
@@ -821,10 +740,6 @@ func (DeepAssignPrimitivePrestring) String() string {
 // ParamAssignDeep is when a value flows to a point where it is assigned deeply into a function parameter
 type ParamAssignDeep struct {
 	TriggerIfDeepNonNil
-}
-
-func (p ParamAssignDeep) String() string {
-	return p.Prestring().String()
 }
 
 // Prestring returns this ParamAssignDeep as a Prestring
@@ -844,10 +759,6 @@ func (p ParamAssignDeepPrestring) String() string {
 // FuncRetAssignDeep is when a value flows to a point where it is assigned deeply into a function return
 type FuncRetAssignDeep struct {
 	TriggerIfDeepNonNil
-}
-
-func (f FuncRetAssignDeep) String() string {
-	return f.Prestring().String()
 }
 
 // Prestring returns this FuncRetAssignDeep as a Prestring
@@ -875,10 +786,6 @@ type VariadicParamAssignDeep struct {
 	TriggerIfNonNil
 }
 
-func (v VariadicParamAssignDeep) String() string {
-	return v.Prestring().String()
-}
-
 // Prestring returns this VariadicParamAssignDeep as a Prestring
 func (v VariadicParamAssignDeep) Prestring() Prestring {
 	paramAnn := v.Ann.(ParamAnnotationKey)
@@ -901,10 +808,6 @@ type FieldAssignDeep struct {
 	TriggerIfDeepNonNil
 }
 
-func (f FieldAssignDeep) String() string {
-	return f.Prestring().String()
-}
-
 // Prestring returns this FieldAssignDeep as a Prestring
 func (f FieldAssignDeep) Prestring() Prestring {
 	fldAnn := f.Ann.(FieldAnnotationKey)
@@ -923,10 +826,6 @@ func (f FieldAssignDeepPrestring) String() string {
 // GlobalVarAssignDeep is when a value flows to a point where it is assigned deeply into a global variable
 type GlobalVarAssignDeep struct {
 	TriggerIfDeepNonNil
-}
-
-func (g GlobalVarAssignDeep) String() string {
-	return g.Prestring().String()
 }
 
 // Prestring returns this GlobalVarAssignDeep as a Prestring
@@ -949,10 +848,6 @@ type ChanAccess struct {
 	ConsumeTriggerTautology
 }
 
-func (c ChanAccess) String() string {
-	return c.Prestring().String()
-}
-
 // Prestring returns this MapWrittenTo as a Prestring
 func (c ChanAccess) Prestring() Prestring {
 	return ChanAccessPrestring{}
@@ -969,10 +864,6 @@ func (ChanAccessPrestring) String() string {
 type LocalVarAssignDeep struct {
 	ConsumeTriggerTautology
 	LocalVar *types.Var
-}
-
-func (l LocalVarAssignDeep) String() string {
-	return l.Prestring().String()
 }
 
 // Prestring returns this LocalVarAssignDeep as a Prestring
@@ -992,10 +883,6 @@ func (l LocalVarAssignDeepPrestring) String() string {
 // ChanSend is when a value flows to a point where it is sent to a channel
 type ChanSend struct {
 	TriggerIfDeepNonNil
-}
-
-func (c ChanSend) String() string {
-	return c.Prestring().String()
 }
 
 // Prestring returns this ChanSend as a Prestring
@@ -1025,10 +912,6 @@ type FldEscape struct {
 	TriggerIfNonNil
 }
 
-func (f FldEscape) String() string {
-	return f.Prestring().String()
-}
-
 // Prestring returns this FldEscape as a Prestring
 func (f FldEscape) Prestring() Prestring {
 	ann := f.Ann.(EscapeFieldAnnotationKey)
@@ -1052,10 +935,6 @@ type UseAsNonErrorRetDependentOnErrorRetNilability struct {
 
 	IsNamedReturn bool
 	RetStmt       *ast.ReturnStmt
-}
-
-func (u UseAsNonErrorRetDependentOnErrorRetNilability) String() string {
-	return u.Prestring().String()
 }
 
 // Prestring returns this UseAsNonErrorRetDependentOnErrorRetNilability as a Prestring
@@ -1103,10 +982,6 @@ type UseAsErrorRetWithNilabilityUnknown struct {
 
 	IsNamedReturn bool
 	RetStmt       *ast.ReturnStmt
-}
-
-func (u UseAsErrorRetWithNilabilityUnknown) String() string {
-	return u.Prestring().String()
 }
 
 // Prestring returns this UseAsErrorRetWithNilabilityUnknown as a Prestring
@@ -1214,15 +1089,6 @@ func (c *ConsumeTrigger) Pos() token.Pos {
 		return pos
 	}
 	return c.Expr.Pos()
-}
-
-func (c *ConsumeTrigger) String() string {
-	guarded := ""
-	if !c.Guards.IsEmpty() {
-		guarded = fmt.Sprintf("%s-GuardMatched ", c.Guards)
-	}
-	return fmt.Sprintf("{(%s%T@%d-%d %s)}",
-		guarded, c.Expr, c.Expr.Pos(), c.Expr.End(), c.Annotation.String())
 }
 
 // MergeConsumeTriggerSlices merges two slices of `ConsumeTrigger`s

--- a/annotation/full_trigger.go
+++ b/annotation/full_trigger.go
@@ -54,24 +54,6 @@ func (t *FullTrigger) Pos() token.Pos {
 	return t.Consumer.Pos()
 }
 
-func (t *FullTrigger) String() string {
-	str := fmt.Sprintf("%T -> (%T@%d %s)",
-		t.Producer.Annotation, t.Consumer.Expr, t.Pos(), t.Consumer.Annotation.String())
-	if t.Controller != nil {
-		str += " if " + t.Controller.String() + " is nilable"
-	}
-	return "[" + str + "]"
-}
-
-// TriggerSlicesString returns a string representation of a slice of `FullTrigger`s
-func TriggerSlicesString(triggers []FullTrigger) string {
-	out := fmt.Sprintf("FullTriggers len %d: {\n", len(triggers))
-	for _, trigger := range triggers {
-		out += fmt.Sprintf("\t%s\n", trigger.String())
-	}
-	return out + "}"
-}
-
 // Check is a boolean test that determines whether this FullTrigger should be triggered against the Annotation map `annMap`
 func (t *FullTrigger) Check(annMap Map) bool {
 	return t.Producer.Annotation.CheckProduce(annMap) &&

--- a/annotation/produce_trigger.go
+++ b/annotation/produce_trigger.go
@@ -52,7 +52,6 @@ type ProducingAnnotationTrigger interface {
 	// This should be very sparingly used, and only with utter conviction of correctness
 	SetNeedsGuard(bool) ProducingAnnotationTrigger
 
-	String() string
 	Prestring() Prestring
 
 	// Kind returns the kind of the trigger.
@@ -67,10 +66,6 @@ type ProducingAnnotationTrigger interface {
 // key is nilable
 type TriggerIfNilable struct {
 	Ann Key
-}
-
-func (t TriggerIfNilable) String() string {
-	return t.Prestring().String()
 }
 
 // Prestring returns this Prestring as a Prestring
@@ -113,10 +108,6 @@ func (t TriggerIfNilable) UnderlyingSite() Key { return t.Ann }
 // key is deeply nilable
 type TriggerIfDeepNilable struct {
 	Ann Key
-}
-
-func (t TriggerIfDeepNilable) String() string {
-	return t.Prestring().String()
 }
 
 // Prestring returns this Prestring as a Prestring
@@ -166,10 +157,6 @@ func (ProduceTriggerTautology) NeedsGuardMatch() bool { return false }
 // SetNeedsGuard for a ProduceTriggerTautology is a noop
 func (p ProduceTriggerTautology) SetNeedsGuard(bool) ProducingAnnotationTrigger { return p }
 
-func (p ProduceTriggerTautology) String() string {
-	return p.Prestring().String()
-}
-
 // Prestring returns this Prestring as a Prestring
 func (ProduceTriggerTautology) Prestring() Prestring {
 	return ProduceTriggerTautologyPrestring{}
@@ -190,10 +177,6 @@ func (ProduceTriggerTautologyPrestring) String() string {
 
 // ProduceTriggerNever is used for trigger producers that will never be nil
 type ProduceTriggerNever struct{}
-
-func (p ProduceTriggerNever) String() string {
-	return p.Prestring().String()
-}
 
 // Prestring returns this Prestring as a Prestring
 func (ProduceTriggerNever) Prestring() Prestring {
@@ -245,10 +228,6 @@ type PositiveNilCheck struct {
 	ProduceTriggerTautology
 }
 
-func (p PositiveNilCheck) String() string {
-	return p.Prestring().String()
-}
-
 // Prestring returns this Prestring as a Prestring
 func (PositiveNilCheck) Prestring() Prestring {
 	return PositiveNilCheckPrestring{}
@@ -264,10 +243,6 @@ func (PositiveNilCheckPrestring) String() string {
 // NegativeNilCheck is used when a value is checked in a conditional to NOT BE nil
 type NegativeNilCheck struct {
 	ProduceTriggerNever
-}
-
-func (p NegativeNilCheck) String() string {
-	return p.Prestring().String()
 }
 
 // Prestring returns this Prestring as a Prestring
@@ -299,10 +274,6 @@ type ConstNil struct {
 	ProduceTriggerTautology
 }
 
-func (c ConstNil) String() string {
-	return c.Prestring().String()
-}
-
 // Prestring returns this Prestring as a Prestring
 func (ConstNil) Prestring() Prestring {
 	return ConstNilPrestring{}
@@ -318,10 +289,6 @@ func (ConstNilPrestring) String() string {
 // UnassignedFld is when a field of struct is not assigned at initialization
 type UnassignedFld struct {
 	ProduceTriggerTautology
-}
-
-func (c UnassignedFld) String() string {
-	return c.Prestring().String()
 }
 
 // Prestring returns this Prestring as a Prestring
@@ -340,10 +307,6 @@ func (UnassignedFldPrestring) String() string {
 type NoVarAssign struct {
 	ProduceTriggerTautology
 	VarObj *types.Var
-}
-
-func (n NoVarAssign) String() string {
-	return n.Prestring().String()
 }
 
 // Prestring returns this Prestring as a Prestring
@@ -393,10 +356,6 @@ type FuncParam struct {
 	TriggerIfNilable
 }
 
-func (f FuncParam) String() string {
-	return f.Prestring().String()
-}
-
 // Prestring returns this FuncParam as a Prestring
 func (f FuncParam) Prestring() Prestring {
 	switch key := f.Ann.(type) {
@@ -433,10 +392,6 @@ type MethodRecv struct {
 	VarDecl *types.Var
 }
 
-func (m MethodRecv) String() string {
-	return m.Prestring().String()
-}
-
 // Prestring returns this MethodRecv as a Prestring
 func (m MethodRecv) Prestring() Prestring {
 	return MethodRecvPrestring{m.VarDecl.Name()}
@@ -455,10 +410,6 @@ func (m MethodRecvPrestring) String() string {
 type MethodRecvDeep struct {
 	TriggerIfDeepNilable
 	VarDecl *types.Var
-}
-
-func (m MethodRecvDeep) String() string {
-	return m.Prestring().String()
 }
 
 // Prestring returns this MethodRecv as a Prestring
@@ -482,10 +433,6 @@ type VariadicFuncParam struct {
 	VarDecl *types.Var
 }
 
-func (v VariadicFuncParam) String() string {
-	return v.Prestring().String()
-}
-
 // Prestring returns this Prestring as a Prestring
 func (v VariadicFuncParam) Prestring() Prestring {
 	return VariadicFuncParamPrestring{v.VarDecl.Name()}
@@ -505,10 +452,6 @@ type TrustedFuncNilable struct {
 	ProduceTriggerTautology
 }
 
-func (t TrustedFuncNilable) String() string {
-	return t.Prestring().String()
-}
-
 // Prestring returns this Prestring as a Prestring
 func (TrustedFuncNilable) Prestring() Prestring {
 	return TrustedFuncNilablePrestring{}
@@ -526,10 +469,6 @@ type TrustedFuncNonnil struct {
 	ProduceTriggerNever
 }
 
-func (t TrustedFuncNonnil) String() string {
-	return t.Prestring().String()
-}
-
 // Prestring returns this Prestring as a Prestring
 func (TrustedFuncNonnil) Prestring() Prestring {
 	return TrustedFuncNonnilPrestring{}
@@ -545,10 +484,6 @@ func (TrustedFuncNonnilPrestring) String() string {
 // FldRead is used when a value is determined to flow from a read to a field
 type FldRead struct {
 	TriggerIfNilable
-}
-
-func (f FldRead) String() string {
-	return f.Prestring().String()
 }
 
 // Prestring returns this FldRead as a Prestring
@@ -574,10 +509,6 @@ type ParamFldRead struct {
 	TriggerIfNilable
 }
 
-func (f ParamFldRead) String() string {
-	return f.Prestring().String()
-}
-
 // Prestring returns this ParamFldRead as a Prestring
 func (f ParamFldRead) Prestring() Prestring {
 	ann := f.Ann.(ParamFieldAnnotationKey)
@@ -598,10 +529,6 @@ func (f ParamFldReadPrestring) String() string {
 // FldReturn is used when a struct field value is determined to flow from a return value of a function
 type FldReturn struct {
 	TriggerIfNilable
-}
-
-func (f FldReturn) String() string {
-	return f.Prestring().String()
 }
 
 // Prestring returns this FldReturn as a Prestring
@@ -630,10 +557,6 @@ func (f FldReturnPrestring) String() string {
 type FuncReturn struct {
 	TriggerIfNilable
 	Guarded bool
-}
-
-func (f FuncReturn) String() string {
-	return f.Prestring().String()
 }
 
 // Prestring returns this FuncReturn as a Prestring
@@ -683,10 +606,6 @@ type MethodReturn struct {
 	TriggerIfNilable
 }
 
-func (m MethodReturn) String() string {
-	return m.Prestring().String()
-}
-
 // Prestring returns this MethodReturn as a Prestring
 func (m MethodReturn) Prestring() Prestring {
 	retKey := m.Ann.(RetAnnotationKey)
@@ -707,10 +626,6 @@ func (m MethodReturnPrestring) String() string {
 type MethodResultReachesInterface struct {
 	TriggerIfNilable
 	AffiliationPair
-}
-
-func (m MethodResultReachesInterface) String() string {
-	return m.Prestring().String()
 }
 
 // Prestring returns this MethodResultReachesInterface as a Prestring
@@ -740,10 +655,6 @@ type InterfaceParamReachesImplementation struct {
 	AffiliationPair
 }
 
-func (i InterfaceParamReachesImplementation) String() string {
-	return i.Prestring().String()
-}
-
 // Prestring returns this InterfaceParamReachesImplementation as a Prestring
 func (i InterfaceParamReachesImplementation) Prestring() Prestring {
 	paramAnn := i.Ann.(ParamAnnotationKey)
@@ -770,10 +681,6 @@ type GlobalVarRead struct {
 	TriggerIfNilable
 }
 
-func (g GlobalVarRead) String() string {
-	return g.Prestring().String()
-}
-
 // Prestring returns this GlobalVarRead as a Prestring
 func (g GlobalVarRead) Prestring() Prestring {
 	key := g.Ann.(GlobalVarAnnotationKey)
@@ -796,10 +703,6 @@ func (g GlobalVarReadPrestring) String() string {
 type MapRead struct {
 	TriggerIfDeepNilable
 	NeedsGuard bool
-}
-
-func (m MapRead) String() string {
-	return m.Prestring().String()
 }
 
 // Prestring returns this MapRead as a Prestring
@@ -831,10 +734,6 @@ type ArrayRead struct {
 	TriggerIfDeepNilable
 }
 
-func (a ArrayRead) String() string {
-	return a.Prestring().String()
-}
-
 // Prestring returns this ArrayRead as a Prestring
 func (a ArrayRead) Prestring() Prestring {
 	key := a.Ann.(TypeNameAnnotationKey)
@@ -853,10 +752,6 @@ func (a ArrayReadPrestring) String() string {
 // SliceRead is when a value is determined to flow from a slice index expression
 type SliceRead struct {
 	TriggerIfDeepNilable
-}
-
-func (s SliceRead) String() string {
-	return s.Prestring().String()
 }
 
 // Prestring returns this SliceRead as a Prestring
@@ -879,10 +774,6 @@ type PtrRead struct {
 	TriggerIfDeepNilable
 }
 
-func (p PtrRead) String() string {
-	return p.Prestring().String()
-}
-
 // Prestring returns this PtrRead as a Prestring
 func (p PtrRead) Prestring() Prestring {
 	key := p.Ann.(TypeNameAnnotationKey)
@@ -902,10 +793,6 @@ func (p PtrReadPrestring) String() string {
 type ChanRecv struct {
 	TriggerIfDeepNilable
 	NeedsGuard bool
-}
-
-func (c ChanRecv) String() string {
-	return c.Prestring().String()
 }
 
 // Prestring returns this ChanRecv as a Prestring
@@ -937,10 +824,6 @@ func (c ChanRecv) SetNeedsGuard(b bool) ProducingAnnotationTrigger {
 type FuncParamDeep struct {
 	TriggerIfDeepNilable
 	NeedsGuard bool
-}
-
-func (f FuncParamDeep) String() string {
-	return f.Prestring().String()
 }
 
 // Prestring returns this FuncParamDeep as a Prestring
@@ -975,10 +858,6 @@ type VariadicFuncParamDeep struct {
 	NeedsGuard bool
 }
 
-func (v VariadicFuncParamDeep) String() string {
-	return v.Prestring().String()
-}
-
 // Prestring returns this VariadicFuncParamDeep as a Prestring
 func (v VariadicFuncParamDeep) Prestring() Prestring {
 	return VariadicFuncParamDeepPrestring{v.Ann.(ParamAnnotationKey).ParamNameString()}
@@ -1008,10 +887,6 @@ func (v VariadicFuncParamDeep) SetNeedsGuard(b bool) ProducingAnnotationTrigger 
 type FuncReturnDeep struct {
 	TriggerIfDeepNilable
 	NeedsGuard bool
-}
-
-func (f FuncReturnDeep) String() string {
-	return f.Prestring().String()
 }
 
 // Prestring returns this FuncReturnDeep as a Prestring
@@ -1047,10 +922,6 @@ type FldReadDeep struct {
 	NeedsGuard bool
 }
 
-func (f FldReadDeep) String() string {
-	return f.Prestring().String()
-}
-
 // Prestring returns this FldReadDeep as a Prestring
 func (f FldReadDeep) Prestring() Prestring {
 	key := f.Ann.(FieldAnnotationKey)
@@ -1084,10 +955,6 @@ type LocalVarReadDeep struct {
 	ReadVar    *types.Var
 }
 
-func (v LocalVarReadDeep) String() string {
-	return v.Prestring().String()
-}
-
 // Prestring returns this LocalVarReadDeep as a Prestring
 func (v LocalVarReadDeep) Prestring() Prestring {
 	return LocalVarReadDeepPrestring{v.ReadVar.Name()}
@@ -1117,10 +984,6 @@ func (v LocalVarReadDeep) SetNeedsGuard(b bool) ProducingAnnotationTrigger {
 type GlobalVarReadDeep struct {
 	TriggerIfDeepNilable
 	NeedsGuard bool
-}
-
-func (g GlobalVarReadDeep) String() string {
-	return g.Prestring().String()
 }
 
 // Prestring returns this GlobalVarReadDeep as a Prestring
@@ -1161,10 +1024,6 @@ func (g GlobalVarReadDeep) SetNeedsGuard(b bool) ProducingAnnotationTrigger {
 type GuardMissing struct {
 	ProduceTriggerTautology
 	OldAnnotation ProducingAnnotationTrigger
-}
-
-func (g GuardMissing) String() string {
-	return g.Prestring().String()
 }
 
 // Prestring returns this GuardMissing as a Prestring

--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -166,12 +166,6 @@ func (r *RootAssertionNode) ObjectOf(ident *ast.Ident) types.Object {
 	return r.functionContext.findFakeIdent(ident)
 }
 
-func (r *RootAssertionNode) String() string {
-	// TODO: deep print
-	return fmt.Sprintf("{RootAssertionNode:\n\tFullTriggers:%s\n",
-		annotation.TriggerSlicesString(r.triggers))
-}
-
 // funcArgsFromCallExpr returns the set of arguments that are passed to the method at the call site. If the method
 // is an anonymous function, it expands the argument set with the closure variables collected for that function
 func (r *RootAssertionNode) funcArgsFromCallExpr(expr *ast.CallExpr) []ast.Expr {

--- a/assertion/function/assertiontree/util.go
+++ b/assertion/function/assertiontree/util.go
@@ -39,19 +39,6 @@ func GetDeclaringPath(pass *analysis.Pass, start, end token.Pos) ([]ast.Node, bo
 	return nil, false
 }
 
-// RootNodeSlicesString returns a slice of RootAssertionNodes as a string representation
-func RootNodeSlicesString(name string, rootNodes []*RootAssertionNode) string {
-	out := fmt.Sprintf("%s len %d: {\n", name, len(rootNodes))
-	for i, rootNode := range rootNodes {
-		repr := "nil"
-		if rootNode != nil {
-			repr = rootNode.String()
-		}
-		out += fmt.Sprintf("\t%s[%d]: %s\n", name, i, repr)
-	}
-	return out + "}"
-}
-
 // each of the following deepNilabilityOf... functions serves to inspect an object for possible sites
 // that could grant it a deep nilability annotation. Every case defaults to just introspecting the
 // type itself - as named types can be declared with annotations; this is the call to `DeepNilabilityAsNamedType`


### PR DESCRIPTION
This PR deletes `String()` methods that we no longer use.