### PR TITLE
Fix for supporting variable declarations in rich check effects

### DIFF
--- a/assertion/function/assertiontree/contract.go
+++ b/assertion/function/assertiontree/contract.go
@@ -265,7 +265,7 @@ func parseExpr(rootNode *RootAssertionNode, expr ast.Expr) TrackableExpr {
 // It matches on `AssignStmt`s of the form `v, ok := mp[k]` and `v, ok := <-ch`
 // nilable(result 0)
 func NodeTriggersOkRead(rootNode *RootAssertionNode, nonceGenerator *util.GuardNonceGenerator, node ast.Node) ([]RichCheckEffect, bool) {
-	lhs, rhs := extractLhsRhs(node)
+	lhs, rhs := extractLHSRHS(node)
 	if len(lhs) != 2 || len(rhs) != 1 {
 		return nil, false
 	}
@@ -343,7 +343,7 @@ func NodeTriggersOkRead(rootNode *RootAssertionNode, nonceGenerator *util.GuardN
 // it matches on calls to functions with error-returning types
 // nilable(result 0)
 func NodeTriggersFuncErrRet(rootNode *RootAssertionNode, nonceGenerator *util.GuardNonceGenerator, node ast.Node) ([]RichCheckEffect, bool) {
-	lhs, rhs := extractLhsRhs(node)
+	lhs, rhs := extractLHSRHS(node)
 
 	if len(lhs) == 0 || len(rhs) != 1 {
 		return nil, false
@@ -461,7 +461,8 @@ func guardExpr(rootNode *RootAssertionNode, expr TrackableExpr, guard util.Guard
 	}
 }
 
-func extractLhsRhs(node ast.Node) (lhs, rhs []ast.Expr) {
+// extractLHSRHS extracts the left-hand side and right-hand side of an assignment statement or a variable declaration
+func extractLHSRHS(node ast.Node) (lhs, rhs []ast.Expr) {
 	switch expr := node.(type) {
 	case *ast.AssignStmt:
 		lhs, rhs = expr.Lhs, expr.Rhs

--- a/testdata/src/go.uber.org/channels/channels.go
+++ b/testdata/src/go.uber.org/channels/channels.go
@@ -383,6 +383,12 @@ func testOkChecksForResults() *int {
 			// the rich bool should still be in place
 			return vNonnil
 		}
+	case 6:
+		var vNonnil, okNonnil = <-retsNonnilChans()
+		if !okNonnil {
+			panic(vNonnil)
+		}
+		return vNonnil
 	}
 
 	i := 0

--- a/testdata/src/go.uber.org/contracts/contracts.go
+++ b/testdata/src/go.uber.org/contracts/contracts.go
@@ -38,6 +38,14 @@ func simpleCond(m map[any]any) any {
 	return v
 }
 
+func testVarDecl(m map[any]any) any {
+	var v, ok = m[0]
+	if !ok {
+		panic(0)
+	}
+	return v
+}
+
 func threeWay(m map[any]any) any {
 	var v any
 	var ok bool

--- a/testdata/src/go.uber.org/errorreturn/errorreturn.go
+++ b/testdata/src/go.uber.org/errorreturn/errorreturn.go
@@ -317,6 +317,14 @@ func usesErrFunc() {
 
 		takesNonnil(nonnilPtr)
 		takesNonnil(nilablePtr) //want "passed" "passed"
+
+	case 13:
+		var nonnilPtr, nilablePtr, err = retsNonnilNilableWithErr(&i, &i)
+		if err != nil {
+			return
+		}
+		takesNonnil(nonnilPtr)
+		takesNonnil(nilablePtr) //want "passed"
 	}
 }
 

--- a/util/asthelper/asthelper.go
+++ b/util/asthelper/asthelper.go
@@ -102,3 +102,17 @@ func printExpr(writer io.Writer, fset *token.FileSet, e ast.Expr) (err error) {
 	}
 	return
 }
+
+// ExtractLHSRHS extracts the left-hand side and right-hand side of an assignment statement or a variable declaration
+func ExtractLHSRHS(node ast.Node) (lhs, rhs []ast.Expr) {
+	switch expr := node.(type) {
+	case *ast.AssignStmt:
+		lhs, rhs = expr.Lhs, expr.Rhs
+	case *ast.ValueSpec:
+		for _, name := range expr.Names {
+			lhs = append(lhs, name)
+		}
+		rhs = expr.Values
+	}
+	return
+}


### PR DESCRIPTION
This PR fixes the handling of rich check effects by adding support for variable declarations (`ast.ValueSpec`), along with assignments (`ast.AssignStmt`).

[closes #179 ]