### PR TITLE
Add missing gob encodings

### DIFF
--- a/inference/engine.go
+++ b/inference/engine.go
@@ -525,6 +525,8 @@ func GobRegister() {
 	gob.RegisterName(nextStr(), annotation.GlobalVarAssignDeepPrestring{})
 	gob.RegisterName(nextStr(), annotation.LocalVarAssignDeepPrestring{})
 	gob.RegisterName(nextStr(), annotation.ChanSendPrestring{})
+	gob.RegisterName(nextStr(), annotation.ArgPassDeepPrestring{})
+	gob.RegisterName(nextStr(), annotation.UseAsReturnDeepPrestring{})
 
 	gob.RegisterName(nextStr(), annotation.TriggerIfNilablePrestring{})
 	gob.RegisterName(nextStr(), annotation.TriggerIfDeepNilablePrestring{})


### PR DESCRIPTION
This PR the registers gob encodings for the newly created consumer trigger structs in PR #88 .