### PR TITLE
Handle more cases for zero-slicing nilable slices

### DIFF
--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -779,7 +779,7 @@ func (r *RootAssertionNode) AddComputation(expr ast.Expr) {
 	case *ast.SliceExpr:
 		// similar to index case
 
-		// zero slicing contains b[:0] b[0:0] b[0:] b[:] b[0:0:0], which are safe even when b is
+		// zero slicing contains b[:0] b[0:0] b[0:] b[:] b[:0:0] b[0:0:0], which are safe even when b is
 		// nil, so we do not create consumer triggers for those slicing.
 		if !r.isZeroSlicing(expr) {
 			// For all the other slicing, the slice must be nonnil, so we create a consumer

--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -1123,12 +1123,12 @@ func (r *RootAssertionNode) isType(expr ast.Expr) bool {
 }
 
 // isZeroSlicing returns if the given slice expression is a special case that will not cause panic
-// even when the slice itself is nil, i.e, one of [:0] [0:0] [0:] [:] [0:0:0]
+// even when the slice itself is nil, i.e, one of [:0] [0:0] [0:] [:] [:0:0] [0:0:0]
 func (r *RootAssertionNode) isZeroSlicing(expr *ast.SliceExpr) bool {
 	lo, hi, max := expr.Low, expr.High, expr.Max
 	return ((lo == nil || r.isIntZero(lo)) && r.isIntZero(hi) && max == nil) || // [:0] [0:0]
 		((lo == nil || r.isIntZero(lo)) && hi == nil && max == nil) || // [0:] [:]
-		r.isIntZero(lo) && r.isIntZero(hi) && r.isIntZero(max) // [0:0:0]
+		((lo == nil || r.isIntZero(lo)) && r.isIntZero(hi) && r.isIntZero(max)) // [:0:0] [0:0:0]
 }
 
 // isIntZero returns if the given expression is evaluated to integer zero at compile time. For

--- a/testdata/src/go.uber.org/slices/slices.go
+++ b/testdata/src/go.uber.org/slices/slices.go
@@ -494,6 +494,12 @@ func testSlicingDoesNotCreateConsumersForNilableSlice() []int {
 		b = nilA[1-1 : 1-1 : 0-0]
 		b = nilA[zero:zero:zero]
 		b = nilA[zero+1-1 : zero+1-1 : zero+1-1]
+	case 6:
+		// [:0:0]
+		b = nilA[:0:0]
+		b = nilA[: 1-1 : 0-0]
+		b = nilA[:zero:zero]
+		b = nilA[: zero+1-1 : zero+1-1]
 	}
 	return b
 }


### PR DESCRIPTION
Support more cases for zero-slicing nilable slices like `[:0:0]` (fix #168)