### PR TITLE
Fix makefile to run test/coverage/lint on all modules in the repository

### DIFF
--- a/tools/cmd/golden-test/main_test.go
+++ b/tools/cmd/golden-test/main_test.go
@@ -39,11 +39,11 @@ func TestWriteDiff(t *testing.T) {
 	var buf bytes.Buffer
 	base := map[Diagnostic]bool{
 		// Same in both.
-		Diagnostic{Posn: "src/file1:10:2", Message: "nil pointer dereference"}: true,
+		{Posn: "src/file1:10:2", Message: "nil pointer dereference"}: true,
 	}
 	test := map[Diagnostic]bool{
 		// Same in both.
-		Diagnostic{Posn: "src/file1:10:2", Message: "nil pointer dereference"}: true,
+		{Posn: "src/file1:10:2", Message: "nil pointer dereference"}: true,
 	}
 	branches := [2]*BranchResult{
 		{Name: "base", ShortSHA: "123456", Result: base},
@@ -70,19 +70,19 @@ func TestDiff(t *testing.T) {
 
 	base := map[Diagnostic]bool{
 		// Same in both.
-		Diagnostic{Posn: "src/file1:10:2", Message: "nil pointer dereference"}: true,
+		{Posn: "src/file1:10:2", Message: "nil pointer dereference"}: true,
 		// Differs in position.
-		Diagnostic{Posn: "src/file2:10:2", Message: "nil pointer dereference"}: true,
+		{Posn: "src/file2:10:2", Message: "nil pointer dereference"}: true,
 		// Differs in message.
-		Diagnostic{Posn: "src/file4:10:2", Message: "foo error"}: true,
+		{Posn: "src/file4:10:2", Message: "foo error"}: true,
 	}
 	test := map[Diagnostic]bool{
 		// Same in both.
-		Diagnostic{Posn: "src/file1:10:2", Message: "nil pointer dereference"}: true,
+		{Posn: "src/file1:10:2", Message: "nil pointer dereference"}: true,
 		// Differs in position.
-		Diagnostic{Posn: "src/file3:10:2", Message: "nil pointer dereference"}: true,
+		{Posn: "src/file3:10:2", Message: "nil pointer dereference"}: true,
 		// Differs in message.
-		Diagnostic{Posn: "src/file4:10:2", Message: "bar error"}: true,
+		{Posn: "src/file4:10:2", Message: "bar error"}: true,
 	}
 
 	minuses := Diff(base, test)


### PR DESCRIPTION
By default, the `go test ./...` includes all packages and sub-packages within the current _module_. However, in PR #187 we have introduced another module (`tools`) inside this repository, which is silently ignored by test / coverage / lint tasks in our makefile. This PR fixes this by iterating over a predefined list of modules for all these tasks, making it expandable for future module additions.

Due to this fix, we have run `gofmt -s` on `tools/cmd/golden-test/main_test.go` to pass linting.