### PR TITLE
Fix error handling logic to analyze functions with mixed return types

### DIFF
--- a/assertion/function/assertiontree/backprop_util.go
+++ b/assertion/function/assertiontree/backprop_util.go
@@ -280,13 +280,6 @@ func handleErrorReturns(rootNode *RootAssertionNode, retStmt *ast.ReturnStmt, re
 	nonErrRetExpr := results[:errRetIndex] // n-1 expressions
 
 	// check if the error return is at all guarding any nilable returns, such as pointers, maps, and slices
-	for _, r := range nonErrRetExpr {
-		if util.ExprBarsNilness(rootNode.Pass(), r) {
-			// no need to further analyze and create triggers
-			return true
-		}
-	}
-
 	if isErrorReturnNil(rootNode, errRetExpr) {
 		// if error is the only return expression in the statement, then create a consumer for it, else create consumers for the non-error return expressions
 		if len(nonErrRetExpr) == 0 {

--- a/testdata/src/go.uber.org/errorreturn/inference/errorreturn-with-inference.go
+++ b/testdata/src/go.uber.org/errorreturn/inference/errorreturn-with-inference.go
@@ -176,3 +176,37 @@ func checkAndDeref() {
 		_ = *x //want "error return in position 1 is not guaranteed to be non-nil through all paths"
 	}
 }
+
+// ***** below tests error handling logic for mixed nilable (e.g., pointer) and non-nilable (e.g., string) non-error returns *****
+func retStrNilErr() (string, *int, error) {
+	if dummy2 {
+		return "abc", nil, nil
+	}
+	return "", nil, &myErr2{}
+}
+
+func retNilStrErr() (*int, string, error) {
+	if dummy2 {
+		return nil, "abc", nil
+	}
+	return nil, "", &myErr2{}
+}
+
+func testMixedReturns() {
+	if _, x, err := retStrNilErr(); err == nil {
+		print(*x) //want "dereferenced"
+	}
+
+	if _, x, _ := retStrNilErr(); x != nil {
+		print(*x)
+	}
+
+	if x, _, err := retNilStrErr(); err == nil {
+		print(*x) //want "dereferenced"
+	}
+}
+
+// nonnil(result 1)
+func testMixedReturnsPassToAnotherFunc() (string, *int, error) { //want "returned"
+	return retStrNilErr()
+}

--- a/testdata/src/go.uber.org/errorreturn/inference/errorreturn-with-inference.go
+++ b/testdata/src/go.uber.org/errorreturn/inference/errorreturn-with-inference.go
@@ -210,3 +210,19 @@ func testMixedReturns() {
 func testMixedReturnsPassToAnotherFunc() (string, *int, error) { //want "returned"
 	return retStrNilErr()
 }
+
+type myPointer *int
+
+func retAliasedNilStrErr() (string, myPointer, error) {
+	if dummy2 {
+		return "abc", nil, nil
+	}
+	return "", nil, &myErr2{}
+}
+
+func testAliasedMixedReturns() {
+	if _, x, err := retAliasedNilStrErr(); err == nil {
+		print(*x) //want "dereferenced"
+	}
+
+}


### PR DESCRIPTION
The error handling logic contained code that skipped analysis of error returning functions with a mix of nilable and non-nilable (e.g., string, int) types, resulting in false negatives. This PR fixes the bug.