### PR TITLE
Add nilable receiver support for named types

### DIFF
--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -736,8 +736,8 @@ func (r *RootAssertionNode) AddComputation(expr ast.Expr) {
 		//			receiver at the call site itself.
 		//       - In-scope flow:
 		//       	- Check 3: the invoked method is in scope
-		//       	- Check 4: the invoking expression (caller) is of struct type. (We are restricting support only for structs
-		//            due to the challenges of secret nil for interfaces.)
+		//       	- Check 4: the invoking expression (caller) is of a non-interface type (e.g., struct or named). (We are
+		//       		restricting support only for non-interfaces due to the challenges of secret nil for interfaces.)
 		//       - Out-of-scope flow:
 		//          - Check 5: consider the criteria satisfied to support optimistic default
 		//
@@ -752,7 +752,7 @@ func (r *RootAssertionNode) AddComputation(expr ast.Expr) {
 				if conf.IsPkgInScope(funcObj.Pkg()) { // Check 3: invoked method is in scope
 					t := util.TypeOf(r.Pass(), expr.X)
 					// Here, `t` can only be of type struct or interface, of which we only support for structs.
-					if util.TypeAsDeeplyStruct(t) != nil { // Check 4: invoking expression (caller) is of struct type
+					if !util.TypeIsDeeplyInterface(t) { // Check 4: invoking expression (caller) is of a non-interface type (e.g., struct or named)
 						allowNilable = true
 						// We are in the special case of supporting nilable receivers! Can be nilable depending on declaration annotation/inferred nilability.
 						r.AddConsumption(&annotation.ConsumeTrigger{

--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -751,7 +751,7 @@ func (r *RootAssertionNode) AddComputation(expr ast.Expr) {
 				conf := r.Pass().ResultOf[config.Analyzer].(*config.Config)
 				if conf.IsPkgInScope(funcObj.Pkg()) { // Check 3: invoked method is in scope
 					t := util.TypeOf(r.Pass(), expr.X)
-					// Here, `t` can only be of type struct or interface, of which we only support for structs.
+					// Here, `t` can only be of type interface, struct, or named, of which we only support for struct and named types.
 					if !util.TypeIsDeeplyInterface(t) { // Check 4: invoking expression (caller) is of a non-interface type (e.g., struct or named)
 						allowNilable = true
 						// We are in the special case of supporting nilable receivers! Can be nilable depending on declaration annotation/inferred nilability.

--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -735,9 +735,11 @@ func (r *RootAssertionNode) AddComputation(expr ast.Expr) {
 		//			this is not a candidate for analyzing nilable receiver, instead we should check for nilablilty of the
 		//			receiver at the call site itself.
 		//       - In-scope flow:
-		//       	- Check 3: the invoked method is in scope
-		//       	- Check 4: the invoking expression (caller) is of struct type. (We are restricting support only for structs
+		//       	- Check 2: the invoked method is in scope
+		//       	- Check 3: the invoking expression (caller) is of struct type. (We are restricting support only for structs
 		//            due to the challenges of secret nil for interfaces.)
+		// 			- Check 4: receiver is named and a pointer type (e.g., `func (s *S) foo()`). Blank receivers (`func (*S) foo()`)
+		//       		do not cause nil panics.
 		//       - Out-of-scope flow:
 		//          - Check 5: consider the criteria satisfied to support optimistic default
 		//
@@ -766,12 +768,12 @@ func (r *RootAssertionNode) AddComputation(expr ast.Expr) {
 							Guards: util.NoGuards(),
 						})
 					}
-				} else { // Check 5: invoked method is out of scope
-					// We are setting an optimistic default here for methods out of scope, specifically to avoid
-					// false positives being reported for methods in generated code. It means that such external
-					// methods are assumed to be safely handling nil receivers
-					allowNilable = true
 				}
+			} else { // Check 5: invoked method is out of scope
+				// We are setting an optimistic default here for methods out of scope, specifically to avoid
+				// false positives being reported for methods in generated code. It means that such external
+				// methods are assumed to be safely handling nil receivers
+				allowNilable = true
 			}
 		}
 		if !allowNilable {

--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -735,11 +735,9 @@ func (r *RootAssertionNode) AddComputation(expr ast.Expr) {
 		//			this is not a candidate for analyzing nilable receiver, instead we should check for nilablilty of the
 		//			receiver at the call site itself.
 		//       - In-scope flow:
-		//       	- Check 2: the invoked method is in scope
-		//       	- Check 3: the invoking expression (caller) is of struct type. (We are restricting support only for structs
+		//       	- Check 3: the invoked method is in scope
+		//       	- Check 4: the invoking expression (caller) is of struct type. (We are restricting support only for structs
 		//            due to the challenges of secret nil for interfaces.)
-		// 			- Check 4: receiver is named and a pointer type (e.g., `func (s *S) foo()`). Blank receivers (`func (*S) foo()`)
-		//       		do not cause nil panics.
 		//       - Out-of-scope flow:
 		//          - Check 5: consider the criteria satisfied to support optimistic default
 		//
@@ -768,12 +766,12 @@ func (r *RootAssertionNode) AddComputation(expr ast.Expr) {
 							Guards: util.NoGuards(),
 						})
 					}
+				} else { // Check 5: invoked method is out of scope
+					// We are setting an optimistic default here for methods out of scope, specifically to avoid
+					// false positives being reported for methods in generated code. It means that such external
+					// methods are assumed to be safely handling nil receivers
+					allowNilable = true
 				}
-			} else { // Check 5: invoked method is out of scope
-				// We are setting an optimistic default here for methods out of scope, specifically to avoid
-				// false positives being reported for methods in generated code. It means that such external
-				// methods are assumed to be safely handling nil receivers
-				allowNilable = true
 			}
 		}
 		if !allowNilable {

--- a/testdata/src/go.uber.org/receivers/inference/receivers-with-inference.go
+++ b/testdata/src/go.uber.org/receivers/inference/receivers-with-inference.go
@@ -71,7 +71,7 @@ func testInScope() {
 
 	var a *A
 	err := a.retErr()
-	print(err.Error()) // false negative, since `Error()` is nil-unsafe
+	print(err.Error()) //want "result 0 of `retErr.*`"
 }
 
 // -----------------------------------

--- a/testdata/src/go.uber.org/receivers/inference/receivers-with-inference.go
+++ b/testdata/src/go.uber.org/receivers/inference/receivers-with-inference.go
@@ -71,7 +71,7 @@ func testInScope() {
 
 	var a *A
 	err := a.retErr()
-	print(err.Error()) //want "result 0 of `retErr.*`"
+	print(err.Error()) // false negative, since `Error()` is nil-unsafe
 }
 
 // -----------------------------------

--- a/testdata/src/go.uber.org/receivers/inference/receivers-with-inference.go
+++ b/testdata/src/go.uber.org/receivers/inference/receivers-with-inference.go
@@ -132,6 +132,24 @@ func (A) nonNamedNonPointer() {}
 func (_ *A) blankPointer()   {}
 func (_ A) blankNonPointer() {}
 
+type myInt int
+
+func (*myInt) String() string {
+	return ""
+}
+
+func (m *myInt) namedPointer() {
+	_ = *m //want "dereferenced"
+}
+
+func (m myInt) namedNonPointer() {
+	_ = m.String()
+}
+
+func (*myInt) blankPointer() {}
+
+func (myInt) blankNonPointer() {}
+
 func testBlankAndNonPointerReceivers() {
 	var s1, s2, s3, s4, s5, s6 *A
 	s1.namedPointer()    // safe at call site
@@ -142,6 +160,15 @@ func testBlankAndNonPointerReceivers() {
 	s3.namedNonpointer()    //want "unassigned variable"
 	s4.nonNamedNonPointer() //want "unassigned variable"
 	s6.blankNonPointer()    //want "unassigned variable"
+
+	// same tests as above, but user-defined named types
+	var m1, m2, m3, m4 *myInt
+	m1.namedPointer() // safe at call site
+	m2.blankPointer() // safe at call site
+
+	// below two non-pointer cases are not safe at call site
+	m3.namedNonPointer() //want "unassigned variable"
+	m4.blankNonPointer() //want "unassigned variable"
 }
 
 type myErr struct{}

--- a/testdata/src/go.uber.org/receivers/receivers.go
+++ b/testdata/src/go.uber.org/receivers/receivers.go
@@ -77,7 +77,6 @@ type E struct {
 
 func testCaller(dummy bool, i int, e *E) {
 	var s *S // DECL_1: s is uninitialized
-
 	switch i {
 	case 0:
 		s.nonnilRecv() //want "used as receiver to call `nonnilRecv.*`"

--- a/testdata/src/go.uber.org/receivers/receivers.go
+++ b/testdata/src/go.uber.org/receivers/receivers.go
@@ -77,6 +77,8 @@ type E struct {
 
 func testCaller(dummy bool, i int, e *E) {
 	var s *S // DECL_1: s is uninitialized
+	var errObj *myErr
+
 	switch i {
 	case 0:
 		s.nonnilRecv() //want "used as receiver to call `nonnilRecv.*`"

--- a/testdata/src/go.uber.org/receivers/receivers.go
+++ b/testdata/src/go.uber.org/receivers/receivers.go
@@ -77,8 +77,6 @@ type E struct {
 
 func testCaller(dummy bool, i int, e *E) {
 	var s *S // DECL_1: s is uninitialized
-	var errObj *myErr
-
 	switch i {
 	case 0:
 		s.nonnilRecv() //want "used as receiver to call `nonnilRecv.*`"

--- a/testdata/src/go.uber.org/receivers/receivers.go
+++ b/testdata/src/go.uber.org/receivers/receivers.go
@@ -77,7 +77,6 @@ type E struct {
 
 func testCaller(dummy bool, i int, e *E) {
 	var s *S // DECL_1: s is uninitialized
-	var errObj *myErr
 
 	switch i {
 	case 0:

--- a/util/util.go
+++ b/util/util.go
@@ -155,6 +155,18 @@ func TypeAsDeeplyStruct(typ types.Type) *types.Struct {
 	return nil
 }
 
+// TypeIsDeeplyInterface returns true if `t` is of struct type, including
+// transitively through Named types
+func TypeIsDeeplyInterface(t types.Type) bool {
+	if _, ok := t.(*types.Interface); ok {
+		return true
+	}
+	if t, ok := t.(*types.Named); ok {
+		return TypeIsDeeplyInterface(t.Underlying())
+	}
+	return false
+}
+
 // UnwrapPtr unwraps a pointer type and returns the element type. For all other types it returns
 // the type unmodified.
 func UnwrapPtr(t types.Type) types.Type {


### PR DESCRIPTION
This PR extends the nilable receiver support for methods of named types. (Earlier the support was limited to only structs.)