### PR TITLE
Enable manual contract support in NilAway

### DIFF
--- a/annotation/map.go
+++ b/annotation/map.go
@@ -627,7 +627,7 @@ func newObservedMap(pass *analysis.Pass, files []*ast.File) *ObservedMap {
 
 	// Parse inline annotations at call sites.
 	for _, file := range files {
-		if !conf.IsFileInScope(file) || !util.DocContainsFunctionContractsCheck(file.Doc) {
+		if !conf.IsFileInScope(file) {
 			continue
 		}
 		// Store a mapping between single comment's line number to its text.

--- a/assertion/function/functioncontracts/function_contracts_map.go
+++ b/assertion/function/functioncontracts/function_contracts_map.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	"go.uber.org/nilaway/config"
-	"go.uber.org/nilaway/util"
 	"golang.org/x/tools/go/analysis"
 )
 
@@ -89,7 +88,7 @@ func collectFunctionContracts(pass *analysis.Pass) Map {
 
 	m := Map{}
 	for _, file := range pass.Files {
-		if !conf.IsFileInScope(file) || !util.DocContainsFunctionContractsCheck(file.Doc) {
+		if !conf.IsFileInScope(file) {
 			continue
 		}
 		for _, decl := range file.Decls {

--- a/config/const.go
+++ b/config/const.go
@@ -63,10 +63,6 @@ const NilAwayStructInitCheckString = "<nilaway struct enable>"
 // force NilAway to enable anonymous func checking
 const NilAwayAnonymousFuncCheckString = "<nilaway anonymous function enable>"
 
-// NilAwayFunctionContractsCheckString is the string that may be inserted into the docstring for a
-// package to force NilAway to enable function contracts.
-const NilAwayFunctionContractsCheckString = "<nilaway contract enable>"
-
 func maxRoundsFromBlocks(numBlocks int) int {
 	return numBlocks * numBlocks * 2
 }

--- a/testdata/src/go.uber.org/functioncontracts/functioncontracts.go
+++ b/testdata/src/go.uber.org/functioncontracts/functioncontracts.go
@@ -2,7 +2,6 @@
 This package aims to test function contracts.
 
 <nilaway no inference>
-<nilaway contract enable>
 */
 package functioncontracts
 

--- a/testdata/src/go.uber.org/functioncontracts/inference/functioncontracts-with-inference.go
+++ b/testdata/src/go.uber.org/functioncontracts/inference/functioncontracts-with-inference.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// <nilaway contract enable>
 package inference
 
 import "math/rand"

--- a/util/util.go
+++ b/util/util.go
@@ -419,12 +419,6 @@ func DocContainsAnonymousFuncCheck(group *ast.CommentGroup) bool {
 	return docContainsString(config.NilAwayAnonymousFuncCheckString)(group)
 }
 
-// DocContainsFunctionContractsCheck is used by analyzers to check if the function contracts check
-// enabling string is present.
-func DocContainsFunctionContractsCheck(group *ast.CommentGroup) bool {
-	return docContainsString(config.NilAwayFunctionContractsCheckString)(group)
-}
-
 // docContainsString is used to check if the file comments contain a string s.
 func docContainsString(s string) func(*ast.CommentGroup) bool {
 	return func(group *ast.CommentGroup) bool {


### PR DESCRIPTION
@zzqatuber has implemented contract support in NilAway and has merged the manual contract support (i.e., via manual annotations such as `//contract(nonnil->nonnil)`) in main NilAway but hidden under a flag.

After internal performance validations there are no major performance/functionality degradations of simply enabling this feature, therefore this PR removes the hidden flag and make it available in NilAway.

After this PR, we will prioritize merging the automatic inference of the function contracts (i.e., PR #40 , PR #41 , and PR #42 ).