### PR TITLE
Fix for infinite loops

### DIFF
--- a/assertion/function/assertiontree/backprop_util.go
+++ b/assertion/function/assertiontree/backprop_util.go
@@ -664,9 +664,11 @@ func blocksAndPreprocessingFromCFG(
 		Index: int32(numBlocks),
 		Live:  true,
 	})
-	// link all returning blocks to the "return" block
+	// add "return" block as a successor for:
+	// - all returning blocks
+	// - while loops (`for <EXPR> {}` or `for {}`)
 	for i := 0; i < numBlocks; i++ {
-		if blocks[i].Return() != nil {
+		if blocks[i].Return() != nil || (len(blocks[i].Succs) == 1 && blocks[i].Succs[0].Index == blocks[i].Index) {
 			blocks[i].Succs = append(blocks[i].Succs, blocks[numBlocks])
 		}
 	}

--- a/assertion/function/assertiontree/backprop_util.go
+++ b/assertion/function/assertiontree/backprop_util.go
@@ -668,7 +668,10 @@ func blocksAndPreprocessingFromCFG(
 	// - all returning blocks
 	// - while loops (`for <EXPR> {}` or `for {}`)
 	for i := 0; i < numBlocks; i++ {
-		if blocks[i].Return() != nil || (len(blocks[i].Succs) == 1 && blocks[i].Succs[0].Index == blocks[i].Index) {
+		// TODO: storing `blocks[i].Succs` in a local variable should not be needed. But NilAway complaints about slicing
+		//  of the field `blocks[i].Succs` in the if condition. This should be fixed.
+		succ := blocks[i].Succs
+		if blocks[i].Return() != nil || (len(succ) == 1 && succ[0].Index == blocks[i].Index) {
 			blocks[i].Succs = append(blocks[i].Succs, blocks[numBlocks])
 		}
 	}

--- a/testdata/src/go.uber.org/loopflow/loopflow.go
+++ b/testdata/src/go.uber.org/loopflow/loopflow.go
@@ -78,6 +78,16 @@ func infiniteAssertion() {
 	for dummyBool() {
 		a = a.f //want "accessed field `f`"
 	}
+
+	var cond bool
+	for cond {
+		a = a.f //want "accessed field `f`"
+	}
+
+	// infinite while loop
+	for {
+		a = a.f //want "accessed field `f`"
+	}
 }
 
 // This is a known false negative. The analysis can be sound in this case if config.StableRoundLimit >= 9. However, that


### PR DESCRIPTION
This PR adds support for correctly analyzing `while` loops, particularly infinite loops, that were causing false negatives.