### PR TITLE
Add Pre-Commit Hooks Definition

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: nilaway
+  name: nilaway
+  description: Static Analysis tool to detect potential Nil panics in Go code
+  entry: nilaway .
+  types: [go]
+  language: golang
+  pass_filenames: false


### PR DESCRIPTION
Would allow this project to be used more directly as a hook with [pre-commit](https://pre-commit.com/)