### PR TITLE
Refactor the docContains functions to asthelper package

### DIFF
--- a/assertion/anonymousfunc/analyzer.go
+++ b/assertion/anonymousfunc/analyzer.go
@@ -24,7 +24,7 @@ import (
 	"strconv"
 
 	"go.uber.org/nilaway/config"
-	"go.uber.org/nilaway/util"
+	"go.uber.org/nilaway/util/asthelper"
 	"golang.org/x/tools/go/analysis"
 )
 
@@ -106,7 +106,7 @@ func run(pass *analysis.Pass) (result interface{}, _ error) {
 	funcLitMap := make(map[*ast.FuncLit]*FuncLitInfo)
 
 	for _, file := range pass.Files {
-		if !conf.IsFileInScope(file) || !util.DocContainsAnonymousFuncCheck(file.Doc) {
+		if !conf.IsFileInScope(file) || !asthelper.DocContains(file.Doc, config.NilAwayAnonymousFuncCheckString) {
 			continue
 		}
 

--- a/assertion/function/analyzer.go
+++ b/assertion/function/analyzer.go
@@ -32,6 +32,7 @@ import (
 	"go.uber.org/nilaway/assertion/structfield"
 	"go.uber.org/nilaway/config"
 	"go.uber.org/nilaway/util"
+	"go.uber.org/nilaway/util/asthelper"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/ctrlflow"
 	"golang.org/x/tools/go/cfg"
@@ -143,8 +144,12 @@ func run(pass *analysis.Pass) (result interface{}, _ error) {
 			// TODO: enable struct initialization flag (tracked in Issue #23).
 			// TODO: enable anonymous function flag.
 		} else {
-			functionConfig.StructInitCheckType = util.DocContainsStructInitCheck(file.Doc)
-			functionConfig.EnableAnonymousFunc = util.DocContainsAnonymousFuncCheck(file.Doc)
+			if asthelper.DocContains(file.Doc, config.NilAwayStructInitCheckString) {
+				functionConfig.StructInitCheckType = config.DepthOneFieldCheck
+			} else {
+				functionConfig.StructInitCheckType = config.NoCheck
+			}
+			functionConfig.EnableAnonymousFunc = asthelper.DocContains(file.Doc, config.NilAwayAnonymousFuncCheckString)
 		}
 
 		// Collect all function declarations and function literals if anonymous function support

--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"strings"
 
+	"go.uber.org/nilaway/util/asthelper"
 	"golang.org/x/tools/go/analysis"
 )
 
@@ -79,7 +80,7 @@ func (c *Config) IsFileInScope(file *ast.File) bool {
 		}
 
 		for _, exclude := range c.excludeFileDocStrings {
-			if strings.Contains(comment.Text(), exclude) {
+			if asthelper.DocContains(comment, exclude) {
 				return false
 			}
 		}

--- a/inference/mode.go
+++ b/inference/mode.go
@@ -15,10 +15,8 @@
 package inference
 
 import (
-	"go/ast"
-	"strings"
-
 	"go.uber.org/nilaway/config"
+	"go.uber.org/nilaway/util/asthelper"
 	"golang.org/x/tools/go/analysis"
 )
 
@@ -42,21 +40,9 @@ const (
 // docstring is found, multi-package inference is used (returns FullInfer).
 func DetermineMode(pass *analysis.Pass) ModeOfInference {
 	for _, file := range pass.Files {
-		if docContains(file.Doc, config.NilAwayNoInferString) {
+		if asthelper.DocContains(file.Doc, config.NilAwayNoInferString) {
 			return NoInfer
 		}
 	}
 	return FullInfer
-}
-
-// docContains checks if the comment group contains a certain string.
-func docContains(group *ast.CommentGroup, s string) bool {
-	if group != nil {
-		for _, comment := range group.List {
-			if strings.Contains(comment.Text, s) {
-				return true
-			}
-		}
-	}
-	return false
 }

--- a/util/asthelper/asthelper.go
+++ b/util/asthelper/asthelper.go
@@ -25,6 +25,20 @@ import (
 	"golang.org/x/tools/go/analysis"
 )
 
+func DocContains(group *ast.CommentGroup, s string) bool {
+	if group == nil {
+		return false
+	}
+
+	for _, comment := range group.List {
+		if strings.Contains(comment.Text, s) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // PrintExpr converts AST expression to string, and shortens long expressions if isShortenExpr is true
 func PrintExpr(e ast.Expr, pass *analysis.Pass, isShortenExpr bool) (string, error) {
 	builder := &strings.Builder{}

--- a/util/asthelper/asthelper.go
+++ b/util/asthelper/asthelper.go
@@ -25,6 +25,7 @@ import (
 	"golang.org/x/tools/go/analysis"
 )
 
+// DocContains returns true if the comment group contains the given string.
 func DocContains(group *ast.CommentGroup, s string) bool {
 	if group == nil {
 		return false

--- a/util/asthelper/asthelper_test.go
+++ b/util/asthelper/asthelper_test.go
@@ -1,0 +1,61 @@
+package asthelper
+
+import (
+	"go/ast"
+	"go/token"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDocContains(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		description string
+		s           string
+		node        *ast.CommentGroup
+		want        bool
+	}{
+		{
+			description: "contains the text",
+			s:           "42",
+			node: &ast.CommentGroup{List: []*ast.Comment{
+				{Slash: token.Pos(1), Text: "my comment 42"},
+			}},
+			want: true,
+		},
+		{
+			description: "contains the text in separate comment inside the group",
+			s:           "42",
+			node: &ast.CommentGroup{List: []*ast.Comment{
+				{Slash: token.Pos(1), Text: "my comment"},
+				{Slash: token.Pos(10), Text: "some 42 some other text"},
+			}},
+			want: true,
+		},
+		{
+			description: "does not contain the text in nil group",
+			s:           "42",
+			node:        nil,
+			want:        false,
+		},
+		{
+			description: "does not contain the text",
+			s:           "42",
+			node: &ast.CommentGroup{List: []*ast.Comment{
+				{Slash: token.Pos(1), Text: "my comment"},
+				{Slash: token.Pos(10), Text: "some some other text"},
+			}},
+			want: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, DocContains(tc.node, tc.s))
+		})
+	}
+}

--- a/util/util.go
+++ b/util/util.go
@@ -404,35 +404,6 @@ func GetSelectorExprHeadIdent(selExpr *ast.SelectorExpr) *ast.Ident {
 	return nil
 }
 
-// DocContainsStructInitCheck is used by analyzers to check if the struct initialization check enabling string is present
-// in the comments.
-func DocContainsStructInitCheck(group *ast.CommentGroup) config.StructInitCheckType {
-	if docContainsString(config.NilAwayStructInitCheckString)(group) {
-		return config.DepthOneFieldCheck
-	}
-	return config.NoCheck
-}
-
-// DocContainsAnonymousFuncCheck is used by analyzers to check if the anonymous function check enabling string is present
-// in the comments.
-func DocContainsAnonymousFuncCheck(group *ast.CommentGroup) bool {
-	return docContainsString(config.NilAwayAnonymousFuncCheckString)(group)
-}
-
-// docContainsString is used to check if the file comments contain a string s.
-func docContainsString(s string) func(*ast.CommentGroup) bool {
-	return func(group *ast.CommentGroup) bool {
-		if group != nil {
-			for _, comment := range group.List {
-				if strings.Contains(comment.Text, s) {
-					return true
-				}
-			}
-		}
-		return false
-	}
-}
-
 // IsLiteral returns true if `expr` is a literal that matches with one of the given literal values (e.g., "nil", "true", "false)
 func IsLiteral(expr ast.Expr, literals ...string) bool {
 	if ident, ok := expr.(*ast.Ident); ok {


### PR DESCRIPTION
This PR does a simple refactor that consolidates the group of `docContains` functions and move them to the new `asthelper` package for better code organization and maintainability. No functionality changes are included in this PR