### PR TITLE
Fix nondeterminism when filtering triggers for error returns

### DIFF
--- a/inference/engine.go
+++ b/inference/engine.go
@@ -23,7 +23,6 @@ import (
 
 	"go.uber.org/nilaway/annotation"
 	"go.uber.org/nilaway/assertion/function/assertiontree"
-	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 	"golang.org/x/tools/go/analysis"
 )
@@ -162,11 +161,14 @@ func (e *Engine) ObservePackage(pkgFullTriggers []annotation.FullTrigger) {
 	// their nilability status is known, then filter out the unnecessary UseAsNonErrorRetDependentOnErrorRetNilability
 	// triggers, and run the pkg inference process again only for the remainder triggers.
 	// Steps 1--3 below depict this approach in more detail.
-	nonErrRetTriggers := make(map[annotation.FullTrigger]bool, 0)
-	var otherTriggers []annotation.FullTrigger
+	var (
+		nonErrRetTriggers []annotation.FullTrigger
+		// In most cases all triggers will be stored in otherTriggers, so we set a proper capacity.
+		otherTriggers = make([]annotation.FullTrigger, 0, len(pkgFullTriggers))
+	)
 	for _, t := range pkgFullTriggers {
 		if _, ok := t.Consumer.Annotation.(*annotation.UseAsNonErrorRetDependentOnErrorRetNilability); ok {
-			nonErrRetTriggers[t] = true
+			nonErrRetTriggers = append(nonErrRetTriggers, t)
 		} else {
 			otherTriggers = append(otherTriggers, t)
 		}
@@ -215,13 +217,19 @@ func (e *Engine) ObservePackage(pkgFullTriggers []annotation.FullTrigger) {
 			return assertiontree.ProducerNilabilityUnknown
 		})
 
-	// remove deleted triggers from nonErrRetTriggers
-	for _, t := range delTriggers {
-		delete(nonErrRetTriggers, t)
+	filteredTriggers := nonErrRetTriggers
+	// Remove deleted triggers from nonErrRetTriggers (if needed).
+	if len(delTriggers) != 0 {
+		filteredTriggers = make([]annotation.FullTrigger, 0, len(nonErrRetTriggers)-len(delTriggers))
+		for _, t := range nonErrRetTriggers {
+			if !delTriggers[t] {
+				filteredTriggers = append(filteredTriggers, t)
+			}
+		}
 	}
 
 	// Step 3: run the inference building process for only the remaining UseAsNonErrorRetDependentOnErrorRetNilability triggers, and collect assertions
-	e.buildPkgInferenceMap(maps.Keys(nonErrRetTriggers))
+	e.buildPkgInferenceMap(filteredTriggers)
 }
 
 func (e *Engine) buildPkgInferenceMap(triggers []annotation.FullTrigger) {


### PR DESCRIPTION
We have observed nondeterministic behaviors from NilAway when analyzing the standard libraries. 

When we process the full triggers for a particular package, we first filter out the non-error triggers for the error-returning functions that are dependent on the nilability of the error, process the other triggers, and later removing some non-error triggers if the nilabilities of the error are known due to the partial processing. This helps reduce a lot of false positives.

However, we are using a set (map) to store the non-error triggers for error-returning functions since it makes later deletion faster. Eventually, we call `maps.Keys` to convert the map back to a slice to continue processing the triggers.

This brings randomness, and NilAway currently depends on stable processing orders of triggers for deterministic error reporting. 

This PR updates `FilterTriggersForErrorReturn` function to return the deleted triggers in a map instead. Then in our inference engine, we store the triggers in slices, and eventually re-iterate the ordered slice (and reference the deleted trigger map) to construct the final (ordered) filtered triggers. By doing this, we should have similar performance as the original implementation.