### PR TITLE
[Fix] Register UseAsReturnDeepPrestring to Gob

### DIFF
--- a/inference/engine.go
+++ b/inference/engine.go
@@ -568,4 +568,5 @@ func GobRegister() {
 	gob.RegisterName(nextStr(), annotation.RecvPassPrestring{})
 	gob.RegisterName(nextStr(), annotation.MethodRecvDeepPrestring{})
 	gob.RegisterName(nextStr(), annotation.FldReturnPrestring{})
+	gob.RegisterName(nextStr(), annotation.UseAsReturnDeepPrestring{})
 }


### PR DESCRIPTION
*Disclaimer*: As this is my first PR to the project, I welcome any feedback on the format and adherence to the project's PR guidelines. Thank you for your guidance!

This PR addresses a problem encountered with Go tools' [internal facts](https://pkg.go.dev/golang.org/x/tools/go/analysis/internal/facts) following the changes introduced in [PR #88](https://github.com/uber-go/nilaway/pull/88). The issue was identified as a failure to register the `annotations.UseAsReturnDeepPrestring` type with Gob, which is necessary for the proper functioning of Go tools facts.

To resolve this, we just need to register the aforementioned type to Gob.