### PR TITLE
Remove timeout for backpropagation

### DIFF
--- a/assertion/function/analyzer.go
+++ b/assertion/function/analyzer.go
@@ -123,7 +123,7 @@ func run(pass *analysis.Pass) (result interface{}, _ error) {
 	}
 
 	// Set up variables for synchronization and communication.
-	ctx, cancel := context.WithTimeout(context.Background(), config.BackpropTimeout)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	var wg sync.WaitGroup
 	funcChan := make(chan functionResult)

--- a/assertion/function/analyzer_test.go
+++ b/assertion/function/analyzer_test.go
@@ -90,11 +90,9 @@ func TestTimeout(t *testing.T) {
 
 	// Since we have passed a cancelled context, the goroutine should immediately return with a
 	// Canceled error.
-	select {
-	case res := <-resultChan:
-		require.Equal(t, res.index, 0)
-		require.ErrorIs(t, res.err, context.Canceled)
-	}
+	res := <-resultChan
+	require.Equal(t, res.index, 0)
+	require.ErrorIs(t, res.err, context.Canceled)
 }
 
 func TestAnalyzeFuncPanic(t *testing.T) {
@@ -123,11 +121,9 @@ func TestAnalyzeFuncPanic(t *testing.T) {
 		close(resultChan)
 	}()
 
-	select {
-	case res := <-resultChan:
-		require.Equal(t, res.index, 0)
-		require.ErrorContains(t, res.err, "panic")
-	}
+	res := <-resultChan
+	require.Equal(t, res.index, 0)
+	require.ErrorContains(t, res.err, "panic")
 }
 
 func TestMain(m *testing.M) {

--- a/assertion/function/analyzer_test.go
+++ b/assertion/function/analyzer_test.go
@@ -20,7 +20,6 @@ import (
 	"go/types"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
@@ -76,9 +75,10 @@ func TestTimeout(t *testing.T) {
 	wg := new(sync.WaitGroup)
 	wg.Add(1)
 
-	// Give a context that immediately times out, so backprop should return with an error.
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now())
-	defer cancel()
+	// Give a cancelled context, so back propagation should immediately return with an error.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
 	ctrlflowResult := pass.ResultOf[ctrlflow.Analyzer].(*ctrlflow.CFGs)
 	go analyzeFunc(ctx, pass, funcDecl, funcContext, ctrlflowResult.FuncDecl(funcDecl), 0, resultChan, wg)
 
@@ -88,14 +88,12 @@ func TestTimeout(t *testing.T) {
 		close(resultChan)
 	}()
 
-	// Since we have passed a timed out context, the goroutine should immediately return with a
-	// DeadlineExceeded error. Here we wait up to 10 seconds before we force fail.
+	// Since we have passed a cancelled context, the goroutine should immediately return with a
+	// Canceled error.
 	select {
 	case res := <-resultChan:
 		require.Equal(t, res.index, 0)
-		require.ErrorIs(t, res.err, context.DeadlineExceeded)
-	case <-time.After(10 * time.Second):
-		require.Fail(t, "A cancelled context was given to backprop, but it did not return within 10 seconds.")
+		require.ErrorIs(t, res.err, context.Canceled)
 	}
 }
 
@@ -129,8 +127,6 @@ func TestAnalyzeFuncPanic(t *testing.T) {
 	case res := <-resultChan:
 		require.Equal(t, res.index, 0)
 		require.ErrorContains(t, res.err, "panic")
-	case <-time.After(10 * time.Second):
-		require.Fail(t, "analyzeFun did not return within 10 seconds.")
 	}
 }
 

--- a/assertion/function/assertiontree/backprop.go
+++ b/assertion/function/assertiontree/backprop.go
@@ -955,9 +955,10 @@ func BackpropAcrossFunc(ctx context.Context, pass *analysis.Pass, decl *ast.Func
 			break
 		}
 
-		config.CheckCFGFixedPointRuntime(
+		checkCFGFixedPointRuntime(
 			fmt.Sprintf("BackpropAcrossFunc(%s) Forwards Propagation", decl.Name.Name),
-			len(blocks), roundCount)
+			roundCount, len(blocks),
+		)
 
 		// Move variables from this round to last round and create new ones for next round.
 		// For best performance, we reuse the slices by simply swapping them and clearing the

--- a/assertion/function/assertiontree/preprocess_blocks.go
+++ b/assertion/function/assertiontree/preprocess_blocks.go
@@ -19,7 +19,6 @@ import (
 	"go/ast"
 	"go/token"
 
-	"go.uber.org/nilaway/config"
 	"go.uber.org/nilaway/util"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/cfg"
@@ -736,8 +735,7 @@ func propagateRichChecks(graph *cfg.CFG, richCheckBlocks [][]RichCheckEffect) []
 
 		roundCount++
 
-		config.CheckCFGFixedPointRuntime(
-			"RichCheckEffect Forwards Propagation", n, roundCount)
+		checkCFGFixedPointRuntime("RichCheckEffect Forwards Propagation", roundCount, n)
 	}
 
 	// this strips duplicates from the RichCheckEffect slices

--- a/assertion/function/assertiontree/util.go
+++ b/assertion/function/assertiontree/util.go
@@ -26,6 +26,17 @@ import (
 	"golang.org/x/tools/go/ast/astutil"
 )
 
+// checkCFGFixedPointRuntime panics if a fixed point iteration loop runs beyond some upper
+// bounded round number, determined by the number of blocks in the CFG of the analyzed function.
+func checkCFGFixedPointRuntime(passName string, currRound, numBlocks int) {
+	if maxRound := numBlocks * numBlocks * 2; currRound > maxRound {
+		panic(fmt.Sprintf("propagation over %d-block CFG in %q ran for "+
+			"%d rounds, when maximum allowed was %d rounds.",
+			numBlocks, passName, currRound, maxRound),
+		)
+	}
+}
+
 // GetDeclaringPath finds the path of nested AST nodes beginning with the passed interval `[start, end]`
 func GetDeclaringPath(pass *analysis.Pass, start, end token.Pos) ([]ast.Node, bool) {
 	astFile := lookupAstFromFile(pass, pass.Fset.File(start))

--- a/config/const.go
+++ b/config/const.go
@@ -1,10 +1,5 @@
 package config
 
-import (
-	"fmt"
-	"time"
-)
-
 // This file hosts non-user-configurable parameters --- these are for development and testing purposes only.
 
 // StableRoundLimit is the number of rounds in backpropagation algorithm after which, if there is no change
@@ -15,11 +10,6 @@ import (
 // After experimentation, we observed that using StableRoundLimit = 5 with NilAway yields similar analysis time compared
 // to lower values, making it a good compromise for precise results.
 const StableRoundLimit = 5
-
-// BackpropTimeout is the timeout set for analysis of each function. This ensures build time SLAs.
-// NilAway should report an error if this timeout is ever hit, in order not to silently ignore any
-// functions due to this.
-const BackpropTimeout = 10 * time.Second
 
 // ErrorOnNilableMapRead configures whether reading from nil maps should be considered an error.
 // Since Go does not panic on this, right now we do not interpret it as one, but this could be
@@ -62,19 +52,3 @@ const NilAwayStructInitCheckString = "<nilaway struct enable>"
 // NilAwayAnonymousFuncCheckString is the string that may be inserted into the docstring for a package to
 // force NilAway to enable anonymous func checking
 const NilAwayAnonymousFuncCheckString = "<nilaway anonymous function enable>"
-
-func maxRoundsFromBlocks(numBlocks int) int {
-	return numBlocks * numBlocks * 2
-}
-
-// CheckCFGFixedPointRuntime throws a panic if a fixed point iteration loop runs beyond some upper
-// bounded round number, determined by the number of blocks in the CFG of the analyzed function,
-// processed by maxRoundsFromBlocks
-func CheckCFGFixedPointRuntime(passName string, numBlocks, currRound int) {
-	if currRound > maxRoundsFromBlocks(numBlocks) {
-		panic(fmt.Sprintf("ERROR: Propagation over %d-block CFG in pass '%s' ran for "+
-			"%d rounds, when maximum allowed was %d rounds. This indicates a failure of the fixpoint"+
-			" logic and must be debugged at the source level.",
-			numBlocks, passName, currRound, maxRoundsFromBlocks(numBlocks)))
-	}
-}


### PR DESCRIPTION
We added a timeout for backpropagation (10s) for the analysis of any particular function some time ago for keeping the build time SLAs since we observed long analysis time for some particular structures (where the backpropagation runs for many iterations).

@shubhamugare had thoroughly analyzed the problem and implemented optimizations in PR #5, which drastically improved the performance of NilAway's backpropagation algorithm. Meanwhile, the time-based bound showed its own problem, including but certainly not limited to (1) difficulty for debugging, (2) breaking build hermeticity, (3) flaky CI since github CI machines are heavily resource-shared, and more.

After thorough testing in our internal repository, we see no instances of such timeout being hit. This PR removes this timeout completely. Note that we still keep the heuristic upper bound on backpropagation iterations based on the number of blocks in the CFG as a final safety net (which shouldn't be hit either). This PR also takes this opportunity to refactor and move this check to the corresponding packages for better code organization.

 