### PR TITLE
Add run Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ all: build lint test
 build:
 	go install go.uber.org/nilaway/cmd/nilaway
 
+.PHONY: run
+run:
+	go run cmd/nilaway/main.go ./...
+
 .PHONY: test
 test:
 	go test -v -race ./...


### PR DESCRIPTION
This PR adds a `run` Makefile target to make it easier to well, run the tool during development/testing 🙂