### PR TITLE
Shorten expression strings in assignment messages

### DIFF
--- a/assertion/function/assertiontree/backprop.go
+++ b/assertion/function/assertiontree/backprop.go
@@ -27,6 +27,7 @@ import (
 	"go.uber.org/nilaway/annotation"
 	"go.uber.org/nilaway/config"
 	"go.uber.org/nilaway/util"
+	"go.uber.org/nilaway/util/asthelper"
 	"golang.org/x/exp/slices"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/cfg"
@@ -591,8 +592,8 @@ buildShadowMask:
 						// Add assignment entries to the consumers of lhsNode for informative printing of errors
 						for _, c := range lhsNode.ConsumeTriggers() {
 							c.Annotation.AddAssignment(annotation.Assignment{
-								LHSExprStr: util.ExprToString(lhsVal, rootNode.Pass(), true /* isShortenExpr */),
-								RHSExprStr: util.ExprToString(rhsVal, rootNode.Pass(), true /* isShortenExpr */),
+								LHSExprStr: asthelper.PrintExpr(lhsVal, rootNode.Pass(), true /* isShortenExpr */),
+								RHSExprStr: asthelper.PrintExpr(rhsVal, rootNode.Pass(), true /* isShortenExpr */),
 								Position:   util.TruncatePosition(util.PosToLocation(lhsVal.Pos(), rootNode.Pass())),
 							})
 						}
@@ -636,8 +637,8 @@ buildShadowMask:
 						}
 						for _, t := range rootNode.triggers[beforeTriggersLastIndex:len(rootNode.triggers)] {
 							t.Consumer.Annotation.AddAssignment(annotation.Assignment{
-								LHSExprStr: util.ExprToString(lhsVal, rootNode.Pass(), true /* isShortenExpr */),
-								RHSExprStr: util.ExprToString(rhsVal, rootNode.Pass(), true /* isShortenExpr */),
+								LHSExprStr: asthelper.PrintExpr(lhsVal, rootNode.Pass(), true /* isShortenExpr */),
+								RHSExprStr: asthelper.PrintExpr(rhsVal, rootNode.Pass(), true /* isShortenExpr */),
 								Position:   util.TruncatePosition(util.PosToLocation(lhsVal.Pos(), rootNode.Pass())),
 							})
 						}

--- a/assertion/function/assertiontree/backprop.go
+++ b/assertion/function/assertiontree/backprop.go
@@ -591,9 +591,18 @@ buildShadowMask:
 					if ok && lhsNode != nil {
 						// Add assignment entries to the consumers of lhsNode for informative printing of errors
 						for _, c := range lhsNode.ConsumeTriggers() {
+							var lhsExprStr, rhsExprStr string
+							var err error
+							if lhsExprStr, err = asthelper.PrintExpr(lhsVal, rootNode.Pass(), true /* isShortenExpr */); err != nil {
+								return err
+							}
+							if rhsExprStr, err = asthelper.PrintExpr(rhsVal, rootNode.Pass(), true /* isShortenExpr */); err != nil {
+								return err
+							}
+
 							c.Annotation.AddAssignment(annotation.Assignment{
-								LHSExprStr: asthelper.PrintExpr(lhsVal, rootNode.Pass(), true /* isShortenExpr */),
-								RHSExprStr: asthelper.PrintExpr(rhsVal, rootNode.Pass(), true /* isShortenExpr */),
+								LHSExprStr: lhsExprStr,
+								RHSExprStr: rhsExprStr,
 								Position:   util.TruncatePosition(util.PosToLocation(lhsVal.Pos(), rootNode.Pass())),
 							})
 						}
@@ -636,9 +645,18 @@ buildShadowMask:
 							continue
 						}
 						for _, t := range rootNode.triggers[beforeTriggersLastIndex:len(rootNode.triggers)] {
+							var lhsExprStr, rhsExprStr string
+							var err error
+							if lhsExprStr, err = asthelper.PrintExpr(lhsVal, rootNode.Pass(), true /* isShortenExpr */); err != nil {
+								return err
+							}
+							if rhsExprStr, err = asthelper.PrintExpr(rhsVal, rootNode.Pass(), true /* isShortenExpr */); err != nil {
+								return err
+							}
+
 							t.Consumer.Annotation.AddAssignment(annotation.Assignment{
-								LHSExprStr: asthelper.PrintExpr(lhsVal, rootNode.Pass(), true /* isShortenExpr */),
-								RHSExprStr: asthelper.PrintExpr(rhsVal, rootNode.Pass(), true /* isShortenExpr */),
+								LHSExprStr: lhsExprStr,
+								RHSExprStr: rhsExprStr,
 								Position:   util.TruncatePosition(util.PosToLocation(lhsVal.Pos(), rootNode.Pass())),
 							})
 						}

--- a/assertion/function/assertiontree/backprop.go
+++ b/assertion/function/assertiontree/backprop.go
@@ -591,8 +591,8 @@ buildShadowMask:
 						// Add assignment entries to the consumers of lhsNode for informative printing of errors
 						for _, c := range lhsNode.ConsumeTriggers() {
 							c.Annotation.AddAssignment(annotation.Assignment{
-								LHSExprStr: util.ExprToString(lhsVal, rootNode.Pass()),
-								RHSExprStr: util.ExprToString(rhsVal, rootNode.Pass()),
+								LHSExprStr: util.ExprToString(lhsVal, rootNode.Pass(), true /* isShortenExpr */),
+								RHSExprStr: util.ExprToString(rhsVal, rootNode.Pass(), true /* isShortenExpr */),
 								Position:   util.TruncatePosition(util.PosToLocation(lhsVal.Pos(), rootNode.Pass())),
 							})
 						}
@@ -636,8 +636,8 @@ buildShadowMask:
 						}
 						for _, t := range rootNode.triggers[beforeTriggersLastIndex:len(rootNode.triggers)] {
 							t.Consumer.Annotation.AddAssignment(annotation.Assignment{
-								LHSExprStr: util.ExprToString(lhsVal, rootNode.Pass()),
-								RHSExprStr: util.ExprToString(rhsVal, rootNode.Pass()),
+								LHSExprStr: util.ExprToString(lhsVal, rootNode.Pass(), true /* isShortenExpr */),
+								RHSExprStr: util.ExprToString(rhsVal, rootNode.Pass(), true /* isShortenExpr */),
 								Position:   util.TruncatePosition(util.PosToLocation(lhsVal.Pos(), rootNode.Pass())),
 							})
 						}

--- a/testdata/src/go.uber.org/errormessage/errormessage.go
+++ b/testdata/src/go.uber.org/errormessage/errormessage.go
@@ -100,6 +100,7 @@ func test9(m map[int]*int) {
 	y := x
 	print(*y) //want "`m\\[0\\]` to `x`"
 }
+
 func test10(ch chan *int) {
 	x := <-ch //want "nil channel accessed"
 	y := x

--- a/testdata/src/go.uber.org/errormessage/errormessage.go
+++ b/testdata/src/go.uber.org/errormessage/errormessage.go
@@ -48,8 +48,7 @@ func test3(x *int) {
 
 // nilable(f)
 type S struct {
-	f    *int
-	sPtr *S
+	f *int
 }
 
 func test4(x *int) {
@@ -149,7 +148,7 @@ func test13() *int {
 	return new(int)
 }
 
-// below tests check shortening of expressions
+// below tests check shortening of expressions in assignment messages
 
 // nilable(s, result 0)
 func (s *S) bar(i int) *int {
@@ -157,26 +156,26 @@ func (s *S) bar(i int) *int {
 }
 
 // nilable(result 0)
-func (s *S) retNil(a int, b *int, c string, d bool) *S {
+func (s *S) foo(a int, b *int, c string, d bool) *S {
 	return nil
 }
 
 func test14(x *int, i int) {
 	s := &S{}
-	x = s.retNil(1,
+	x = s.foo(1,
 		new(int),
 		"abc",
 		true).bar(i)
 	y := x
-	print(*y) //want "`s.retNil\\(...\\).bar\\(i\\)` to `x`"
+	print(*y) //want "`s.foo\\(...\\).bar\\(i\\)` to `x`"
 }
 
 func test15(x *int) {
 	var longVarName, anotherLongVarName, yetAnotherLongName int
 	s := &S{}
-	x = s.retNil(longVarName, &anotherLongVarName, "abc", true).bar(yetAnotherLongName)
+	x = s.foo(longVarName, &anotherLongVarName, "abc", true).bar(yetAnotherLongName)
 	y := x
-	print(*y) //want "`s.retNil\\(...\\).bar\\(...\\)` to `x`"
+	print(*y) //want "`s.foo\\(...\\).bar\\(...\\)` to `x`"
 }
 
 func test16(mp map[int]*int) {
@@ -190,14 +189,14 @@ func test17(x *int, mp map[int]*int) {
 	var aVeryVeryVeryLongIndexVar int
 	s := &S{}
 
-	x = s.retNil(1, mp[aVeryVeryVeryLongIndexVar], "abc", true).bar(2) //want "deep read"
+	x = s.foo(1, mp[aVeryVeryVeryLongIndexVar], "abc", true).bar(2) //want "deep read"
 	y := x
-	print(*y) //want "`s.retNil\\(...\\).bar\\(2\\)` to `x`"
+	print(*y) //want "`s.foo\\(...\\).bar\\(2\\)` to `x`"
 }
 
 func test18(x *int, mp map[int]*int) {
 	s := &S{}
-	x = mp[*(s.retNil(1, new(int), "abc", true).bar(2))] //want "dereferenced"
+	x = mp[*(s.foo(1, new(int), "abc", true).bar(2))] //want "dereferenced"
 	y := x
 	print(*y) //want "`mp\\[...\\]` to `x`"
 }

--- a/testdata/src/go.uber.org/errormessage/errormessage.go
+++ b/testdata/src/go.uber.org/errormessage/errormessage.go
@@ -48,7 +48,8 @@ func test3(x *int) {
 
 // nilable(f)
 type S struct {
-	f *int
+	f    *int
+	sPtr *S
 }
 
 func test4(x *int) {
@@ -146,4 +147,57 @@ func test13() *int {
 		return nil //want "literal `nil` returned"
 	}
 	return new(int)
+}
+
+// below tests check shortening of expressions
+
+// nilable(s, result 0)
+func (s *S) bar(i int) *int {
+	return nil
+}
+
+// nilable(result 0)
+func (s *S) retNil(a int, b *int, c string, d bool) *S {
+	return nil
+}
+
+func test14(x *int, i int) {
+	s := &S{}
+	x = s.retNil(1,
+		new(int),
+		"abc",
+		true).bar(i)
+	y := x
+	print(*y) //want "`s.retNil\\(...\\).bar\\(i\\)` to `x`"
+}
+
+func test15(x *int) {
+	var longVarName, anotherLongVarName, yetAnotherLongName int
+	s := &S{}
+	x = s.retNil(longVarName, &anotherLongVarName, "abc", true).bar(yetAnotherLongName)
+	y := x
+	print(*y) //want "`s.retNil\\(...\\).bar\\(...\\)` to `x`"
+}
+
+func test16(mp map[int]*int) {
+	var aVeryVeryVeryLongIndexVar int
+	x := mp[aVeryVeryVeryLongIndexVar]
+	y := x
+	print(*y) //want "`mp\\[...\\]` to `x`"
+}
+
+func test17(x *int, mp map[int]*int) {
+	var aVeryVeryVeryLongIndexVar int
+	s := &S{}
+
+	x = s.retNil(1, mp[aVeryVeryVeryLongIndexVar], "abc", true).bar(2) //want "deep read"
+	y := x
+	print(*y) //want "`s.retNil\\(...\\).bar\\(2\\)` to `x`"
+}
+
+func test18(x *int, mp map[int]*int) {
+	s := &S{}
+	x = mp[*(s.retNil(1, new(int), "abc", true).bar(2))] //want "dereferenced"
+	y := x
+	print(*y) //want "`mp\\[...\\]` to `x`"
 }

--- a/testdata/src/go.uber.org/errormessage/errormessage.go
+++ b/testdata/src/go.uber.org/errormessage/errormessage.go
@@ -200,3 +200,58 @@ func test18(x *int, mp map[int]*int) {
 	y := x
 	print(*y) //want "`mp\\[...\\]` to `x`"
 }
+
+func test19() {
+	mp := make(map[string]*string)
+	x := mp["("]
+	y := x
+	print(*y) //want "`mp\\[\"\\(\"\\]` to `x`"
+
+	x = mp[")"]
+	y = x
+	print(*y) //want "`mp\\[\"\\)\"\\]` to `x`"
+
+	x = mp["))"]
+	y = x
+	print(*y) //want "`mp\\[...\\]` to `x`"
+
+	x = mp["(("]
+	y = x
+	print(*y) //want "`mp\\[...\\]` to `x`"
+
+	x = mp[")))((("]
+	y = x
+	print(*y) //want "`mp\\[...\\]` to `x`"
+
+	x = mp[")))((("]
+	y = x
+	print(*y) //want "`mp\\[...\\]` to `x`"
+
+	x = mp["(((()"]
+	y = x
+	print(*y) //want "`mp\\[...\\]` to `x`"
+
+	x = mp["())))"]
+	y = x
+	print(*y) //want "`mp\\[...\\]` to `x`"
+
+	s := &S{}
+	i := 0
+	a := s.foo(1,
+		new(int),
+		"({[",
+		true).bar(i)
+	b := a
+	print(*b) //want "`s.foo\\(...\\).bar\\(i\\)` to `a`"
+}
+
+func test20() {
+	mp := make(map[rune]*rune)
+	x := mp['(']
+	y := x
+	print(*y) //want "`mp\\['\\('\\]` to `x`"
+
+	x = mp[')']
+	y = x
+	print(*y) //want "`mp\\['\\)'\\]` to `x`"
+}

--- a/testdata/src/go.uber.org/errormessage/errormessage.go
+++ b/testdata/src/go.uber.org/errormessage/errormessage.go
@@ -256,3 +256,9 @@ func test20() {
 	y = x
 	print(*y) //want "`mp\\['\\)'\\]` to `x`"
 }
+
+// below test checks that NilAway can handle non-English (non-ASCII) identifiers
+func test21() {
+	var 世界 *int = nil
+	print(*世界) //want "`nil` to `世界`"
+}

--- a/util/asthelper/asthelper.go
+++ b/util/asthelper/asthelper.go
@@ -63,50 +63,39 @@ func printExpr(writer io.Writer, fset *token.FileSet, e ast.Expr) (err error) {
 
 	switch node := e.(type) {
 	case *ast.Ident:
-		_, err = writer.Write([]byte(node.Name))
+		_, err = io.WriteString(writer, node.Name)
 
 	case *ast.SelectorExpr:
 		if err = printExpr(writer, fset, node.X); err != nil {
 			return
 		}
-		output := []byte{'.'}
-		output = append(output, node.Sel.Name...)
-		_, err = writer.Write(output)
+		_, err = io.WriteString(writer, "."+node.Sel.Name)
 
 	case *ast.CallExpr:
 		if err = printExpr(writer, fset, node.Fun); err != nil {
 			return
 		}
-		output := make([]byte, 0, 5)
-		output = append(output, '(')
+		var argStr string
 		if len(node.Args) > 0 {
-			isShorten := true
+			argStr = "..."
 			if len(node.Args) == 1 {
-				if arg, ok := fullExpr(node.Args[0]); ok {
-					output = append(output, arg...)
-					isShorten = false
+				if a, ok := fullExpr(node.Args[0]); ok {
+					argStr = a
 				}
 			}
-			if isShorten {
-				output = append(output, '.', '.', '.') // ellipsis
-			}
 		}
-		output = append(output, ')')
-		_, err = writer.Write(output)
+		_, err = io.WriteString(writer, "("+argStr+")")
 
 	case *ast.IndexExpr:
 		if err = printExpr(writer, fset, node.X); err != nil {
 			return
 		}
-		output := make([]byte, 0, 5)
-		output = append(output, '[')
+
+		indexExpr := "..."
 		if v, ok := fullExpr(node.Index); ok {
-			output = append(output, v...)
-		} else {
-			output = append(output, '.', '.', '.') // ellipsis
+			indexExpr = v
 		}
-		output = append(output, ']')
-		_, err = writer.Write(output)
+		_, err = io.WriteString(writer, "["+indexExpr+"]")
 
 	default:
 		err = printer.Fprint(writer, fset, e)

--- a/util/asthelper/asthelper.go
+++ b/util/asthelper/asthelper.go
@@ -1,0 +1,110 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package asthelper implements utility functions for AST.
+package asthelper
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/printer"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+// astExprToString converts AST expression to string using the `printer` package
+func astExprToString(e ast.Expr, pass *analysis.Pass) string {
+	var buf bytes.Buffer
+	err := printer.Fprint(&buf, pass.Fset, e)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to convert AST expression to string: %v\n", err))
+	}
+	return buf.String()
+}
+
+// PrintExpr converts AST expression to string, and shortens long expressions if isShortenExpr is true
+func PrintExpr(e ast.Expr, pass *analysis.Pass, isShortenExpr bool) string {
+	if !isShortenExpr {
+		astExprToString(e, pass)
+	}
+
+	// traverse over the AST expression's subtree and shorten long expressions (e.g., s.foo(longVarName, anotherLongVarName, someOtherLongVarName) --> s.foo(...))
+	s := strings.Builder{}
+	printExprHelper(e, pass, &s)
+
+	return s.String()
+}
+
+func printExprHelper(e ast.Expr, pass *analysis.Pass, s *strings.Builder) {
+	// _shortenExprLen is the maximum length of an expression to be printed in full. The value is set to 3 to account for
+	// the length of the ellipsis ("..."), which is used to shorten long expressions.
+	const _shortenExprLen = 3
+
+	// fullExpr returns true if the expression is short enough (<= _shortenExprLen) to be printed in full
+	fullExpr := func(node ast.Node) (string, bool) {
+		switch n := node.(type) {
+		case *ast.Ident:
+			if len(n.Name) <= _shortenExprLen {
+				return n.Name, true
+			}
+		case *ast.BasicLit:
+			if len(n.Value) <= _shortenExprLen {
+				return n.Value, true
+			}
+		}
+		return "", false
+	}
+
+	switch node := e.(type) {
+	case *ast.Ident:
+		s.WriteString(node.Name)
+
+	case *ast.SelectorExpr:
+		printExprHelper(node.X, pass, s)
+		s.WriteString(".")
+		s.WriteString(node.Sel.Name)
+
+	case *ast.CallExpr:
+		printExprHelper(node.Fun, pass, s)
+		s.WriteString("(")
+		if len(node.Args) > 0 {
+			isShorten := true
+			if len(node.Args) == 1 {
+				if arg, ok := fullExpr(node.Args[0]); ok {
+					s.WriteString(arg)
+					isShorten = false
+				}
+			}
+			if isShorten {
+				s.WriteString("...")
+			}
+		}
+		s.WriteString(")")
+
+	case *ast.IndexExpr:
+		printExprHelper(node.X, pass, s)
+		s.WriteString("[")
+		if v, ok := fullExpr(node.Index); ok {
+			s.WriteString(v)
+		} else {
+			s.WriteString("...")
+		}
+		s.WriteString("]")
+
+	default:
+		s.WriteString(astExprToString(e, pass))
+	}
+}

--- a/util/util.go
+++ b/util/util.go
@@ -489,11 +489,70 @@ func PosToLocation(pos token.Pos, pass *analysis.Pass) token.Position {
 }
 
 // ExprToString converts AST expression to string
-func ExprToString(e ast.Expr, pass *analysis.Pass) string {
+func ExprToString(e ast.Expr, pass *analysis.Pass, isShortenExpr bool) string {
 	var buf bytes.Buffer
 	err := printer.Fprint(&buf, pass.Fset, e)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to convert AST expression to string: %v\n", err))
 	}
-	return buf.String()
+	s := buf.String()
+
+	if isShortenExpr {
+		// shorten long expression strings (e.g., s.foo(longVarName, anotherLongVarName, someOtherLongVarName) --> s.foo(...))
+		s = shortenExpr(s)
+	}
+
+	return s
+}
+
+// shortenExpr shortens long expressions enclosed in brackets ('()', '{}', '[]') to "...". It also handles nested brackets
+// and multi-line expressions.
+// Examples:
+// 1. "s.foo(longVarName, anotherLongVarName, someOtherLongVarName)" becomes "s.foo(...)"
+// 2. "s.foo(a, b, c ,d ,e, f).bar(i)" becomes "s.foo(...).bar(i)"
+// 3. "s.foo(someVar, bar(), baz(x, y))" becomes "s.foo(...)"
+// 4. "foo(exprOnLine1,
+// exprOnLine2,
+// exprOnLine3)" becomes "foo(...)"
+func shortenExpr(expr string) string {
+	var result strings.Builder
+	var depth int
+	var inBrackets bool
+	var innerExpr strings.Builder
+
+	for _, char := range expr {
+		switch char {
+		case '(', '{', '[':
+			if depth == 0 {
+				depth++
+				inBrackets = true
+				result.WriteRune(char)
+			}
+			continue
+
+		case ')', '}', ']':
+			depth--
+			if depth == 0 {
+				// Replace the content inside brackets with "..." if it is long (more than 3 characters)
+				if innerExpr.Len() > 3 {
+					result.WriteString("...")
+				} else {
+					result.WriteString(innerExpr.String())
+				}
+				result.WriteRune(char)
+
+				inBrackets = false
+				innerExpr.Reset()
+			}
+			continue
+		}
+
+		if inBrackets {
+			innerExpr.WriteRune(char)
+			continue
+		}
+		result.WriteRune(char)
+	}
+
+	return result.String()
 }

--- a/util/util.go
+++ b/util/util.go
@@ -519,10 +519,19 @@ func shortenExpr(expr string) string {
 	var depth int                 // helps to keep track of nested brackets
 	var inBrackets bool           // indicates if we are currently inside brackets
 	var innerExpr strings.Builder // stores the content inside brackets
+	var inQuotes bool             // indicates if we are currently inside quotes
 
 	for _, char := range expr {
 		switch char {
+		case '"', '\'':
+			inQuotes = !inQuotes
+
 		case '(', '{', '[':
+			if inQuotes {
+				innerExpr.WriteRune(char)
+				continue
+			}
+
 			if depth == 0 {
 				inBrackets = true
 				result.WriteRune(char) // append the opening bracket
@@ -531,6 +540,11 @@ func shortenExpr(expr string) string {
 			continue
 
 		case ')', '}', ']':
+			if inQuotes {
+				innerExpr.WriteRune(char)
+				continue
+			}
+
 			depth--
 			if depth == 0 {
 				// Replace the content inside brackets with "..." if it is long (more than 3 characters), else
@@ -548,11 +562,11 @@ func shortenExpr(expr string) string {
 			continue
 		}
 
-		if inBrackets {
+		if inBrackets || inQuotes {
 			innerExpr.WriteRune(char) // append the character to the inner expression
-			continue
+		} else {
+			result.WriteRune(char) // append the character to the result if not in brackets, and not a bracket itself
 		}
-		result.WriteRune(char) // append the character to the result if not in brackets, and not a bracket itself
 	}
 
 	return result.String()

--- a/util/util.go
+++ b/util/util.go
@@ -516,30 +516,31 @@ func ExprToString(e ast.Expr, pass *analysis.Pass, isShortenExpr bool) string {
 // exprOnLine3)" becomes "foo(...)"
 func shortenExpr(expr string) string {
 	var result strings.Builder
-	var depth int
-	var inBrackets bool
-	var innerExpr strings.Builder
+	var depth int                 // helps to keep track of nested brackets
+	var inBrackets bool           // indicates if we are currently inside brackets
+	var innerExpr strings.Builder // stores the content inside brackets
 
 	for _, char := range expr {
 		switch char {
 		case '(', '{', '[':
 			if depth == 0 {
-				depth++
 				inBrackets = true
-				result.WriteRune(char)
+				result.WriteRune(char) // append the opening bracket
 			}
+			depth++
 			continue
 
 		case ')', '}', ']':
 			depth--
 			if depth == 0 {
-				// Replace the content inside brackets with "..." if it is long (more than 3 characters)
+				// Replace the content inside brackets with "..." if it is long (more than 3 characters), else
+				// retain the original content as is.
 				if innerExpr.Len() > 3 {
 					result.WriteString("...")
 				} else {
 					result.WriteString(innerExpr.String())
 				}
-				result.WriteRune(char)
+				result.WriteRune(char) // append the closing bracket
 
 				inBrackets = false
 				innerExpr.Reset()
@@ -548,10 +549,10 @@ func shortenExpr(expr string) string {
 		}
 
 		if inBrackets {
-			innerExpr.WriteRune(char)
+			innerExpr.WriteRune(char) // append the character to the inner expression
 			continue
 		}
-		result.WriteRune(char)
+		result.WriteRune(char) // append the character to the result if not in brackets, and not a bracket itself
 	}
 
 	return result.String()


### PR DESCRIPTION
This PR shortens the expression strings in assignment part of the error messages. For example, the expression `x = s.foo(longVarName, &anotherLongVarName, "abc", true)` is shortened to `s.foo(...)` to offer better readability. The changes have also have been performance evaluated internally.