### PR TITLE
Add instructions on how to set up NilAway on bazel and golangci-lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,10 @@ overhead.
 
 :star2: For more detailed technical discussion, please check our [Wiki][wiki], [Engineering Blog][blog], and paper (WIP).
 
-## Installation
+## Running NilAway
 
-NilAway is implemented using the standard [go/analysis](https://pkg.go.dev/golang.org/x/tools/go/analysis) framework, 
-making it easy to integrate with existing analyzer drivers (e.g., [golangci-lint](https://github.com/golangci/golangci-lint),
-[nogo](https://github.com/bazelbuild/rules_go/blob/master/go/nogo.rst), or 
-[running as a standalone checker](https://pkg.go.dev/golang.org/x/tools/go/analysis/singlechecker)). Here, we list the 
-instructions for running NilAway as a standalone checker. More integration supports will be added soon.
+NilAway is implemented using the standard [go/analysis][go-analysis], making it easy to integrate with existing analyzer
+drivers (i.e., [golangci-lint][golangci-lint], [nogo][nogo], or [running as a standalone checker][singlechecker]).
 
 ### Standalone Checker
 
@@ -120,6 +117,10 @@ our [Uber Contributor License Agreement](https://cla-assistant.io/uber-go/nilawa
 
 This project is copyright 2023 Uber Technologies, Inc., and licensed under Apache 2.0.
 
+[go-analysis]: https://pkg.go.dev/golang.org/x/tools/go/analysis
+[golangci-lint]: https://github.com/golangci/golangci-lint
+[singlechecker]: https://pkg.go.dev/golang.org/x/tools/go/analysis/singlechecker
+[nogo]: https://github.com/bazelbuild/rules_go/blob/master/go/nogo.rst
 [doc-img]: https://pkg.go.dev/badge/go.uber.org/nilaway.svg
 [doc]: https://pkg.go.dev/go.uber.org/nilaway
 [ci-img]: https://github.com/uber-go/nilaway/actions/workflows/ci.yml/badge.svg

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ $ bazel build --keep_going //...
 ```
 
 (5) See [nogo documentation][nogo-configure-analyzers] on how to pass a configuration JSON to the nogo driver, and see 
-our [wiki page][] on how to pass configurations to NilAway.
+our [wiki page][nogo-configure-nilaway] on how to pass configurations to NilAway.
 
 ### golangci-lint
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ documentation) to avoid `go mod tidy` from removing NilAway as a tool dependency
 ```bash
 # Get NilAway as a dependency, as well as getting its transitive dependencies in go.mod file.
 $ go get go.uber.org/nilaway@latest
-# This should not clean NilAway as a dependency in your go.mod file.
+# This should not remove NilAway as a dependency in your go.mod file.
 $ go mod tidy
 # Run gazelle to sync dependencies from go.mod to WORKSPACE file.
 $ bazel run //:gazelle -- update-repos -from_file=go.mod

--- a/README.md
+++ b/README.md
@@ -33,10 +33,11 @@ NilAway is implemented using the standard [go/analysis][go-analysis], making it 
 drivers (i.e., [golangci-lint][golangci-lint], [nogo][nogo], or [running as a standalone checker][singlechecker]).
 
 > [!IMPORTANT]  
-> Due to the sophistication of the analyses that NilAway does, it tries to cache its findings about a particular 
+> Due to the sophistication of the analyses that NilAway does, NilAway caches its findings about a particular 
 > package via the [Fact Mechanism][fact-mechanism] from the [go/analysis][go-analysis] framework. Therefore, it is 
 > _highly_ recommended to leverage a driver that supports modular analysis (i.e., bazel/nogo or golangci-lint, but _not_
-> the standalone checker since it stores all facts in memory) for better performance on large projects.
+> the standalone checker since it stores all facts in memory) for better performance on large projects. For example,
+> see [instructions][nogo-instructions] below for running NilAway on your project with bazel/nogo.
 
 > [!IMPORTANT]  
 > By default, NilAway analyzes _all_ Go code, including the standard libraries and dependencies. This helps NilAway 
@@ -44,8 +45,9 @@ drivers (i.e., [golangci-lint][golangci-lint], [nogo][nogo], or [running as a st
 > significant performance cost (only once for drivers with modular support) and increase the number of non-actionable 
 > errors in dependencies, for large Go projects with a lot of dependencies.
 > 
-> You can use the [`include-pkgs`][include-pkgs-flag] flag to only include analysis of first-party code, where NilAway
-> will apply optimistic defaults for the out-of-scope Go code (meaning a potential increase of false negatives).
+> We highly recommend using the [include-pkgs][include-pkgs-flag] flag to narrow down the analysis to your project's 
+> code exclusively. This directs NilAway to skip analyzing dependencies (e.g., third-party libraries), allowing you to 
+> focus solely on potential nil panics reported by NilAway in your first-party code!
 
 ### Standalone Checker
 
@@ -211,3 +213,4 @@ This project is copyright 2023 Uber Technologies, Inc., and licensed under Apach
 [track-tool-dependencies]: https://go.dev/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
 [nogo-configure-analyzers]: https://github.com/bazelbuild/rules_go/blob/master/go/nogo.rst#id14
 [nogo-configure-nilaway]: https://github.com/uber-go/nilaway/wiki/Configuration#nogo
+[nogo-instructions]: https://github.com/uber-go/nilaway?tab=readme-ov-file#bazelnogo

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ default set of linters configured. Then,
 
 (1) Add `import _ "go.uber.org/nilaway"` to your `tools.go` file (or other file that you use for configuring tool 
 dependencies, see [How can I track tool dependencies for a module?][track-tool-dependencies] from Go Modules 
-documentation for more details) to avoid `go mod tidy` from removing NilAway as a tool dependency.
+documentation) to avoid `go mod tidy` from removing NilAway as a tool dependency.
 
 (2) Run the following commands to add NilAway as a tool dependency to your project:
 ```bash
@@ -105,7 +105,7 @@ our [wiki page][] on how to pass configurations to NilAway.
 ### golangci-lint
 
 NilAway, as its current form, still reports a fair number of false positives. This makes NilAway fail to be merged with 
-[golangci-lint][golangci-lint] to be offered as a linter (see [PR#4045][pr-4045]). The alternatives are to:
+[golangci-lint][golangci-lint] and be offered as a linter (see [PR#4045][pr-4045]). The alternatives are to:
 
 (1) [build NilAway as a plugin to golangci-lint][nilaway-as-a-plugin]: the Go plugin system _requires_ that NilAway 
   shares the exact same versions of dependencies as the ones from golangci-lint. This is almost impossible for us to


### PR DESCRIPTION
This PR updates the README to include instructions on how to set up NilAway on bazel, as well as providing several thoughts on how to work with the popular open-source driver golangci-lint.

We have also added two important notes to recommend (1) using a driver that supports modular analysis, and (2) only include analysis of first party code in large Go projects for best performance.

Closes #127, #131, #161.