### PR TITLE
Optimize codebase with features from Go 1.21

### DIFF
--- a/annotation/helper_test.go
+++ b/annotation/helper_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/nilaway/util"
-	"golang.org/x/exp/maps"
 	"golang.org/x/tools/go/packages"
 )
 
@@ -110,7 +109,11 @@ func getImplementedMethods(t *types.Named) []*types.Func {
 	visitedMethods := make(map[string]*types.Func) // helps in only storing the latest overridden implementation of a method
 	visitedStructs := make(map[*types.Struct]bool) // helps in avoiding infinite recursion if there is a cycle in the struct embedding
 	collectMethods(t, visitedMethods, visitedStructs)
-	return maps.Values(visitedMethods)
+	methods := make([]*types.Func, 0, len(visitedMethods))
+	for _, m := range visitedMethods {
+		methods = append(methods, m)
+	}
+	return methods
 }
 
 // collectMethods is a helper function that recursively collects all `methods` implemented by the struct `t`.

--- a/assertion/function/assertiontree/backprop.go
+++ b/assertion/function/assertiontree/backprop.go
@@ -23,11 +23,11 @@ import (
 	"go/ast"
 	"go/token"
 	"go/types"
+	"slices"
 
 	"go.uber.org/nilaway/annotation"
 	"go.uber.org/nilaway/config"
 	"go.uber.org/nilaway/util"
-	"golang.org/x/exp/slices"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/cfg"
 )
@@ -963,14 +963,10 @@ func BackpropAcrossFunc(ctx context.Context, pass *analysis.Pass, decl *ast.Func
 		// Move variables from this round to last round and create new ones for next round.
 		// For best performance, we reuse the slices by simply swapping them and clearing the
 		// slices for next rounds.
-		// We do not actually need to allocate a new slice for nextAssertions. However, currently
-		// NilAway thinks nextAssertions is a deeply-nonnil slice, and we cannot assign nil to it.
-		// TODO: investigate and further optimize this.
-		currAssertions, nextAssertions = nextAssertions, make([]*RootAssertionNode, len(blocks))
+		currAssertions, nextAssertions = nextAssertions, currAssertions
+		clear(nextAssertions)
 		updatedLastRound, updatedThisRound = updatedThisRound, updatedLastRound
-		for i := range blocks {
-			updatedThisRound[i] = false
-		}
+		clear(updatedThisRound)
 		currRootAssertionNode, nextRootAssertionNode = nextRootAssertionNode, nil
 	}
 

--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -1159,10 +1159,10 @@ func (r *RootAssertionNode) isType(expr ast.Expr) bool {
 // isZeroSlicing returns if the given slice expression is a special case that will not cause panic
 // even when the slice itself is nil, i.e, one of [:0] [0:0] [0:] [:] [:0:0] [0:0:0]
 func (r *RootAssertionNode) isZeroSlicing(expr *ast.SliceExpr) bool {
-	lo, hi, max := expr.Low, expr.High, expr.Max
-	return ((lo == nil || r.isIntZero(lo)) && r.isIntZero(hi) && max == nil) || // [:0] [0:0]
-		((lo == nil || r.isIntZero(lo)) && hi == nil && max == nil) || // [0:] [:]
-		((lo == nil || r.isIntZero(lo)) && r.isIntZero(hi) && r.isIntZero(max)) // [:0:0] [0:0:0]
+	l, h, m := expr.Low, expr.High, expr.Max
+	return ((l == nil || r.isIntZero(l)) && r.isIntZero(h) && m == nil) || // [:0] [0:0]
+		((l == nil || r.isIntZero(l)) && h == nil && m == nil) || // [0:] [:]
+		((l == nil || r.isIntZero(l)) && r.isIntZero(h) && r.isIntZero(m)) // [:0:0] [0:0:0]
 }
 
 // isIntZero returns if the given expression is evaluated to integer zero at compile time. For

--- a/diagnostic/engine.go
+++ b/diagnostic/engine.go
@@ -72,18 +72,14 @@ func NewEngine(pass *analysis.Pass) *Engine {
 
 		// The file will be fake (conceptually "\n" * 65535) if it is imported from archive. So we
 		// check if there are any gaps between the line starts to determine if the file is fake.
-		// TODO: Go 1.21 introduced a new "token.File.Lines()" API to directly get the underlying
-		//  lines slice, which should allow faster checks since calling "token.File.LineStart"
-		//  repeatedly is slow due to locks/unlocks.
 		isFake := true
-		var prev token.Pos
-		for i := 1; i <= file.LineCount(); i++ {
-			p := file.LineStart(i)
-			if prev.IsValid() && p-prev > 1 {
+		prev := -1
+		for _, pos := range file.Lines() {
+			if prev != -1 && pos-prev > 1 {
 				isFake = false
 				break
 			}
-			prev = p
+			prev = pos
 		}
 		files[name] = fileInfo{
 			file:   file,

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/klauspost/compress v1.17.6
 	github.com/stretchr/testify v1.8.4
 	go.uber.org/goleak v1.3.0
-	golang.org/x/exp v0.0.0-20240213143201-ec583247a57a
 	golang.org/x/tools v0.18.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,6 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
-golang.org/x/exp v0.0.0-20240213143201-ec583247a57a h1:HinSgX1tJRX3KsL//Gxynpw5CTOAIPhgL4W8PNiIpVE=
-golang.org/x/exp v0.0.0-20240213143201-ec583247a57a/go.mod h1:CxmFvTBINI24O/j8iY7H1xHzx2i4OsyguNBmN/uPtqc=
 golang.org/x/mod v0.15.0 h1:SernR4v+D55NyBH2QiEQrlBAnj1ECL6AGrA5+dPaMY8=
 golang.org/x/mod v0.15.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/sync v0.6.0 h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ=

--- a/inference/engine.go
+++ b/inference/engine.go
@@ -17,13 +17,13 @@
 package inference
 
 import (
+	"cmp"
 	"encoding/gob"
 	"fmt"
-	"strings"
+	"slices"
 
 	"go.uber.org/nilaway/annotation"
 	"go.uber.org/nilaway/assertion/function/assertiontree"
-	"golang.org/x/exp/slices"
 	"golang.org/x/tools/go/analysis"
 )
 
@@ -93,7 +93,7 @@ func (e *Engine) ObserveUpstream() {
 	// important for determinism in NilAway since our inference algorithm depends on the order of
 	// trigger / site nilability applications.
 	slices.SortFunc(facts, func(i, j analysis.PackageFact) int {
-		return strings.Compare(i.Package.Path(), j.Package.Path())
+		return cmp.Compare(i.Package.Path(), j.Package.Path())
 	})
 
 	for _, f := range facts {

--- a/tools/cmd/golden-test/main.go
+++ b/tools/cmd/golden-test/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"bytes"
+	"cmp"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -242,10 +243,10 @@ func Diff(first, second map[Diagnostic]bool) []Diagnostic {
 	}
 	// Sort the diff such that we have stable ordering for the same runs.
 	slices.SortFunc(diff, func(i, j Diagnostic) int {
-		if n := strings.Compare(i.Posn, j.Posn); n != 0 {
+		if n := cmp.Compare(i.Posn, j.Posn); n != 0 {
 			return n
 		}
-		return strings.Compare(i.Message, j.Message)
+		return cmp.Compare(i.Message, j.Message)
 	})
 	return diff
 }


### PR DESCRIPTION
This PR optimizes the codebase using the new features introduced in Go 1.21 since we have bumped our minimum required version.

Specifically, we are:

(1) leveraging the builtin `clear` to clear the entire slice instead of allocating a new one in each iteration of backpropagation.
(2) Replacing the helper functions in `x/exp` for slices and maps with the corresponding one from standard library. By doing this, we have removed the dependency for `x/exp`.
(3) Renaming a local variable `max` to avoid collisions with the new builtin function `max`.
(4) Replacing `strings.Compare` with the generic version `cmp.Compare` from standard libraries.
(5) Using `token.File.Lines()` for better performance when checking if a file is "fake" (i.e., imported from archive).

All these changes bring slight performance gains and/or better code readability.

Depends on PR #201 