### PR TITLE
Support for blank receivers in nilable receivers logic to address false negatives

### DIFF
--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -731,7 +731,7 @@ func (r *RootAssertionNode) AddComputation(expr ast.Expr) {
 		//       is currently limited to enabling this analysis only if the below criteria is satisfied.
 		//       - Check 1: selector expression is a method invocation (e.g., `s.foo()`)
 		//       - Check 2: receiver is named and a pointer type (e.g., `func (s *S) foo()`). Blank receivers (`func (*S) foo()`)
-		//          or non-pointer receivers (`func (s S) foo()`) do not cause nil panics.
+		//       	do not cause nil panics.
 		//       - In-scope flow:
 		//       	- Check 3: the invoked method is in scope
 		//       	- Check 4: the invoking expression (caller) is of struct type. (We are restricting support only for structs
@@ -746,7 +746,7 @@ func (r *RootAssertionNode) AddComputation(expr ast.Expr) {
 		if funcObj, ok := r.ObjectOf(expr.Sel).(*types.Func); ok { // Check 1:  selector expression is a method invocation
 			recv := funcObj.Type().(*types.Signature).Recv()
 
-			if len(recv.Name()) > 0 && util.TypeIsDeeplyPtr(recv.Type()) { // Check 2: receiver is named and of pointer type
+			if len(recv.Name()) > 0 { // Check 2: receiver is named and of pointer type
 				conf := r.Pass().ResultOf[config.Analyzer].(*config.Config)
 				if conf.IsPkgInScope(funcObj.Pkg()) { // Check 3: invoked method is in scope
 					t := util.TypeOf(r.Pass(), expr.X)

--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -730,12 +730,12 @@ func (r *RootAssertionNode) AddComputation(expr ast.Expr) {
 		//       with so far the only known case being of method invocations for supporting nilable receivers. Our support
 		//       is currently limited to enabling this analysis only if the below criteria is satisfied.
 		//       - Check 1: selector expression is a method invocation (e.g., `s.foo()`)
-		//       - Check 2: receiver is named and a pointer type (e.g., `func (s *S) foo()`). Blank receivers (`func (*S) foo()`)
-		//       	do not cause nil panics.
 		//       - In-scope flow:
-		//       	- Check 3: the invoked method is in scope
-		//       	- Check 4: the invoking expression (caller) is of struct type. (We are restricting support only for structs
+		//       	- Check 2: the invoked method is in scope
+		//       	- Check 3: the invoking expression (caller) is of struct type. (We are restricting support only for structs
 		//            due to the challenges of secret nil for interfaces.)
+		// 			- Check 4: receiver is named and a pointer type (e.g., `func (s *S) foo()`). Blank receivers (`func (*S) foo()`)
+		//       		do not cause nil panics.
 		//       - Out-of-scope flow:
 		//          - Check 5: consider the criteria satisfied to support optimistic default
 		//
@@ -744,14 +744,14 @@ func (r *RootAssertionNode) AddComputation(expr ast.Expr) {
 
 		allowNilable := false
 		if funcObj, ok := r.ObjectOf(expr.Sel).(*types.Func); ok { // Check 1:  selector expression is a method invocation
-			recv := funcObj.Type().(*types.Signature).Recv()
+			conf := r.Pass().ResultOf[config.Analyzer].(*config.Config)
+			if conf.IsPkgInScope(funcObj.Pkg()) { // Check 2: invoked method is in scope
+				t := util.TypeOf(r.Pass(), expr.X)
+				// Here, `t` can only be of type struct or interface, of which we only support for structs.
+				if util.TypeAsDeeplyStruct(t) != nil { // Check 3: invoking expression (caller) is of struct type
+					recv := funcObj.Type().(*types.Signature).Recv()
 
-			if len(recv.Name()) > 0 { // Check 2: receiver is named and of pointer type
-				conf := r.Pass().ResultOf[config.Analyzer].(*config.Config)
-				if conf.IsPkgInScope(funcObj.Pkg()) { // Check 3: invoked method is in scope
-					t := util.TypeOf(r.Pass(), expr.X)
-					// Here, `t` can only be of type struct or interface, of which we only support for structs.
-					if util.TypeAsDeeplyStruct(t) != nil { // Check 4: invoking expression (caller) is of struct type
+					if len(recv.Name()) > 0 { // Check 4: receiver is a named receiver
 						allowNilable = true
 						// We are in the special case of supporting nilable receivers! Can be nilable depending on declaration annotation/inferred nilability.
 						r.AddConsumption(&annotation.ConsumeTrigger{
@@ -765,12 +765,12 @@ func (r *RootAssertionNode) AddComputation(expr ast.Expr) {
 							Guards: util.NoGuards(),
 						})
 					}
-				} else { // Check 5: invoked method is out of scope
-					// We are setting an optimistic default here for methods out of scope, specifically to avoid
-					// false positives being reported for methods in generated code. It means that such external
-					// methods are assumed to be safely handling nil receivers
-					allowNilable = true
 				}
+			} else { // Check 5: invoked method is out of scope
+				// We are setting an optimistic default here for methods out of scope, specifically to avoid
+				// false positives being reported for methods in generated code. It means that such external
+				// methods are assumed to be safely handling nil receivers
+				allowNilable = true
 			}
 		}
 		if !allowNilable {

--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -730,12 +730,14 @@ func (r *RootAssertionNode) AddComputation(expr ast.Expr) {
 		//       with so far the only known case being of method invocations for supporting nilable receivers. Our support
 		//       is currently limited to enabling this analysis only if the below criteria is satisfied.
 		//       - Check 1: selector expression is a method invocation (e.g., `s.foo()`)
+		//       - Check 2: receiver is a pointer receiver (e.g., `func (s *S) foo()` or `func (*S) foo()`). Go automatically
+		//			dereferences a value (non-pointer) receiver when a method is called on a pointer to the type. This means that
+		//			this is not a candidate for analyzing nilable receiver, instead we should check for nilablilty of the
+		//			receiver at the call site itself.
 		//       - In-scope flow:
-		//       	- Check 2: the invoked method is in scope
-		//       	- Check 3: the invoking expression (caller) is of struct type. (We are restricting support only for structs
+		//       	- Check 3: the invoked method is in scope
+		//       	- Check 4: the invoking expression (caller) is of struct type. (We are restricting support only for structs
 		//            due to the challenges of secret nil for interfaces.)
-		// 			- Check 4: receiver is named and a pointer type (e.g., `func (s *S) foo()`). Blank receivers (`func (*S) foo()`)
-		//       		do not cause nil panics.
 		//       - Out-of-scope flow:
 		//          - Check 5: consider the criteria satisfied to support optimistic default
 		//
@@ -744,14 +746,13 @@ func (r *RootAssertionNode) AddComputation(expr ast.Expr) {
 
 		allowNilable := false
 		if funcObj, ok := r.ObjectOf(expr.Sel).(*types.Func); ok { // Check 1:  selector expression is a method invocation
-			conf := r.Pass().ResultOf[config.Analyzer].(*config.Config)
-			if conf.IsPkgInScope(funcObj.Pkg()) { // Check 2: invoked method is in scope
-				t := util.TypeOf(r.Pass(), expr.X)
-				// Here, `t` can only be of type struct or interface, of which we only support for structs.
-				if util.TypeAsDeeplyStruct(t) != nil { // Check 3: invoking expression (caller) is of struct type
-					recv := funcObj.Type().(*types.Signature).Recv()
-
-					if len(recv.Name()) > 0 { // Check 4: receiver is a named receiver
+			recv := funcObj.Type().(*types.Signature).Recv()
+			if util.TypeIsDeeplyPtr(recv.Type()) { // Check 2: receiver is a pointer receiver
+				conf := r.Pass().ResultOf[config.Analyzer].(*config.Config)
+				if conf.IsPkgInScope(funcObj.Pkg()) { // Check 3: invoked method is in scope
+					t := util.TypeOf(r.Pass(), expr.X)
+					// Here, `t` can only be of type struct or interface, of which we only support for structs.
+					if util.TypeAsDeeplyStruct(t) != nil { // Check 4: invoking expression (caller) is of struct type
 						allowNilable = true
 						// We are in the special case of supporting nilable receivers! Can be nilable depending on declaration annotation/inferred nilability.
 						r.AddConsumption(&annotation.ConsumeTrigger{
@@ -765,12 +766,12 @@ func (r *RootAssertionNode) AddComputation(expr ast.Expr) {
 							Guards: util.NoGuards(),
 						})
 					}
+				} else { // Check 5: invoked method is out of scope
+					// We are setting an optimistic default here for methods out of scope, specifically to avoid
+					// false positives being reported for methods in generated code. It means that such external
+					// methods are assumed to be safely handling nil receivers
+					allowNilable = true
 				}
-			} else { // Check 5: invoked method is out of scope
-				// We are setting an optimistic default here for methods out of scope, specifically to avoid
-				// false positives being reported for methods in generated code. It means that such external
-				// methods are assumed to be safely handling nil receivers
-				allowNilable = true
 			}
 		}
 		if !allowNilable {

--- a/assertion/function/assertiontree/trusted_func.go
+++ b/assertion/function/assertiontree/trusted_func.go
@@ -145,7 +145,7 @@ var negatedSelfExpr action = func(call *ast.CallExpr, argIndex int, _ *analysis.
 	}
 }
 
-var nonnilProducer action = func(call *ast.CallExpr, argIndex int, _ *analysis.Pass) any {
+var nonnilProducer action = func(call *ast.CallExpr, _ int, _ *analysis.Pass) any {
 	return &annotation.ProduceTrigger{
 		Annotation: &annotation.TrustedFuncNonnil{ProduceTriggerNever: &annotation.ProduceTriggerNever{}},
 		Expr:       call,

--- a/assertion/function/assertiontree/util.go
+++ b/assertion/function/assertiontree/util.go
@@ -177,7 +177,7 @@ func inverseToken(t token.Token) token.Token {
 // For better performance by the caller, it also returns a boolean flag `isNoop` indicating whether
 // the returned function is a no-op
 func AddNilCheck(pass *analysis.Pass, expr ast.Expr) (trueCheck, falseCheck RootFunc, isNoop bool) {
-	noop := func(node *RootAssertionNode) {}
+	noop := func(_ *RootAssertionNode) {}
 
 	binExpr, ok := util.StripParens(expr).(*ast.BinaryExpr)
 

--- a/testdata/src/go.uber.org/receivers/inference/receivers-with-inference.go
+++ b/testdata/src/go.uber.org/receivers/inference/receivers-with-inference.go
@@ -71,7 +71,7 @@ func testInScope() {
 
 	var a *A
 	err := a.retErr()
-	print(err.Error()) // false negative, since `Error()` is nil-unsafe
+	print(err.Error()) //want "result 0 of `retErr.*`"
 }
 
 // -----------------------------------

--- a/testdata/src/go.uber.org/receivers/inference/receivers-with-inference.go
+++ b/testdata/src/go.uber.org/receivers/inference/receivers-with-inference.go
@@ -71,7 +71,7 @@ func testInScope() {
 
 	var a *A
 	err := a.retErr()
-	print(err.Error()) //want "result 0 of `retErr.*`"
+	print(err.Error()) // false negative, since `Error()` is nil-unsafe
 }
 
 // -----------------------------------

--- a/testdata/src/go.uber.org/receivers/inference/receivers-with-inference.go
+++ b/testdata/src/go.uber.org/receivers/inference/receivers-with-inference.go
@@ -129,14 +129,19 @@ func (*A) nonnamedPointer() {}
 
 func (A) nonNamedNonPointer() {}
 
+func (_ *A) blankPointer()   {}
+func (_ A) blankNonPointer() {}
+
 func testBlankAndNonPointerReceivers() {
-	var s1, s2, s3, s4 *A
+	var s1, s2, s3, s4, s5, s6 *A
 	s1.namedPointer()    // safe at call site
 	s2.nonnamedPointer() // safe at call site
+	s5.blankPointer()    // safe at call site
 
 	// below two non-pointer cases are not safe at call site
 	s3.namedNonpointer()    //want "unassigned variable"
 	s4.nonNamedNonPointer() //want "unassigned variable"
+	s6.blankNonPointer()    //want "unassigned variable"
 }
 
 type myErr struct{}

--- a/testdata/src/go.uber.org/receivers/receivers.go
+++ b/testdata/src/go.uber.org/receivers/receivers.go
@@ -128,8 +128,8 @@ func testCaller(dummy bool, i int, e *E) {
 		print(errObj.Error()) //want "unassigned variable"
 
 	case 8:
-		e.errField = errObj
-		print(e.errField.Error()) //want "unassigned variable"
+		e.errField = nil
+		print(e.errField.Error())
 	}
 }
 

--- a/testdata/src/go.uber.org/receivers/receivers.go
+++ b/testdata/src/go.uber.org/receivers/receivers.go
@@ -47,29 +47,8 @@ func (s *S) nonnilRecv() {
 	_ = s.f
 }
 
-func (s S) nonPointerRecv() {
-	_ = s.f
-}
-
-func (*S) blankPointerRecv(i int) *int {
-	return &i
-}
-
-func (S) blankNonPointerRecv(i int) *int {
-	return &i
-}
-
-type myErr struct{}
-
-func (myErr) Error() string { return "myErr message" }
-
-type E struct {
-	errField error
-}
-
-func testCaller(dummy bool, i int, e *E) {
+func testCaller(dummy bool, i int) {
 	var s *S // DECL_1: s is uninitialized
-	var errObj *myErr
 
 	switch i {
 	case 0:
@@ -114,22 +93,6 @@ func testCaller(dummy bool, i int, e *E) {
 		}
 		// here - two different flows result in a nilable (DECL_1 and DECL_2)
 		s.nonnilRecv() //want "used as receiver to call `nonnilRecv.*`" "used as receiver to call `nonnilRecv.*`"
-
-	case 4:
-		s.nonPointerRecv() //want "unassigned variable"
-
-	case 5:
-		s.blankPointerRecv(0) //want "unassigned variable"
-
-	case 6:
-		s.blankNonPointerRecv(0) //want "unassigned variable"
-
-	case 7:
-		print(errObj.Error()) //want "unassigned variable"
-
-	case 8:
-		e.errField = nil
-		print(e.errField.Error())
 	}
 }
 

--- a/testdata/src/go.uber.org/receivers/receivers.go
+++ b/testdata/src/go.uber.org/receivers/receivers.go
@@ -47,8 +47,30 @@ func (s *S) nonnilRecv() {
 	_ = s.f
 }
 
-func testCaller(dummy bool, i int) {
+func (s S) nonPointerRecv() {
+	_ = s.f
+}
+
+func (*S) blankPointerRecv(i int) *int {
+	return &i
+}
+
+func (S) blankNonPointerRecv(i int) *int {
+	return &i
+}
+
+type myErr struct{}
+
+func (myErr) Error() string { return "myErr message" }
+
+type E struct {
+	errField error
+}
+
+func testCaller(dummy bool, i int, e *E) {
 	var s *S // DECL_1: s is uninitialized
+	var errObj *myErr
+
 	switch i {
 	case 0:
 		s.nonnilRecv() //want "used as receiver to call `nonnilRecv.*`"
@@ -92,6 +114,22 @@ func testCaller(dummy bool, i int) {
 		}
 		// here - two different flows result in a nilable (DECL_1 and DECL_2)
 		s.nonnilRecv() //want "used as receiver to call `nonnilRecv.*`" "used as receiver to call `nonnilRecv.*`"
+
+	case 4:
+		s.nonPointerRecv() //want "unassigned variable"
+
+	case 5:
+		s.blankPointerRecv(0) //want "unassigned variable"
+
+	case 6:
+		s.blankNonPointerRecv(0) //want "unassigned variable"
+
+	case 7:
+		print(errObj.Error()) //want "unassigned variable"
+
+	case 8:
+		e.errField = errObj
+		print(e.errField.Error()) //want "unassigned variable"
 	}
 }
 

--- a/testdata/src/go.uber.org/receivers/receivers.go
+++ b/testdata/src/go.uber.org/receivers/receivers.go
@@ -59,6 +59,14 @@ func (S) blankNonPointerRecv(i int) *int {
 	return &i
 }
 
+func (_ *S) blankIdentifierPointerRecv(i int) *int {
+	return &i
+}
+
+func (_ S) blankIdentifierNonPointerRecv(i int) *int {
+	return &i
+}
+
 type myErr struct{}
 
 func (myErr) Error() string { return "myErr message" }
@@ -121,13 +129,19 @@ func testCaller(dummy bool, i int, e *E) {
 	case 5:
 		s.blankPointerRecv(0) //want "unassigned variable"
 
-	case 6:
+	case 7:
 		s.blankNonPointerRecv(0) //want "unassigned variable"
 
-	case 7:
+	case 8:
+		s.blankIdentifierPointerRecv(0) //want "unassigned variable"
+
+	case 9:
+		s.blankIdentifierNonPointerRecv(0) //want "unassigned variable"
+
+	case 10:
 		print(errObj.Error()) //want "unassigned variable"
 
-	case 8:
+	case 11:
 		e.errField = errObj
 		print(e.errField.Error()) //want "unassigned variable"
 	}

--- a/testdata/src/go.uber.org/receivers/receivers.go
+++ b/testdata/src/go.uber.org/receivers/receivers.go
@@ -49,7 +49,6 @@ func (s *S) nonnilRecv() {
 
 func testCaller(dummy bool, i int) {
 	var s *S // DECL_1: s is uninitialized
-
 	switch i {
 	case 0:
 		s.nonnilRecv() //want "used as receiver to call `nonnilRecv.*`"


### PR DESCRIPTION
This PR refines the logic for nilable receivers by adding support for blank receivers, i.e., non-pointer receivers. Such receivers cannot take a nil value, and should be checked for nilability at the call site.

[Closes #169 ]