### PR TITLE
Support for handling of `ok` form for functions/methods

### DIFF
--- a/assertion/function/assertiontree/backprop.go
+++ b/assertion/function/assertiontree/backprop.go
@@ -198,13 +198,12 @@ func backpropAcrossReturn(rootNode *RootAssertionNode, node *ast.ReturnStmt) err
 						// this nil check reflects programmer logic
 						return errors.New("producers variable is nil")
 					}
-
-					isErrReturning := util.FuncIsErrReturning(funcObj)
-					isOkReturning := util.FuncIsOkReturning(funcObj)
-
 					// since we don't individually track the returns of a multiply returning function,
 					// we form full triggers for each return whose type doesn't bar nilness
 					if !util.TypeBarsNilness(funcObj.Type().(*types.Signature).Results().At(i).Type()) {
+						isErrReturning := util.FuncIsErrReturning(funcObj)
+						isOkReturning := util.FuncIsOkReturning(funcObj)
+
 						rootNode.AddNewTriggers(annotation.FullTrigger{
 							Producer: &annotation.ProduceTrigger{
 								// since the value is being returned directly, only its shallow nilability

--- a/assertion/function/assertiontree/backprop.go
+++ b/assertion/function/assertiontree/backprop.go
@@ -200,6 +200,7 @@ func backpropAcrossReturn(rootNode *RootAssertionNode, node *ast.ReturnStmt) err
 					}
 
 					isErrReturning := util.FuncIsErrReturning(funcObj)
+					isOkReturning := util.FuncIsOkReturning(funcObj)
 
 					// since we don't individually track the returns of a multiply returning function,
 					// we form full triggers for each return whose type doesn't bar nilness
@@ -225,7 +226,7 @@ func backpropAcrossReturn(rootNode *RootAssertionNode, node *ast.ReturnStmt) err
 								// if an error returning function returns directly as the result of
 								// another error returning function, then its results can safely be
 								// interpreted as guarded
-								GuardMatched: isErrReturning,
+								GuardMatched: isErrReturning || isOkReturning,
 							},
 						})
 					}

--- a/assertion/function/assertiontree/backprop_util.go
+++ b/assertion/function/assertiontree/backprop_util.go
@@ -329,9 +329,7 @@ func handleErrorReturns(rootNode *RootAssertionNode, retStmt *ast.ReturnStmt, re
 // which guards at least one of the first n-1 non-bool results). Similar to the handliong of error returning functions,
 // for boolean returns, we generate consumers by applying the following boolean contract:
 // (1) if boolean return value = true, create consumers for the non-boolean returns
-// TODO: currently we support only explicit boolean returns, i.e., `return r0, r1, ..., true`. We should also support
-//
-//	implicit boolean returns, i.e., `return` or `return <expr>`
+// TODO: currently we support only explicit boolean returns, i.e., `return r0, r1, ..., true`. We should also support implicit boolean returns, i.e., `return` or `return <expr>`
 func handleBooleanReturns(rootNode *RootAssertionNode, retStmt *ast.ReturnStmt, results []ast.Expr, isNamedReturn bool) {
 	nRetIndex := len(results) - 1
 	nRetExpr := results[nRetIndex]          // n-th expression

--- a/assertion/function/assertiontree/backprop_util.go
+++ b/assertion/function/assertiontree/backprop_util.go
@@ -274,15 +274,11 @@ func isBooleanReturnTrue(errRet ast.Expr) bool {
 	return false
 }
 
-// handleErrorReturns handles the special case for functions with contract returning pattern, namely, error returns
-// and boolean (`ok`) returns. In this, the n-th result of type `error` or `boolean` guards at least one of the first n-1 results.
-// For error returns, we generate consumers by applying the following error contract:
+// handleErrorReturns handles the special case for error returning functions (n-th result of type `error` which guards at least one of the first n-1 non-error results).
+// It generates consumers by applying the error contract:
 // (1) if error return value = nil, create consumers for the non-error returns
 // (2) if error return value = non-nil, create consumer for error return
 // (3) if error return value = unknown, create consumers for all returns (error and non-error), and defer applying of the error contract when the nilability status is known, such as at `ProcessEntry`
-//
-// Similarly, for boolean returns, we generate consumers by applying the following boolean contract:
-// (1) if boolean return value = true, create consumers for the non-boolean returns
 //
 // Note that `results` should be explicitly passed since `retStmt` of a named return will contain no results
 func handleErrorReturns(rootNode *RootAssertionNode, retStmt *ast.ReturnStmt, results []ast.Expr, isNamedReturn bool) {
@@ -329,6 +325,13 @@ func handleErrorReturns(rootNode *RootAssertionNode, retStmt *ast.ReturnStmt, re
 	}
 }
 
+// handleBooleanReturns handles the special case for boolean (`ok`) returning functions (n-th result of type `bool`
+// which guards at least one of the first n-1 non-bool results). Similar to the handliong of error returning functions,
+// for boolean returns, we generate consumers by applying the following boolean contract:
+// (1) if boolean return value = true, create consumers for the non-boolean returns
+// TODO: currently we support only explicit boolean returns, i.e., `return r0, r1, ..., true`. We should also support
+//
+//	implicit boolean returns, i.e., `return` or `return <expr>`
 func handleBooleanReturns(rootNode *RootAssertionNode, retStmt *ast.ReturnStmt, results []ast.Expr, isNamedReturn bool) {
 	nRetIndex := len(results) - 1
 	nRetExpr := results[nRetIndex]          // n-th expression

--- a/assertion/function/assertiontree/contract.go
+++ b/assertion/function/assertiontree/contract.go
@@ -323,7 +323,7 @@ func NodeTriggersOkRead(rootNode *RootAssertionNode, nonceGenerator *util.GuardN
 			return nil, false
 		}
 
-		rhsFuncDecl, ok := rootNode.Pass().TypesInfo.ObjectOf(callIdent).(*types.Func)
+		rhsFuncDecl, ok := rootNode.ObjectOf(callIdent).(*types.Func)
 
 		if !ok || !util.FuncIsOkReturning(rhsFuncDecl) {
 			return nil, false

--- a/assertion/function/assertiontree/parse_expr_producer.go
+++ b/assertion/function/assertiontree/parse_expr_producer.go
@@ -411,6 +411,7 @@ func (r *RootAssertionNode) getFuncReturnProducers(ident *ast.Ident, expr *ast.C
 
 	numResults := util.FuncNumResults(funcObj)
 	isErrReturning := util.FuncIsErrReturning(funcObj)
+	isOkReturning := util.FuncIsOkReturning(funcObj)
 
 	producers := make([]producer.ParsedProducer, numResults)
 
@@ -436,11 +437,11 @@ func (r *RootAssertionNode) getFuncReturnProducers(ident *ast.Ident, expr *ast.C
 				Annotation: &annotation.FuncReturn{
 					TriggerIfNilable: &annotation.TriggerIfNilable{
 						Ann: retKey,
-						// for an error-returning function, all but the last result are guarded
-						// TODO: add an annotation that allows more results to escape from guarding
-						// such as "error-nonnil" or "always-nonnil"
-						NeedsGuard: isErrReturning && i != numResults-1,
 					},
+					// for an error-returning function, all but the last result are guarded
+					// TODO: add an annotation that allows more results to escape from guarding
+					// such as "error-nonnil" or "always-nonnil"
+					NeedsGuard: (isErrReturning || isOkReturning) && i != numResults-1,
 				},
 				Expr: expr,
 			},

--- a/assertion/function/assertiontree/parse_expr_producer.go
+++ b/assertion/function/assertiontree/parse_expr_producer.go
@@ -437,11 +437,12 @@ func (r *RootAssertionNode) getFuncReturnProducers(ident *ast.Ident, expr *ast.C
 				Annotation: &annotation.FuncReturn{
 					TriggerIfNilable: &annotation.TriggerIfNilable{
 						Ann: retKey,
+
+						// for an error-returning function, all but the last result are guarded
+						// TODO: add an annotation that allows more results to escape from guarding
+						// such as "error-nonnil" or "always-nonnil"
+						NeedsGuard: (isErrReturning || isOkReturning) && i != numResults-1,
 					},
-					// for an error-returning function, all but the last result are guarded
-					// TODO: add an annotation that allows more results to escape from guarding
-					// such as "error-nonnil" or "always-nonnil"
-					NeedsGuard: (isErrReturning || isOkReturning) && i != numResults-1,
 				},
 				Expr: expr,
 			},

--- a/nilaway_test.go
+++ b/nilaway_test.go
@@ -39,7 +39,7 @@ func TestContracts(t *testing.T) {
 	t.Parallel()
 
 	testdata := analysistest.TestData()
-	analysistest.Run(t, testdata, Analyzer, "go.uber.org/contracts")
+	analysistest.Run(t, testdata, Analyzer, "go.uber.org/contracts", "go.uber.org/contracts/namedtypes")
 }
 
 func TestTesting(t *testing.T) {

--- a/testdata/src/go.uber.org/contracts/namedtypes/namedtypes.go
+++ b/testdata/src/go.uber.org/contracts/namedtypes/namedtypes.go
@@ -1,0 +1,44 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package namedtypes: This package tests that named types are correctly handled for contract types (e.g., error
+// returning functions and ok-form for functions)
+package namedtypes
+
+// the below test uses the built-in name `bool` for creating a user-defined named type. However, the logic for determining
+// an ok-form function should not depend on the name `bool`, but the underlying type. This test ensures that the logic.
+type bool int
+
+func retPtrBoolNamed() (*int, bool) {
+	return nil, 0
+}
+
+func testNamedBool() {
+	if v, ok := retPtrBoolNamed(); ok == 0 {
+		_ = *v // want "dereferenced"
+	}
+}
+
+// Similar to the above test, but with the built-in name `error`
+type error int
+
+func retPtrErrorNamed() (*int, error) {
+	return nil, 0
+}
+
+func testNamedError() {
+	if v, ok := retPtrErrorNamed(); ok == 0 {
+		_ = *v // want "dereferenced"
+	}
+}

--- a/testdata/src/go.uber.org/contracts/userdefinedfunctions.go
+++ b/testdata/src/go.uber.org/contracts/userdefinedfunctions.go
@@ -12,27 +12,626 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/*
-This file tests the contract of "ok" form for user defined functions.
-
-<nilaway no inference>
-*/
+// Package contracts: This file tests the contract of "ok" form for user defined and standard library functions.
+//
+// <nilaway no inference>
 package contracts
 
-func test() {
-	m := map[*int]*int{}
-	if v, ok := m[new(int)]; ok {
-		print(*v) // no error reported because NilAway handles "OK" form for a map.
+import "runtime/debug"
+
+// below tests check behavior of ok-form for user defined functions
+
+func retPtrAndBool() (*int, bool) {
+	if true {
+		return nil, false
 	}
-	if v, ok := foo(new(int)); ok {
-		print(*v) // However, this line still throws a false positive because NilAway does not handle "OK" form for a user-defined function.
+	return new(int), true
+}
+
+func testSafeCases(i int) {
+	switch i {
+	case 0:
+		if v, ok := retPtrAndBool(); ok {
+			print(*v)
+		}
+	case 1:
+		v, ok := retPtrAndBool()
+		if ok {
+			print(*v)
+		}
+	case 2:
+		v, ok := retPtrAndBool()
+		if ok == true {
+			print(*v)
+		}
+	case 3:
+		v, ok := retPtrAndBool()
+		if !(!(!(!ok))) {
+			print(*v)
+		}
+	case 4:
+		v, ok := retPtrAndBool()
+		if !ok {
+			return
+		}
+		print(*v)
+	case 5:
+		v, ok := retPtrAndBool()
+		var otherOk bool
+		if ok && !otherOk {
+			print(*v)
+		}
+	}
+}
+
+func testUnsafeCases(i int) {
+	switch i {
+	case 0:
+		if v, ok := retPtrAndBool(); !ok {
+			print(*v) //want "dereferenced"
+		}
+	case 1:
+		v, ok := retPtrAndBool()
+		if !ok {
+			print(*v) //want "dereferenced"
+		}
+	case 2:
+		v, ok := retPtrAndBool()
+		if ok == false {
+			print(*v) //want "dereferenced"
+		}
+	case 3:
+		v, ok := retPtrAndBool()
+		if !(!(!(ok))) {
+			print(*v) //want "dereferenced"
+		}
+	case 4:
+		v, ok := retPtrAndBool()
+		if ok {
+			return
+		}
+		print(*v) //want "dereferenced"
+	case 5:
+		v, ok := retPtrAndBool()
+		var otherOk bool
+		if ok || otherOk {
+			print(*v) //want "dereferenced"
+		}
+	}
+}
+
+// below tests check behavior of ok-form for user defined functions with named returns
+
+func retPtrAndBoolNamed() (x *int, ok bool) {
+	if dummy {
+		return
+	}
+	x = new(int)
+	ok = true
+	return
+}
+
+func testNamedReturn(i int) {
+	if v, ok := retPtrAndBoolNamed(); ok {
+		print(*v)
+	}
+
+	v, ok := retPtrAndBoolNamed()
+	_ = ok
+	print(*v) //want "dereferenced"
+}
+
+// below test checks behavior of ok-form for user defined methods
+
+type T struct {
+	Str *string
+}
+
+func (t *T) GetStr() (*string, bool) {
+	if t == nil || t.Str == nil {
+		return nil, false
+	}
+	return t.Str, true
+}
+
+func testMethod() {
+	t := &T{}
+	if ptr, ok := t.GetStr(); ok {
+		print(*ptr)
+	}
+}
+
+// below test checks behavior of ok-form for library functions
+
+func testLibraryFunction() {
+	info, ok := debug.ReadBuildInfo()
+	print(info.Path) //want "accessed field"
+
+	if !ok {
+		return
+	}
+	for _, kv := range info.Settings {
+		_ = kv
+	}
+}
+
+// below tests are relevant excerpts from the `errorreturn` test suite adapted to the "ok" form for user defined functions
+
+// nilable(result 0)
+func takesNonnilRetsNilable(x *int) *int {
+	return x
+}
+
+// nilable(result 0, result 1)
+func retsNilableNilableWithBool() (*int, *int, bool) {
+	if dummy {
+		return nil, nil, true
+	}
+	return nil, nil, false
+}
+
+func retsNonnilNonnilWithBool() (*int, *int, bool) {
+	i := 0
+	if dummy {
+		return &i, &i, true
+	}
+	return nil, nil, false
+}
+
+// nilable(result 0)
+func retsNilableNonnilWithBool() (*int, *int, bool) {
+	i := 0
+	if dummy {
+		return nil, &i, true
+	}
+	return nil, nil, false
+}
+
+// nilable(x, result 1)
+func retsNonnilNilableWithBool(x *int, y *int, i int) (*int, *int, bool) {
+	switch i {
+	case 1:
+		// this safe case indicates that if we return false as boolean value,
+		// we can return nilable values in n-1 results without error
+		return nil, nil, false
+	case 2:
+		// this is the same safe case as above, but involving flow from a nilable param
+		return x, nil, false
+	case 3:
+		// this is safe
+		return &i, nil, false
+	case 4:
+		// this is safe
+		return y, nil, false
+	case 5:
+		// this checks that even if a false aborts the consumption of the other returns,
+		// the other returns are still checked for inner illegal consumptions
+		return takesNonnilRetsNilable(nil), nil, false //want "passed"
+	case 6:
+		// this error case indicates that if we return true and nil as a
+		// non-nilable result, then that result will be interpreted as an error
+		return nil, nil, true //want "returned"
+	case 7:
+		// this is the same error case as above, but involving flow from a param
+		return x, nil, true //want "returned"
+	case 8:
+		// this is safe
+		return &i, nil, true
+	case 9:
+		// this is safe
+		return y, nil, true
+	}
+
+	// these cases now test the direct return of other of-form-returning functions
+	switch 0 {
+	case 1:
+		return retsNilableNilableWithBool() //want "returned"
+	case 2:
+		return retsNilableNonnilWithBool() //want "returned"
+	case 3:
+		return retsNonnilNonnilWithBool()
+	default:
+		return retsNonnilNilableWithBool(x, y, i)
+	}
+}
+
+func takesNonnil(any) {}
+
+// this is mostly here to identify failures of the `ok` checking mechanism in its most basic form
+// if this test fails then the mechanism is very broken
+func simpleUsesBoolFunc(i int) {
+	nonnilPtr, _, ok := retsNonnilNilableWithBool(&i, &i, i)
+	if ok {
+		takesNonnil(nonnilPtr)
+	}
+}
+
+func usesBoolFunc() {
+	i := 0
+	nonnilPtr, nilablePtr, ok := retsNonnilNilableWithBool(&i, &i, i)
+	var ok2 bool
+
+	switch 0 {
+	case 1:
+		takesNonnil(nonnilPtr)  //want "passed"
+		takesNonnil(nilablePtr) //want "passed"
+	case 2:
+		if ok {
+			takesNonnil(nonnilPtr)
+			takesNonnil(nilablePtr) //want "passed"
+			return
+		}
+		takesNonnil(nonnilPtr)  //want "passed"
+		takesNonnil(nilablePtr) //want "passed"
+	case 3:
+		if !ok {
+			takesNonnil(nonnilPtr)  //want "passed"
+			takesNonnil(nilablePtr) //want "passed"
+			return
+		}
+		takesNonnil(nonnilPtr)
+		takesNonnil(nilablePtr) //want "passed"
+	case 6:
+		if ok2 {
+			takesNonnil(nonnilPtr)  //want "passed"
+			takesNonnil(nilablePtr) //want "passed"
+			return
+		}
+		takesNonnil(nonnilPtr)  //want "passed"
+		takesNonnil(nilablePtr) //want "passed"
+	case 7:
+		if dummy {
+			if !ok {
+				return
+			}
+		} else {
+			if !ok {
+				return
+			}
+		}
+		takesNonnil(nonnilPtr)
+		takesNonnil(nilablePtr) //want "passed"
+	case 8:
+		if dummy {
+			if ok {
+				return
+			}
+		} else {
+			if !ok {
+				return
+			}
+		}
+		takesNonnil(nonnilPtr)  //want "passed"
+		takesNonnil(nilablePtr) //want "passed"
+	case 9:
+		if dummy {
+			if !ok {
+				return
+			}
+		} else {
+			if ok {
+				return
+			}
+		}
+		takesNonnil(nonnilPtr)  //want "passed"
+		takesNonnil(nilablePtr) //want "passed"
+	case 10:
+		var nilablePtr, nonnilPtr *int
+		var ok bool
+		if dummy {
+			nonnilPtr, nilablePtr, ok = retsNonnilNilableWithBool(&i, &i, i)
+		} else {
+			nonnilPtr, nilablePtr, ok = retsNonnilNilableWithBool(&i, &i, i)
+		}
+
+		if !ok {
+			return
+		}
+
+		takesNonnil(nonnilPtr)
+		takesNonnil(nilablePtr) //want "passed"
+	case 11:
+		var nonnilPtr *int
+		var ok bool
+		switch 0 {
+		case 1:
+			nonnilPtr, _, ok = retsNonnilNilableWithBool(&i, &i, i)
+		case 2:
+			nonnilPtr, _, ok = retsNonnilNonnilWithBool()
+		case 3:
+			_, nonnilPtr, ok = retsNonnilNonnilWithBool()
+		default:
+			_, nonnilPtr, ok = retsNilableNonnilWithBool()
+		}
+
+		if !ok {
+			return
+		}
+
+		takesNonnil(nonnilPtr)
+	case 12:
+		var nilablePtr, nonnilPtr *int
+		var ok bool
+		if dummy {
+			nonnilPtr, nilablePtr, ok = retsNonnilNilableWithBool(&i, &i, i)
+		} else {
+			nonnilPtr, nilablePtr = &i, nil
+		}
+
+		if !ok {
+			return
+		}
+
+		takesNonnil(nonnilPtr)
+		takesNonnil(nilablePtr) //want "passed" "passed"
 	}
 }
 
 // nilable(result 0)
-func foo(x *int) (*int, bool) {
-	if x == nil {
-		return nil, false
+func testNilableAnyways() (*int, bool) {
+	if dummy {
+		return nil, true
 	}
-	return new(int), true
+	return nil, false
+}
+
+func retsAnyBool() (any, bool) {
+	return 0, true
+}
+
+func noop() {}
+
+// this test checks to make sure that if a FullTrigger is generated as GuardMatched = true, but becomes
+// discovered to be GuardMatched = false later (here because the path including the second `noop` and
+// `!ok` is longer than the path without it and `ok`) then GuardMatched is correctly
+// updated to false in the final FullTriggers - yielding termination (the matched and unmatched
+// triggers don't endlessly cycle through the `range x` loop) and exactly one error message
+func testStableThroughLoop(x []string) any {
+
+	for range x {
+		noop()
+	}
+
+	cert, ok := retsAnyBool()
+
+	if !ok {
+		noop()
+	}
+
+	return cert //want "returned"
+}
+
+// nilable(f, g)
+type A struct {
+	f  *A
+	g  *A
+	ok bool
+}
+
+// nilable(result 1)
+func retsNonnilNilableAWithBool() (*A, *A, bool) {
+	if dummy {
+		return &A{}, nil, true
+	}
+	return nil, nil, false
+}
+
+func testTrackingThroughDeeperExprParallel() {
+	a, b := &A{}, &A{}
+	a.f, a.g, b.f, b.g = &A{}, &A{}, &A{}, &A{}
+	a.f.g, a.g.f, b.f.g, b.g.f = nil, nil, nil, nil
+	a.f.g, b.g.f, b.ok = retsNonnilNilableAWithBool()
+	b.f.g, a.g.f, a.ok = retsNonnilNilableAWithBool()
+
+	switch getInt() {
+	case getInt():
+		takesNonnil(a)
+		takesNonnil(b)
+		takesNonnil(a.f)
+		takesNonnil(a.g)
+		takesNonnil(b.f)
+		takesNonnil(b.g)
+		takesNonnil(a.f.g) //want "passed"
+		takesNonnil(a.g.f) //want "passed"
+		takesNonnil(b.f.g) //want "passed"
+		takesNonnil(b.g.f) //want "passed"
+	case getInt():
+		if b.ok {
+			takesNonnil(a)
+			takesNonnil(b)
+			takesNonnil(a.f)
+			takesNonnil(a.g)
+			takesNonnil(b.f)
+			takesNonnil(b.g)
+			takesNonnil(a.f.g)
+			takesNonnil(a.g.f) //want "passed"
+			takesNonnil(b.f.g) //want "passed"
+			takesNonnil(b.g.f) //want "passed"
+		}
+	case getInt():
+		if a.ok {
+			takesNonnil(a)
+			takesNonnil(b)
+			takesNonnil(a.f)
+			takesNonnil(a.g)
+			takesNonnil(b.f)
+			takesNonnil(b.g)
+			takesNonnil(a.f.g) //want "passed"
+			takesNonnil(a.g.f) //want "passed"
+			takesNonnil(b.f.g)
+			takesNonnil(b.g.f) //want "passed"
+		}
+	case getInt():
+		if a.ok && b.ok {
+			takesNonnil(a)
+			takesNonnil(b)
+			takesNonnil(a.f)
+			takesNonnil(a.g)
+			takesNonnil(b.f)
+			takesNonnil(b.g)
+			takesNonnil(a.f.g)
+			takesNonnil(a.g.f) //want "passed"
+			takesNonnil(b.f.g)
+			takesNonnil(b.g.f) //want "passed"
+		}
+	case getInt():
+		if a.ok || b.ok {
+			takesNonnil(a)
+			takesNonnil(b)
+			takesNonnil(a.f)
+			takesNonnil(a.g)
+			takesNonnil(b.f)
+			takesNonnil(b.g)
+			takesNonnil(a.f.g) //want "passed"
+			takesNonnil(a.g.f) //want "passed"
+			takesNonnil(b.f.g) //want "passed"
+			takesNonnil(b.g.f) //want "passed"
+		}
+	case getInt():
+		if b.ok && a.ok {
+			takesNonnil(a)
+			takesNonnil(b)
+			takesNonnil(a.f)
+			takesNonnil(a.g)
+			takesNonnil(b.f)
+			takesNonnil(b.g)
+			takesNonnil(a.f.g)
+			takesNonnil(a.g.f) //want "passed"
+			takesNonnil(b.f.g)
+			takesNonnil(b.g.f) //want "passed"
+		}
+	case getInt():
+		if b.ok || a.ok {
+			takesNonnil(a)
+			takesNonnil(b)
+			takesNonnil(a.f)
+			takesNonnil(a.g)
+			takesNonnil(b.f)
+			takesNonnil(b.g)
+			takesNonnil(a.f.g) //want "passed"
+			takesNonnil(a.g.f) //want "passed"
+			takesNonnil(b.f.g) //want "passed"
+			takesNonnil(b.g.f) //want "passed"
+		}
+	}
+}
+
+func testTrackingThroughDeeperExprSeries() {
+	a, b := &A{}, &A{}
+	a.f, a.g, b.f, b.g = &A{}, &A{}, &A{}, &A{}
+	a.f.g, a.g.f, b.f.g, b.g.f = nil, nil, nil, nil
+	a.f.g, b.g.f, b.ok = retsNonnilNilableAWithBool()
+	b.f.g, a.g.f, a.ok = retsNonnilNilableAWithBool()
+
+	takesNonnil(a)
+	takesNonnil(b)
+	takesNonnil(a.f)
+	takesNonnil(a.g)
+	takesNonnil(b.f)
+	takesNonnil(b.g)
+	takesNonnil(a.f.g) //want "passed"
+	takesNonnil(a.g.f) //want "passed"
+	takesNonnil(b.f.g) //want "passed"
+	takesNonnil(b.g.f) //want "passed"
+
+	if b.ok {
+		takesNonnil(a)
+		takesNonnil(b)
+		takesNonnil(a.f)
+		takesNonnil(a.g)
+		takesNonnil(b.f)
+		takesNonnil(b.g)
+		takesNonnil(a.f.g)
+		takesNonnil(a.g.f) //want "passed"
+		takesNonnil(b.f.g) //want "passed"
+		takesNonnil(b.g.f) //want "passed"
+	}
+
+	if a.ok {
+		takesNonnil(a)
+		takesNonnil(b)
+		takesNonnil(a.f)
+		takesNonnil(a.g)
+		takesNonnil(b.f)
+		takesNonnil(b.g)
+		takesNonnil(a.f.g) //want "passed"
+		takesNonnil(a.g.f) //want "passed"
+		takesNonnil(b.f.g)
+		takesNonnil(b.g.f) //want "passed"
+	}
+
+	if a.ok && b.ok {
+		takesNonnil(a)
+		takesNonnil(b)
+		takesNonnil(a.f)
+		takesNonnil(a.g)
+		takesNonnil(b.f)
+		takesNonnil(b.g)
+		takesNonnil(a.f.g)
+		takesNonnil(a.g.f) //want "passed"
+		takesNonnil(b.f.g)
+		takesNonnil(b.g.f) //want "passed"
+	}
+
+	if a.ok || b.ok {
+		takesNonnil(a)
+		takesNonnil(b)
+		takesNonnil(a.f)
+		takesNonnil(a.g)
+		takesNonnil(b.f)
+		takesNonnil(b.g)
+		takesNonnil(a.f.g) //want "passed"
+		takesNonnil(a.g.f) //want "passed"
+		takesNonnil(b.f.g) //want "passed"
+		takesNonnil(b.g.f) //want "passed"
+	}
+
+	if b.ok && a.ok {
+		takesNonnil(a)
+		takesNonnil(b)
+		takesNonnil(a.f)
+		takesNonnil(a.g)
+		takesNonnil(b.f)
+		takesNonnil(b.g)
+		takesNonnil(a.f.g)
+		takesNonnil(a.g.f) //want "passed"
+		takesNonnil(b.f.g)
+		takesNonnil(b.g.f) //want "passed"
+	}
+
+	if b.ok || a.ok {
+		takesNonnil(a)
+		takesNonnil(b)
+		takesNonnil(a.f)
+		takesNonnil(a.g)
+		takesNonnil(b.f)
+		takesNonnil(b.g)
+		takesNonnil(a.f.g) //want "passed"
+		takesNonnil(a.g.f) //want "passed"
+		takesNonnil(b.f.g) //want "passed"
+		takesNonnil(b.g.f) //want "passed"
+	}
+}
+
+type I interface{}
+
+func retsI() (I, bool) {
+	return &A{}, true
+}
+
+// this tests a weird heinous case: type switches don't link their AST node variables to internal
+// types.var instances, so we test to make sure that the parsing of ast.AssignStmt's as part of
+// contract propagation can handle that
+func boolContractPassedThroughTypeSwitch() any {
+	i, ok := retsI()
+
+	if !ok {
+		return &A{}
+	}
+
+	switch j := i.(type) {
+	case *A:
+		return j
+	}
+	return i
 }

--- a/testdata/src/go.uber.org/contracts/userdefinedfunctions.go
+++ b/testdata/src/go.uber.org/contracts/userdefinedfunctions.go
@@ -744,6 +744,13 @@ func retPtrBoolConst() (*int, bool) {
 	return new(int), trueVal
 }
 
+func retPtrBoolConstIncorrect() (*int, bool) {
+	if dummy {
+		return nil, trueVal //want "literal `nil` returned"
+	}
+	return new(int), falseVal
+}
+
 func testConstants() {
 	// safe
 	if v, ok := retPtrBoolConst(); ok {

--- a/testdata/src/go.uber.org/contracts/userdefinedfunctions.go
+++ b/testdata/src/go.uber.org/contracts/userdefinedfunctions.go
@@ -106,9 +106,7 @@ func retPtrAndBoolNamed() (x *int, ok bool) {
 	if dummy {
 		return
 	}
-	x = new(int)
-	ok = true
-	return
+	return new(int), true
 }
 
 func testNamedReturn(i int) {
@@ -368,11 +366,17 @@ func usesBoolFunc() {
 }
 
 // nilable(result 0)
-func testNilableAnyways() (*int, bool) {
+func retNilableAnyways() (*int, bool) {
 	if dummy {
 		return nil, true
 	}
 	return nil, false
+}
+
+func testNilableAnyways() {
+	if v, ok := retNilableAnyways(); ok {
+		print(*v) //want "dereferenced"
+	}
 }
 
 func retsAnyBool() (any, bool) {

--- a/testdata/src/go.uber.org/contracts/userdefinedfunctions.go
+++ b/testdata/src/go.uber.org/contracts/userdefinedfunctions.go
@@ -731,3 +731,27 @@ func testMixedReturns() {
 func testMixedReturnsPassToAnotherFunc() (string, *int, bool) {
 	return retStrNilBool() //want "returned"
 }
+
+// below tests check for constants
+
+const falseVal = false
+const trueVal = true
+
+func retPtrBoolConst() (*int, bool) {
+	if dummy {
+		return nil, falseVal
+	}
+	return new(int), trueVal
+}
+
+func testConstants() {
+	// safe
+	if v, ok := retPtrBoolConst(); ok {
+		print(*v)
+	}
+
+	// unsafe
+	if v, ok := retPtrBoolConst(); !ok {
+		print(*v) //want "dereferenced"
+	}
+}

--- a/testdata/src/go.uber.org/contracts/userdefinedfunctions.go
+++ b/testdata/src/go.uber.org/contracts/userdefinedfunctions.go
@@ -1,0 +1,38 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+This file tests the contract of "ok" form for user defined functions.
+
+<nilaway no inference>
+*/
+package contracts
+
+func test() {
+	m := map[*int]*int{}
+	if v, ok := m[new(int)]; ok {
+		print(*v) // no error reported because NilAway handles "OK" form for a map.
+	}
+	if v, ok := foo(new(int)); ok {
+		print(*v) // However, this line still throws a false positive because NilAway does not handle "OK" form for a user-defined function.
+	}
+}
+
+// nilable(result 0)
+func foo(x *int) (*int, bool) {
+	if x == nil {
+		return nil, false
+	}
+	return new(int), true
+}

--- a/testdata/src/go.uber.org/contracts/userdefinedfunctions.go
+++ b/testdata/src/go.uber.org/contracts/userdefinedfunctions.go
@@ -175,6 +175,22 @@ func testCasesWithNonExplicitBool() {
 	}
 }
 
+func retPtrBoolShadowBuiltIn() (*int, bool) {
+	if dummy {
+		// this is a false positive since we don't support variables shadowing built-in types yet
+		var false bool = false
+		return nil, false //want "literal `nil` returned"
+	}
+	var true bool = true
+	return new(int), true
+}
+
+func testShadowBuiltIn() {
+	if v, ok := retPtrBoolShadowBuiltIn(); ok {
+		print(*v)
+	}
+}
+
 // below tests are relevant excerpts from the `errorreturn` test suite adapted to the "ok" form for user defined functions
 
 // nilable(result 0)

--- a/testdata/src/go.uber.org/inference/inference.go
+++ b/testdata/src/go.uber.org/inference/inference.go
@@ -18,136 +18,97 @@
 
 package inference
 
-// var dummyBool bool
-// var dummyInt int
-//
-// func retsNilable1() *int {
-// 	return nil
-// }
-//
-// func retsNilable2() *int {
-// 	if dummyBool {
-// 		return &dummyInt
-// 	}
-// 	return nil
-// }
-//
-// func retsNilable3() *int {
-// 	switch dummyInt {
-// 	case dummyInt:
-// 		return retsNilable1()
-// 	case dummyInt:
-// 		return retsNilable2()
-// 	case dummyInt:
-// 		return retsNilable3()
-// 	}
-// 	return &dummyInt
-// }
-//
-// func retsNonnil1() *int {
-// 	return &dummyInt
-// }
-//
-// func retsNonnil2() *int {
-// 	if dummyBool {
-// 		return &dummyInt
-// 	}
-// 	return &dummyInt
-// }
-//
-// func retsNonnil3() *int {
-// 	switch dummyInt {
-// 	case dummyInt:
-// 		return retsNonnil1()
-// 	case dummyInt:
-// 		return retsNonnil2()
-// 	case dummyInt:
-// 		return retsNonnil3()
-// 	}
-// 	return &dummyInt
-// }
-//
-// func retsNilable4() *int {
-// 	if dummyBool {
-// 		return retsNilable3()
-// 	}
-// 	return retsNilable3()
-// }
-//
-// func takesNonnil(x *int) int {
-// 	return *x
-// }
-//
-// func takesNilable(x *int) int {
-// 	if x == nil {
-// 		return 0
-// 	}
-// 	return *x
-// }
-//
-// func retsAndTakes() {
-// 	switch dummyInt {
-// 	case dummyInt:
-// 		takesNonnil(retsNonnil1())
-// 		takesNonnil(retsNonnil2())
-// 		takesNonnil(retsNonnil3())
-//
-// 		takesNilable(retsNonnil1())
-// 		takesNilable(retsNonnil2())
-// 		takesNilable(retsNonnil3())
-//
-// 		takesNilable(retsNilable1())
-// 		takesNilable(retsNilable2())
-// 		takesNilable(retsNilable3())
-// 		takesNilable(retsNilable4())
-// 	}
-// }
-//
-// // Below test checks the working of inference in the presence of annotations
-// // nonnil(result 0)
-// func foo(x *int) *int { //want "because it is annotated as so"
-// 	return x
-// }
-//
-// func callFoo() {
-// 	_ = foo(nil)
-// }
+var dummyBool bool
+var dummyInt int
 
-// type myErr struct{}
-//
-// func (myErr) Error() string { return "myErr message" }
-//
-// func test() {
-// 	if v, err := foo(); err == nil {
-// 		print(*v)
-// 	}
-// }
-//
-// func foo() (*int, error) {
-// 	if true {
-// 		return nil, &myErr{}
-// 	}
-// 	return new(int), nil
-// }
+func retsNilable1() *int {
+	return nil
+}
 
-func test() {
-	if v, ok := foo(); ok {
-		print(*v) // FP
+func retsNilable2() *int {
+	if dummyBool {
+		return &dummyInt
+	}
+	return nil
+}
+
+func retsNilable3() *int {
+	switch dummyInt {
+	case dummyInt:
+		return retsNilable1()
+	case dummyInt:
+		return retsNilable2()
+	case dummyInt:
+		return retsNilable3()
+	}
+	return &dummyInt
+}
+
+func retsNonnil1() *int {
+	return &dummyInt
+}
+
+func retsNonnil2() *int {
+	if dummyBool {
+		return &dummyInt
+	}
+	return &dummyInt
+}
+
+func retsNonnil3() *int {
+	switch dummyInt {
+	case dummyInt:
+		return retsNonnil1()
+	case dummyInt:
+		return retsNonnil2()
+	case dummyInt:
+		return retsNonnil3()
+	}
+	return &dummyInt
+}
+
+func retsNilable4() *int {
+	if dummyBool {
+		return retsNilable3()
+	}
+	return retsNilable3()
+}
+
+func takesNonnil(x *int) int {
+	return *x
+}
+
+func takesNilable(x *int) int {
+	if x == nil {
+		return 0
+	}
+	return *x
+}
+
+func retsAndTakes() {
+	switch dummyInt {
+	case dummyInt:
+		takesNonnil(retsNonnil1())
+		takesNonnil(retsNonnil2())
+		takesNonnil(retsNonnil3())
+
+		takesNilable(retsNonnil1())
+		takesNilable(retsNonnil2())
+		takesNilable(retsNonnil3())
+
+		takesNilable(retsNilable1())
+		takesNilable(retsNilable2())
+		takesNilable(retsNilable3())
+		takesNilable(retsNilable4())
 	}
 }
 
-func foo() (*int, bool) {
-	if true {
-		return nil, false
-	}
-	return new(int), true
+// Below test checks the working of inference in the presence of annotations
+// nonnil(result 0)
+func foo(x *int) *int { //want "because it is annotated as so"
+	return x
 }
 
-// func test() {
-// 	v, _ := foo()
-// 	print(*v)
-// }
-//
-// func foo() (*int, bool) {
-// 	return new(int), true
-// }
+func callFoo() {
+	_ = foo(nil)
+}

--- a/testdata/src/go.uber.org/inference/inference.go
+++ b/testdata/src/go.uber.org/inference/inference.go
@@ -18,97 +18,136 @@
 
 package inference
 
-var dummyBool bool
-var dummyInt int
+// var dummyBool bool
+// var dummyInt int
+//
+// func retsNilable1() *int {
+// 	return nil
+// }
+//
+// func retsNilable2() *int {
+// 	if dummyBool {
+// 		return &dummyInt
+// 	}
+// 	return nil
+// }
+//
+// func retsNilable3() *int {
+// 	switch dummyInt {
+// 	case dummyInt:
+// 		return retsNilable1()
+// 	case dummyInt:
+// 		return retsNilable2()
+// 	case dummyInt:
+// 		return retsNilable3()
+// 	}
+// 	return &dummyInt
+// }
+//
+// func retsNonnil1() *int {
+// 	return &dummyInt
+// }
+//
+// func retsNonnil2() *int {
+// 	if dummyBool {
+// 		return &dummyInt
+// 	}
+// 	return &dummyInt
+// }
+//
+// func retsNonnil3() *int {
+// 	switch dummyInt {
+// 	case dummyInt:
+// 		return retsNonnil1()
+// 	case dummyInt:
+// 		return retsNonnil2()
+// 	case dummyInt:
+// 		return retsNonnil3()
+// 	}
+// 	return &dummyInt
+// }
+//
+// func retsNilable4() *int {
+// 	if dummyBool {
+// 		return retsNilable3()
+// 	}
+// 	return retsNilable3()
+// }
+//
+// func takesNonnil(x *int) int {
+// 	return *x
+// }
+//
+// func takesNilable(x *int) int {
+// 	if x == nil {
+// 		return 0
+// 	}
+// 	return *x
+// }
+//
+// func retsAndTakes() {
+// 	switch dummyInt {
+// 	case dummyInt:
+// 		takesNonnil(retsNonnil1())
+// 		takesNonnil(retsNonnil2())
+// 		takesNonnil(retsNonnil3())
+//
+// 		takesNilable(retsNonnil1())
+// 		takesNilable(retsNonnil2())
+// 		takesNilable(retsNonnil3())
+//
+// 		takesNilable(retsNilable1())
+// 		takesNilable(retsNilable2())
+// 		takesNilable(retsNilable3())
+// 		takesNilable(retsNilable4())
+// 	}
+// }
+//
+// // Below test checks the working of inference in the presence of annotations
+// // nonnil(result 0)
+// func foo(x *int) *int { //want "because it is annotated as so"
+// 	return x
+// }
+//
+// func callFoo() {
+// 	_ = foo(nil)
+// }
 
-func retsNilable1() *int {
-	return nil
-}
+// type myErr struct{}
+//
+// func (myErr) Error() string { return "myErr message" }
+//
+// func test() {
+// 	if v, err := foo(); err == nil {
+// 		print(*v)
+// 	}
+// }
+//
+// func foo() (*int, error) {
+// 	if true {
+// 		return nil, &myErr{}
+// 	}
+// 	return new(int), nil
+// }
 
-func retsNilable2() *int {
-	if dummyBool {
-		return &dummyInt
+func test() {
+	if v, ok := foo(); ok {
+		print(*v) // FP
 	}
-	return nil
 }
 
-func retsNilable3() *int {
-	switch dummyInt {
-	case dummyInt:
-		return retsNilable1()
-	case dummyInt:
-		return retsNilable2()
-	case dummyInt:
-		return retsNilable3()
+func foo() (*int, bool) {
+	if true {
+		return nil, false
 	}
-	return &dummyInt
+	return new(int), true
 }
 
-func retsNonnil1() *int {
-	return &dummyInt
-}
-
-func retsNonnil2() *int {
-	if dummyBool {
-		return &dummyInt
-	}
-	return &dummyInt
-}
-
-func retsNonnil3() *int {
-	switch dummyInt {
-	case dummyInt:
-		return retsNonnil1()
-	case dummyInt:
-		return retsNonnil2()
-	case dummyInt:
-		return retsNonnil3()
-	}
-	return &dummyInt
-}
-
-func retsNilable4() *int {
-	if dummyBool {
-		return retsNilable3()
-	}
-	return retsNilable3()
-}
-
-func takesNonnil(x *int) int {
-	return *x
-}
-
-func takesNilable(x *int) int {
-	if x == nil {
-		return 0
-	}
-	return *x
-}
-
-func retsAndTakes() {
-	switch dummyInt {
-	case dummyInt:
-		takesNonnil(retsNonnil1())
-		takesNonnil(retsNonnil2())
-		takesNonnil(retsNonnil3())
-
-		takesNilable(retsNonnil1())
-		takesNilable(retsNonnil2())
-		takesNilable(retsNonnil3())
-
-		takesNilable(retsNilable1())
-		takesNilable(retsNilable2())
-		takesNilable(retsNilable3())
-		takesNilable(retsNilable4())
-	}
-}
-
-// Below test checks the working of inference in the presence of annotations
-// nonnil(result 0)
-func foo(x *int) *int { //want "because it is annotated as so"
-	return x
-}
-
-func callFoo() {
-	_ = foo(nil)
-}
+// func test() {
+// 	v, _ := foo()
+// 	print(*v)
+// }
+//
+// func foo() (*int, bool) {
+// 	return new(int), true
+// }

--- a/util/util.go
+++ b/util/util.go
@@ -30,6 +30,9 @@ import (
 // ErrorType is the type of the builtin "error" interface.
 var ErrorType = types.Universe.Lookup("error").Type()
 
+// BoolType is the type of the builtin "bool" interface.
+var BoolType = types.Universe.Lookup("bool").Type()
+
 // BuiltinLen is the builtin "len" function object.
 var BuiltinLen = types.Universe.Lookup("len")
 
@@ -303,37 +306,21 @@ func IsEmptyExpr(expr ast.Expr) bool {
 	return false
 }
 
-const (
-	_errorType = "error"
-	_boolType  = "bool"
-)
-
-// TypeIsRichCheckEffectType checks if the type is an `error` type or an ok form `bool` type.
-func TypeIsRichCheckEffectType(typ types.Type, typName string) bool {
-	switch t := typ.(type) {
-	case *types.Named:
-		return t.String() == typName
-	case *types.Basic:
-		return t.Kind() == types.Bool && t.String() == typName
-	}
-	return false
-}
-
 // funcIsRichCheckEffectReturning encodes the conditions that a function is deemed "rich-check-effect-returning", i.e.,
 // it is an error-returning function or a bool(ok)-returning function.
 // A function is deemed "rich-check-effect-returning" iff it has a single result of type `typName` (error or bool),
 // and that result is the last in the list of results.
-func funcIsRichCheckEffectReturning(fdecl *types.Func, typName string) bool {
+func funcIsRichCheckEffectReturning(fdecl *types.Func, expectedType types.Type) bool {
 	results := fdecl.Type().(*types.Signature).Results()
 	n := results.Len()
 	if n == 0 {
 		return false
 	}
-	if !TypeIsRichCheckEffectType(results.At(n-1).Type(), typName) {
+	if results.At(n-1).Type() != expectedType {
 		return false
 	}
 	for i := 0; i < n-1; i++ {
-		if TypeIsRichCheckEffectType(results.At(i).Type(), typName) {
+		if results.At(i).Type() == expectedType {
 			return false
 		}
 	}
@@ -345,7 +332,7 @@ func funcIsRichCheckEffectReturning(fdecl *types.Func, typName string) bool {
 // A function is deemed "error-returning" iff it has a single result of type `error`, and that
 // result is the last in the list of results.
 func FuncIsErrReturning(fdecl *types.Func) bool {
-	return funcIsRichCheckEffectReturning(fdecl, _errorType)
+	return funcIsRichCheckEffectReturning(fdecl, ErrorType)
 }
 
 // FuncIsOkReturning encodes the conditions that a function is deemed "ok-returning".
@@ -353,7 +340,7 @@ func FuncIsErrReturning(fdecl *types.Func) bool {
 // A function is deemed "ok-returning" iff it has a single result of type `bool`, and that
 // result is the last in the list of results.
 func FuncIsOkReturning(fdecl *types.Func) bool {
-	return funcIsRichCheckEffectReturning(fdecl, _boolType)
+	return funcIsRichCheckEffectReturning(fdecl, BoolType)
 }
 
 // IsFieldSelectorChain returns true if the expr is chain of idents. e.g, x.y.z


### PR DESCRIPTION
This pull request introduces support for the `ok` form in both user-defined and library functions and methods. The implementation addresses false positives, such as those identified in issue #77.

Currently, the feature is designed to handle explicit boolean returns, specifically in the form of `return r0, r1, ..., true`. Support for expression-based returns (e.g., `return r0, r1, ..., flag` or `return r0, r1, ..., isOk()`) is tricky, as tracking boolean types is currently not supported in NilAway. We can handle this scenario in the future.

[Closes #77 ]
[Depends on #156 ]
