### PR TITLE
Increase the timeout for golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,3 +1,6 @@
+run:
+  timeout: 10m
+
 issues:
   # Print all issues reported by all linters.
   max-issues-per-linter: 0


### PR DESCRIPTION
We are sometimes seeing golangci-lint timeouts in CI, e.g., https://github.com/uber-go/nilaway/actions/runs/6564041852. The default timeout is only 1m, which is a little short for CI due to its resource-sharing nature, particularly some linters need the entire project to be parsed and type checked for execution. 

This PR increase the timeout to be 10m.