### PR TITLE
Assignment tracking for many-to-one assignments

### DIFF
--- a/assertion/function/assertiontree/backprop_util.go
+++ b/assertion/function/assertiontree/backprop_util.go
@@ -752,13 +752,15 @@ func CheckGuardOnFullTrigger(trigger annotation.FullTrigger) annotation.FullTrig
 }
 
 // addAssignmentToConsumer updates the consumer with assignment entries for informative printing of errors
-func addAssignmentToConsumer(lhs, rhs ast.Expr, pass *analysis.Pass, consumer annotation.ConsumingAnnotationTrigger) (err error) {
+func addAssignmentToConsumer(lhs, rhs ast.Expr, pass *analysis.Pass, consumer annotation.ConsumingAnnotationTrigger) error {
 	var lhsExprStr, rhsExprStr string
+	var err error
+
 	if lhsExprStr, err = asthelper.PrintExpr(lhs, pass, true /* isShortenExpr */); err != nil {
-		return err
+		return fmt.Errorf("converting LHS of assignment expr to string: %w", err)
 	}
 	if rhsExprStr, err = asthelper.PrintExpr(rhs, pass, true /* isShortenExpr */); err != nil {
-		return err
+		return fmt.Errorf("converting RHS of assignment expr to string: %w", err)
 	}
 
 	consumer.AddAssignment(annotation.Assignment{
@@ -767,5 +769,5 @@ func addAssignmentToConsumer(lhs, rhs ast.Expr, pass *analysis.Pass, consumer an
 		Position:   util.TruncatePosition(util.PosToLocation(lhs.Pos(), pass)),
 	})
 
-	return
+	return nil
 }

--- a/assertion/function/assertiontree/backprop_util.go
+++ b/assertion/function/assertiontree/backprop_util.go
@@ -23,6 +23,7 @@ import (
 
 	"go.uber.org/nilaway/annotation"
 	"go.uber.org/nilaway/util"
+	"go.uber.org/nilaway/util/asthelper"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/cfg"
 )
@@ -748,4 +749,23 @@ func CheckGuardOnFullTrigger(trigger annotation.FullTrigger) annotation.FullTrig
 		}
 	}
 	return trigger
+}
+
+// addAssignmentToConsumer updates the consumer with assignment entries for informative printing of errors
+func addAssignmentToConsumer(lhs, rhs ast.Expr, pass *analysis.Pass, consumer annotation.ConsumingAnnotationTrigger) (err error) {
+	var lhsExprStr, rhsExprStr string
+	if lhsExprStr, err = asthelper.PrintExpr(lhs, pass, true /* isShortenExpr */); err != nil {
+		return err
+	}
+	if rhsExprStr, err = asthelper.PrintExpr(rhs, pass, true /* isShortenExpr */); err != nil {
+		return err
+	}
+
+	consumer.AddAssignment(annotation.Assignment{
+		LHSExprStr: lhsExprStr,
+		RHSExprStr: rhsExprStr,
+		Position:   util.TruncatePosition(util.PosToLocation(lhs.Pos(), pass)),
+	})
+
+	return
 }

--- a/assertion/function/assertiontree/backprop_util.go
+++ b/assertion/function/assertiontree/backprop_util.go
@@ -757,10 +757,10 @@ func addAssignmentToConsumer(lhs, rhs ast.Expr, pass *analysis.Pass, consumer an
 	var err error
 
 	if lhsExprStr, err = asthelper.PrintExpr(lhs, pass, true /* isShortenExpr */); err != nil {
-		return fmt.Errorf("converting LHS of assignment expr to string: %w", err)
+		return fmt.Errorf("converting LHS of assignment to string: %w", err)
 	}
 	if rhsExprStr, err = asthelper.PrintExpr(rhs, pass, true /* isShortenExpr */); err != nil {
-		return fmt.Errorf("converting RHS of assignment expr to string: %w", err)
+		return fmt.Errorf("converting RHS of assignment to string: %w", err)
 	}
 
 	consumer.AddAssignment(annotation.Assignment{


### PR DESCRIPTION
This PR adds assignment tracking for many-to-one assignments for printing informative error messages, following suit of one-to-one assignment tracking (PR #87 ).