### PR TITLE
Fix deferred order to avoid "send on closed channel" panic

### DIFF
--- a/assertion/function/analyzer_test.go
+++ b/assertion/function/analyzer_test.go
@@ -28,8 +28,10 @@ import (
 	"go.uber.org/nilaway/assertion/function/assertiontree"
 	"go.uber.org/nilaway/assertion/function/functioncontracts"
 	"go.uber.org/nilaway/config"
+	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/analysistest"
 	"golang.org/x/tools/go/analysis/passes/ctrlflow"
+	"golang.org/x/tools/go/cfg"
 )
 
 func TestTimeout(t *testing.T) {
@@ -104,16 +106,16 @@ func TestAnalyzeFuncPanic(t *testing.T) {
 
 	resultChan := make(chan functionResult)
 	var wg sync.WaitGroup
-	funcContext := assertiontree.FunctionContext{}
+	wg.Add(1)
+
 	// Intentionally give bad input data to cause a panic. We should convert the panic to an error
 	// and send it back to the original channel.
-	wg.Add(1)
 	go analyzeFunc(ctx,
-		nil,         /* pass */
-		nil,         /* funcDecl */
-		funcContext, /* funcContext */
-		nil,         /* graph */
-		0,           /* index */
+		&analysis.Pass{},                /* pass */
+		&ast.FuncDecl{},                 /* funcDecl */
+		assertiontree.FunctionContext{}, /* funcContext */
+		&cfg.CFG{},                      /* graph */
+		0,                               /* index */
 		resultChan,
 		&wg,
 	)


### PR DESCRIPTION
We have deferred panic handler calls in all entry points of the sub analyzers to avoid NilAway panic in any case. However, we are still seeing a pcni reported in #100.

Recall that deferred statements are pushed to a stack, which are executed in LIFO order. When we are firing up goroutines in the function analyzer  for the analysis of each individual function, we have the following code:

```
defer wg.Done()

defer func() { if r := recover(); r != nil { }
```

This means `wg.Done()` will be called _before_ the panic recovery handler. However, `wg.Done()`would signal the main process that this goroutine is done, and the main process will close the result channel. But, our panic recovery handler still needs access to the result channel to send the error back, hence would result in a `send on closed channel` panic.

This PR reorders the statement with a comment, and we have also included a test case to intentionally cause a panic and see if the panic is correctly recovered (without another panic).

Fixes #100