### PR TITLE
Upgrade checkout actions version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           cache: true
 
       - name: Load cached dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -77,7 +77,7 @@ jobs:
           cache: true
 
       - name: Load cached dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Check out repository
 
       - name: Set up Go
@@ -35,7 +35,7 @@ jobs:
       matrix:
         go: [ "1.21.x", "1.22.x" ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Go
         uses: actions/setup-go@v4
@@ -68,7 +68,7 @@ jobs:
       matrix:
         go: [ "1.21.x", "1.22.x" ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Go
         uses: actions/setup-go@v4

--- a/.github/workflows/golden-test.yml
+++ b/.github/workflows/golden-test.yml
@@ -12,7 +12,7 @@ jobs:
     name: Golden Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Check out repository
 
       - name: Fetch base branch (${{ github.event.pull_request.base.ref }}) locally


### PR DESCRIPTION
This PR upgrades the `actions/checkout` and `actions/cache` versions to avoid the deprecation warnings in CI runs.

We should also consider configuring dependabot to do this in the future, but for now let's merge the upgrades.