### PR TITLE
Minor refinement to error message format

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ error showing this nilness flow:
 
 ```
 go.uber.org/example.go:12:9: error: Potential nil panic detected. Observed nil flow from source to dereference point:
-    -> go.uber.org/example.go:12:9: unassigned variable `p` accessed field `f`
+    - go.uber.org/example.go:12:9: unassigned variable `p` accessed field `f`
 ```
 
 If we guard this dereference with a nilness check (`if p != nil`), the error goes away.
@@ -161,8 +161,8 @@ the nilness flow across function boundaries:
 
 ```
 go.uber.org/example.go:23:13: error: Potential nil panic detected. Observed nil flow from source to dereference point:
-    -> go.uber.org/example.go:20:14: literal `nil` returned from `foo()` in position 0
-    -> go.uber.org/example.go:23:13: result 0 of `foo()` dereferenced
+    - go.uber.org/example.go:20:14: literal `nil` returned from `foo()` in position 0
+    - go.uber.org/example.go:23:13: result 0 of `foo()` dereferenced
 ```
 
 Note that in the above example, `foo` does not necessarily have to reside in the same package as `bar`. NilAway is able

--- a/annotation/consume_trigger.go
+++ b/annotation/consume_trigger.go
@@ -145,8 +145,8 @@ func (a *assignmentFlow) String() string {
 
 	// build the informative print string tracking the assignments
 	var sb strings.Builder
-	sb.WriteString(" via the assignment(s):\n\t\t-> ")
-	sb.WriteString(strings.Join(strs, ",\n\t\t-> "))
+	sb.WriteString(" via the assignment(s):\n\t\t- ")
+	sb.WriteString(strings.Join(strs, ",\n\t\t- "))
 	return sb.String()
 }
 

--- a/diagnostic/nilflow.go
+++ b/diagnostic/nilflow.go
@@ -92,7 +92,7 @@ func (n *node) String() string {
 		reasonStr += n.consumerRepr
 	}
 
-	return fmt.Sprintf("\t-> %s: %s", posStr, reasonStr)
+	return fmt.Sprintf("\t- %s: %s", posStr, reasonStr)
 }
 
 func pathString(nodes []node) string {


### PR DESCRIPTION
This simply replaces the prefix `->` in the error message with `-`.