### PR TITLE
Simplify struct initialization feature flag

### DIFF
--- a/assertion/anonymousfunc/analyzer.go
+++ b/assertion/anonymousfunc/analyzer.go
@@ -106,7 +106,7 @@ func run(pass *analysis.Pass) (result interface{}, _ error) {
 	funcLitMap := make(map[*ast.FuncLit]*FuncLitInfo)
 
 	for _, file := range pass.Files {
-		if !conf.IsFileInScope(file) || !asthelper.DocContains(file.Doc, config.NilAwayAnonymousFuncCheckString) {
+		if !conf.IsFileInScope(file) || !asthelper.DocContains(file.Doc, config.AnonymousFuncCheckString) {
 			continue
 		}
 

--- a/assertion/function/analyzer.go
+++ b/assertion/function/analyzer.go
@@ -108,7 +108,6 @@ func run(pass *analysis.Pass) (result interface{}, _ error) {
 	}()
 
 	conf := pass.ResultOf[config.Analyzer].(*config.Config)
-
 	if !conf.IsPkgInScope(pass.Pkg) {
 		return Result{}, nil
 	}
@@ -144,12 +143,8 @@ func run(pass *analysis.Pass) (result interface{}, _ error) {
 			// TODO: enable struct initialization flag (tracked in Issue #23).
 			// TODO: enable anonymous function flag.
 		} else {
-			if asthelper.DocContains(file.Doc, config.NilAwayStructInitCheckString) {
-				functionConfig.StructInitCheckType = config.DepthOneFieldCheck
-			} else {
-				functionConfig.StructInitCheckType = config.NoCheck
-			}
-			functionConfig.EnableAnonymousFunc = asthelper.DocContains(file.Doc, config.NilAwayAnonymousFuncCheckString)
+			functionConfig.EnableStructInitCheck = asthelper.DocContains(file.Doc, config.StructInitCheckString)
+			functionConfig.EnableAnonymousFunc = asthelper.DocContains(file.Doc, config.AnonymousFuncCheckString)
 		}
 
 		// Collect all function declarations and function literals if anonymous function support
@@ -161,11 +156,10 @@ func run(pass *analysis.Pass) (result interface{}, _ error) {
 			}
 		}
 		if functionConfig.EnableAnonymousFunc {
-			// Due to , we need a stable order of triggers for inference. However, the
+			// We need a stable order of triggers for inference. However, the
 			// fake func decl nodes generated from the anonymous function analyzer are stored in
 			// a map. Hence, here we traverse the file and append the fake func decl nodes in
 			// depth-first order.
-			// TODO: remove this once  is done.
 			ast.Inspect(file, func(node ast.Node) bool {
 				if f, ok := node.(*ast.FuncLit); ok {
 					funcs = append(funcs, f)

--- a/assertion/function/analyzer_test.go
+++ b/assertion/function/analyzer_test.go
@@ -26,7 +26,6 @@ import (
 	"go.uber.org/nilaway/assertion/anonymousfunc"
 	"go.uber.org/nilaway/assertion/function/assertiontree"
 	"go.uber.org/nilaway/assertion/function/functioncontracts"
-	"go.uber.org/nilaway/config"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/analysistest"
 	"golang.org/x/tools/go/analysis/passes/ctrlflow"
@@ -58,8 +57,8 @@ func TestTimeout(t *testing.T) {
 	// (1) Enable all features flags (will not actually make a difference since our test code does
 	// not really require such features).
 	funcConfig := assertiontree.FunctionConfig{
-		StructInitCheckType: config.DepthOneFieldCheck,
-		EnableAnonymousFunc: true,
+		EnableStructInitCheck: true,
+		EnableAnonymousFunc:   true,
 	}
 	// (2) Construct an empty function context. In normal NilAway execution the func lit map and
 	// pkg fake ident map will be created from the separate anonymous function analyzer. However,

--- a/assertion/function/assertiontree/backprop.go
+++ b/assertion/function/assertiontree/backprop.go
@@ -147,7 +147,7 @@ func backpropAcrossReturn(rootNode *RootAssertionNode, node *ast.ReturnStmt) err
 	// we have to handle the case that a multiply-returning function is being returned, and split
 	// the productions appropriate instead of just calling computeAndConsumeResults directly in that case
 
-	if rootNode.functionContext.isDepthOneFieldCheck() {
+	if rootNode.functionContext.functionConfig.EnableStructInitCheck {
 		rootNode.addConsumptionsForFieldsOfParams()
 	}
 
@@ -572,7 +572,7 @@ buildShadowMask:
 				if rpath != nil {
 					// Both lhsVal and rhsVal are trackable! we're in case C
 
-					if rootNode.functionContext.isDepthOneFieldCheck() {
+					if rootNode.functionContext.functionConfig.EnableStructInitCheck {
 						// If rhs is a function call that is tracked then we just add field producers before detaching
 						// the assertion nodes
 						_, rproducers := rootNode.ParseExprAsProducer(rhsVal, true)
@@ -614,7 +614,7 @@ buildShadowMask:
 							Expr:       lhsVal,
 						})
 					case 1:
-						if rootNode.functionContext.isDepthOneFieldCheck() {
+						if rootNode.functionContext.functionConfig.EnableStructInitCheck {
 							fieldProducers := rproducers[0].GetFieldProducers()
 							rootNode.addProductionsForAssignmentFields(fieldProducers, lhsVal)
 						}
@@ -708,7 +708,7 @@ func backpropAcrossManyToOneAssignment(rootNode *RootAssertionNode, lhs, rhs []a
 		}
 
 		// Phase 1
-		if rootNode.functionContext.isDepthOneFieldCheck() {
+		if rootNode.functionContext.functionConfig.EnableStructInitCheck {
 			fieldProducers := producers[i].GetFieldProducers()
 			rootNode.addProductionsForAssignmentFields(fieldProducers, lhsVal)
 		}

--- a/assertion/function/assertiontree/backprop_util.go
+++ b/assertion/function/assertiontree/backprop_util.go
@@ -160,7 +160,7 @@ func computeAndConsumeResults(rootNode *RootAssertionNode, node *ast.ReturnStmt)
 				if !util.IsEmptyExpr(retVariable) {
 					rootNode.AddConsumption(consumer)
 
-					if rootNode.functionContext.isDepthOneFieldCheck() {
+					if rootNode.functionContext.functionConfig.EnableStructInitCheck {
 						rootNode.addConsumptionsForFieldsOfReturns(results[i], i)
 					}
 				} else {
@@ -218,7 +218,7 @@ func computeAndConsumeResults(rootNode *RootAssertionNode, node *ast.ReturnStmt)
 			Guards: util.NoGuards(),
 		})
 
-		if rootNode.functionContext.isDepthOneFieldCheck() {
+		if rootNode.functionContext.functionConfig.EnableStructInitCheck {
 			rootNode.addConsumptionsForFieldsOfReturns(node.Results[i], i)
 		}
 	}
@@ -286,7 +286,7 @@ func handleErrorReturns(rootNode *RootAssertionNode, retStmt *ast.ReturnStmt, re
 		}
 
 		// TODO: handle struct init in the context of error return in a better way in a follow up diff
-		if rootNode.functionContext.isDepthOneFieldCheck() {
+		if rootNode.functionContext.functionConfig.EnableStructInitCheck {
 			for i := range results {
 				rootNode.addConsumptionsForFieldsOfReturns(results[i], i)
 			}
@@ -299,7 +299,7 @@ func handleErrorReturns(rootNode *RootAssertionNode, retStmt *ast.ReturnStmt, re
 		createSpecialConsumersForAllReturns(rootNode, nonErrRetExpr, errRetExpr, errRetIndex, retStmt, isNamedReturn)
 
 		// TODO: handle struct init in the context of error return in a better way in a follow up diff
-		if rootNode.functionContext.isDepthOneFieldCheck() {
+		if rootNode.functionContext.functionConfig.EnableStructInitCheck {
 			for i := range results {
 				rootNode.addConsumptionsForFieldsOfReturns(results[i], i)
 			}
@@ -567,7 +567,7 @@ func exprAsAssignmentConsumer(rootNode *RootAssertionNode, expr ast.Node, exprRH
 			}
 		}
 
-		if rootNode.functionContext.isDepthOneFieldCheck() {
+		if rootNode.functionContext.functionConfig.EnableStructInitCheck {
 			if head := util.GetSelectorExprHeadIdent(expr); head != nil {
 				if obj, ok := rootNode.ObjectOf(head).(*types.Var); ok {
 					if !annotation.VarIsGlobal(obj) {

--- a/assertion/function/assertiontree/fld_assertion_node.go
+++ b/assertion/function/assertiontree/fld_assertion_node.go
@@ -54,7 +54,7 @@ func (f *fldAssertionNode) GetAncestorVarAssertionNode() *varAssertionNode {
 
 // DefaultTrigger for a field node is that field's annotation
 func (f *fldAssertionNode) DefaultTrigger() annotation.ProducingAnnotationTrigger {
-	if f.functionContext.isDepthOneFieldCheck() {
+	if f.functionContext.functionConfig.EnableStructInitCheck {
 		varNode := f.GetAncestorVarAssertionNode()
 		// If the field is not produced by a variable we default to the FieldAnnotationKey
 		// Similarly, for a global variable we default to the FieldAnnotationKey

--- a/assertion/function/assertiontree/function_context.go
+++ b/assertion/function/assertiontree/function_context.go
@@ -20,7 +20,6 @@ import (
 
 	"go.uber.org/nilaway/assertion/anonymousfunc"
 	"go.uber.org/nilaway/assertion/function/functioncontracts"
-	"go.uber.org/nilaway/config"
 	"golang.org/x/tools/go/analysis"
 )
 
@@ -68,9 +67,9 @@ type FunctionContext struct {
 
 // FunctionConfig is meant to hold all the user set configuration for analyzing a function
 type FunctionConfig struct {
-	// StructInitCheckType holds the value of the StructInitCheckType config
-	StructInitCheckType config.StructInitCheckType
-	// EnableAnonymousFunc is a flag to enable checking anonymous functions
+	// EnableStructInitCheck is a flag to enable tracking struct initializations.
+	EnableStructInitCheck bool
+	// EnableAnonymousFunc is a flag to enable checking anonymous functions.
 	EnableAnonymousFunc bool
 }
 
@@ -134,9 +133,4 @@ func (fc *FunctionContext) findFakeIdent(ident *ast.Ident) types.Object {
 		return obj
 	}
 	return fc.pkgFakeIdentMap[ident]
-}
-
-// isDepthOneFieldCheck returns true if configuration flag StructInitCheckType is set to DepthOneFieldCheck
-func (fc *FunctionContext) isDepthOneFieldCheck() bool {
-	return fc.functionConfig.StructInitCheckType == config.DepthOneFieldCheck
 }

--- a/assertion/function/assertiontree/parse_expr_producer.go
+++ b/assertion/function/assertiontree/parse_expr_producer.go
@@ -268,7 +268,7 @@ func (r *RootAssertionNode) ParseExprAsProducer(expr ast.Expr, doNotTrack bool) 
 				// uninitialized with a `new(S)`.
 				// TODO: below logic won't be required once we standardize the calls by replacing `new(S)` with `&S{}`
 				//  in the preprocessing phase after  is implemented.
-				if r.functionContext.isDepthOneFieldCheck() && fun.Name == BuiltinNew {
+				if r.functionContext.functionConfig.EnableStructInitCheck && fun.Name == BuiltinNew {
 					rproducer := r.parseStructCreateExprAsProducer(expr.Args[0], nil)
 					if rproducer != nil {
 						return nil, []producer.ParsedProducer{rproducer}
@@ -393,7 +393,7 @@ func (r *RootAssertionNode) ParseExprAsProducer(expr ast.Expr, doNotTrack bool) 
 		return r.ParseExprAsProducer(expr.X, doNotTrack)
 
 	case *ast.CompositeLit:
-		if r.functionContext.isDepthOneFieldCheck() {
+		if r.functionContext.functionConfig.EnableStructInitCheck {
 			rproducer := r.parseStructCreateExprAsProducer(expr, expr.Elts)
 			if rproducer != nil {
 				return nil, []producer.ParsedProducer{rproducer}
@@ -427,7 +427,7 @@ func (r *RootAssertionNode) getFuncReturnProducers(ident *ast.Ident, expr *ast.C
 
 		var fieldProducers []*annotation.ProduceTrigger
 
-		if r.functionContext.isDepthOneFieldCheck() {
+		if r.functionContext.functionConfig.EnableStructInitCheck {
 			fieldProducers = r.getFieldProducersForFuncReturns(funcObj, i)
 		}
 

--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -682,7 +682,7 @@ func (r *RootAssertionNode) AddComputation(expr ast.Expr) {
 			// so we can mark its arguments as consumed
 			consumeArg = consumeArgTrigger(r.ObjectOf(fun).(*types.Func))
 
-			if r.functionContext.isDepthOneFieldCheck() {
+			if r.functionContext.functionConfig.EnableStructInitCheck {
 				// Add Productions for struct field params
 				r.addProductionForFuncCallArgAndReceiverFields(expr, fun)
 
@@ -938,7 +938,7 @@ func (r *RootAssertionNode) ProcessEntry() {
 		child := r.Children()[0]
 		builtExpr := child.BuildExpr(r.Pass(), nil)
 
-		if r.functionContext.isDepthOneFieldCheck() {
+		if r.functionContext.functionConfig.EnableStructInitCheck {
 			// process field Assertion nodes of function parameters
 			r.addProductionsForParamFields(child, builtExpr)
 		}

--- a/assertion/function/assertiontree/var_assertion_node.go
+++ b/assertion/function/assertiontree/var_assertion_node.go
@@ -67,7 +67,7 @@ func (v *varAssertionNode) DefaultTrigger() annotation.ProducingAnnotationTrigge
 	//  preprocessing phase
 	if !util.TypeIsDeeplyPtr(v.decl.Type()) {
 		if structType := util.TypeAsDeeplyStruct(v.decl.Type()); structType != nil {
-			if v.Root().functionContext.isDepthOneFieldCheck() {
+			if v.Root().functionContext.functionConfig.EnableStructInitCheck {
 				v.Root().addProductionForVarFieldNode(v, v.BuildExpr(v.Root().Pass(), nil))
 			}
 			return &annotation.ProduceTriggerNever{} // indicating that the struct object itself is not nil

--- a/config/const.go
+++ b/config/const.go
@@ -33,22 +33,10 @@ const DirLevelsToPrintForTriggers = 1
 // DefaultNilableNamedTypes is the list of type names that we interpret as default nilable.
 var DefaultNilableNamedTypes = [...]string{}
 
-// StructInitCheckType Config for setting the level of struct initialization check
-type StructInitCheckType int
-
-const (
-	// NoCheck if the checker is not enabled (current default)
-	NoCheck StructInitCheckType = iota
-
-	// DepthOneFieldCheck in this setting we track the nilability of fields at depth 1
-	// i.e. we track nilability of x.y, but we do not track x.y.z
-	DepthOneFieldCheck
-)
-
-// NilAwayStructInitCheckString is the string that may be inserted into the docstring for a package to
+// StructInitCheckString is the string that may be inserted into the docstring for a package to
 // force NilAway to enable struct init checking
-const NilAwayStructInitCheckString = "<nilaway struct enable>"
+const StructInitCheckString = "<nilaway struct enable>"
 
-// NilAwayAnonymousFuncCheckString is the string that may be inserted into the docstring for a package to
+// AnonymousFuncCheckString is the string that may be inserted into the docstring for a package to
 // force NilAway to enable anonymous func checking
-const NilAwayAnonymousFuncCheckString = "<nilaway anonymous function enable>"
+const AnonymousFuncCheckString = "<nilaway anonymous function enable>"


### PR DESCRIPTION
We currently have different modes for struct initialization feature flag (no check vs depth one check). However, we've not been actively adding more modes to this feature. On the opposite, we are trying to merge struct initialization feature into main NilAway itself. 

This PR simplifies this feature flag to be a simple boolean (ON/OFF) to make it easier for further refactors (i.e., exposing this experimental feature as a top-level flag). We can always expand if we truly need the support in the future (which doesn't seem to be the case for now), and simplifying such a flag helps with maintainability and readability a lot.

Depends on PR #176