### PR TITLE
Add a helper function that wraps the `Analyzer.Run` for panics

### DIFF
--- a/annotation/analyzer.go
+++ b/annotation/analyzer.go
@@ -15,58 +15,33 @@
 package annotation
 
 import (
-	"fmt"
 	"reflect"
-	"runtime/debug"
 
 	"go.uber.org/nilaway/config"
+	"go.uber.org/nilaway/util/analysishelper"
 	"golang.org/x/tools/go/analysis"
 )
 
 const _doc = "Read the annotations for each struct, interface, and function in this package, returning" +
 	" the results so that they may be matched against assertions by an accumulator"
 
-// Result is the result struct for the Analyzer.
-type Result struct {
-	// AnnotationMap is the map generated from reading the annotations in the source code.
-	AnnotationMap *ObservedMap
-	// Errors is the slice of errors if errors happened during analysis. We put the errors here as
-	// part of the result of this sub-analyzer so that the upper-level analyzers can decide what
-	// to do with them.
-	Errors []error
-}
-
 // Analyzer here is the analyzer than reads annotations and passes them onto the accumulator to
-// be matched against assertions
+// be matched against assertions. It returns the map generated from reading the annotations in the
+// source code
 var Analyzer = &analysis.Analyzer{
 	Name:       "nilaway_annotation_analyzer",
 	Doc:        _doc,
-	Run:        run,
-	ResultType: reflect.TypeOf((*Result)(nil)).Elem(),
+	Run:        analysishelper.WrapRun(run),
+	ResultType: reflect.TypeOf((*analysishelper.Result[*ObservedMap])(nil)),
 	Requires:   []*analysis.Analyzer{config.Analyzer},
 }
 
-func run(pass *analysis.Pass) (result interface{}, _ error) {
-	// As a last resort, we recover from a panic when running the analyzer, convert the panic to
-	// an error and return.
-	defer func() {
-		if r := recover(); r != nil {
-			// Deferred functions are executed after a result is generated, so here we modify the
-			// return value `result` in-place.
-			e := fmt.Errorf("INTERNAL PANIC: %s\n%s", r, string(debug.Stack()))
-			if retResult, ok := result.(Result); ok {
-				retResult.Errors = append(retResult.Errors, e)
-			} else {
-				result = Result{Errors: []error{e}}
-			}
-		}
-	}()
-
+func run(pass *analysis.Pass) (*ObservedMap, error) {
 	conf := pass.ResultOf[config.Analyzer].(*config.Config)
 
 	if !conf.IsPkgInScope(pass.Pkg) {
-		return Result{AnnotationMap: new(ObservedMap)}, nil
+		return new(ObservedMap), nil
 	}
 
-	return Result{AnnotationMap: newObservedMap(pass, pass.Files)}, nil
+	return newObservedMap(pass, pass.Files), nil
 }

--- a/annotation/analyzer_test.go
+++ b/annotation/analyzer_test.go
@@ -1,0 +1,37 @@
+//  Copyright (c) 2024 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package annotation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+	"go.uber.org/nilaway/util/analysishelper"
+)
+
+func TestAnalyzer(t *testing.T) {
+	t.Parallel()
+
+	// Intentionally give a nil pass variable to trigger a panic, but we should recover from it
+	// and convert it to an error via the result struct.
+	r, err := Analyzer.Run(nil /* pass */)
+	require.NoError(t, err)
+	require.ErrorContains(t, r.(*analysishelper.Result[*ObservedMap]).Err, "INTERNAL PANIC")
+}
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/assertion/affiliation/analyzer.go
+++ b/assertion/affiliation/analyzer.go
@@ -15,12 +15,11 @@
 package affiliation
 
 import (
-	"fmt"
 	"reflect"
-	"runtime/debug"
 
 	"go.uber.org/nilaway/annotation"
 	"go.uber.org/nilaway/config"
+	"go.uber.org/nilaway/util/analysishelper"
 	"golang.org/x/tools/go/analysis"
 )
 
@@ -28,54 +27,26 @@ const _doc = "Track interface declarations and their implementations by identify
 	"into a concrete type (e.g., var i I = &A{}, where I is an interface and A is a struct implementing I). Generate " +
 	"potential triggers for flagging covariance and contravariance errors for return types and parameter types, respectively."
 
-// Result is the result struct for the Analyzer.
-type Result struct {
-	// FullTriggers is the slice of full triggers generated from the assertion analysis.
-	FullTriggers []annotation.FullTrigger
-	// Errors is the slice of errors if errors happened during analysis. We put the errors here as
-	// part of the result of this sub-analyzer so that the upper-level analyzers can decide what
-	// to do with them.
-	Errors []error
-}
-
 // Analyzer here is the analyzer that tracks interface implementations and analyzes for nilability
 // variance, and passes them onto the accumulator to be added to existing assertions to be matched
 // against annotations.
 var Analyzer = &analysis.Analyzer{
 	Name:       "nilaway_affiliation_analyzer",
 	Doc:        _doc,
-	Run:        run,
+	Run:        analysishelper.WrapRun(run),
 	FactTypes:  []analysis.Fact{new(AffliliationCache)},
-	ResultType: reflect.TypeOf((*Result)(nil)).Elem(),
+	ResultType: reflect.TypeOf((*analysishelper.Result[[]annotation.FullTrigger])(nil)),
 	Requires:   []*analysis.Analyzer{config.Analyzer},
 }
 
-func run(pass *analysis.Pass) (result interface{}, _ error) {
-	// As a last resort, we recover from a panic when running the analyzer, convert the panic to
-	// an error and return.
-	defer func() {
-		if r := recover(); r != nil {
-			// Deferred functions are executed after a result is generated, so here we modify the
-			// return value `result` in-place.
-			e := fmt.Errorf("INTERNAL PANIC: %s\n%s", r, string(debug.Stack()))
-			if retResult, ok := result.(Result); ok {
-				retResult.Errors = append(retResult.Errors, e)
-			} else {
-				result = Result{Errors: []error{e}}
-			}
-		}
-	}()
-
+func run(pass *analysis.Pass) ([]annotation.FullTrigger, error) {
 	conf := pass.ResultOf[config.Analyzer].(*config.Config)
 
 	if !conf.IsPkgInScope(pass.Pkg) {
-		return Result{}, nil
+		return nil, nil
 	}
 
 	a := &Affiliation{conf: conf}
-	// get all affiliations
 	a.extractAffiliations(pass)
-
-	// collect all full triggers
-	return Result{FullTriggers: a.triggers}, nil
+	return a.triggers, nil
 }

--- a/assertion/affiliation/analyzer_test.go
+++ b/assertion/affiliation/analyzer_test.go
@@ -1,0 +1,38 @@
+//  Copyright (c) 2024 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package affiliation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+	"go.uber.org/nilaway/annotation"
+	"go.uber.org/nilaway/util/analysishelper"
+)
+
+func TestAnalyzer(t *testing.T) {
+	t.Parallel()
+
+	// Intentionally give a nil pass variable to trigger a panic, but we should recover from it
+	// and convert it to an error via the result struct.
+	r, err := Analyzer.Run(nil /* pass */)
+	require.NoError(t, err)
+	require.ErrorContains(t, r.(*analysishelper.Result[[]annotation.FullTrigger]).Err, "INTERNAL PANIC")
+}
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/assertion/analyzer_test.go
+++ b/assertion/analyzer_test.go
@@ -1,0 +1,38 @@
+//  Copyright (c) 2024 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package assertion
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+	"go.uber.org/nilaway/annotation"
+	"go.uber.org/nilaway/util/analysishelper"
+)
+
+func TestAnalyzer(t *testing.T) {
+	t.Parallel()
+
+	// Intentionally give a nil pass variable to trigger a panic, but we should recover from it
+	// and convert it to an error via the result struct.
+	r, err := Analyzer.Run(nil /* pass */)
+	require.NoError(t, err)
+	require.ErrorContains(t, r.(*analysishelper.Result[[]annotation.FullTrigger]).Err, "INTERNAL PANIC")
+}
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/assertion/function/analyzer.go
+++ b/assertion/function/analyzer.go
@@ -17,6 +17,7 @@ package function
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"go/ast"
 	"go/types"
@@ -32,6 +33,7 @@ import (
 	"go.uber.org/nilaway/assertion/structfield"
 	"go.uber.org/nilaway/config"
 	"go.uber.org/nilaway/util"
+	"go.uber.org/nilaway/util/analysishelper"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/ctrlflow"
 	"golang.org/x/tools/go/cfg"
@@ -41,23 +43,13 @@ const _doc = "Build the trees of assertions for each function in this package, p
 	"entry and then matching them with possible sources of production to create a list of triggers " +
 	"that can then be matched against a set of annotations to generate nil flow errors"
 
-// Result is the result struct for the Analyzer.
-type Result struct {
-	// FullTriggers is the slice of full triggers generated from the assertion analysis.
-	FullTriggers []annotation.FullTrigger
-	// Errors is the slice of errors if errors happened during analysis. We put the errors here as
-	// part of the result of this sub-analyzer so that the upper-level analyzers can decide what
-	// to do with them.
-	Errors []error
-}
-
 // Analyzer here is the analyzer than generates assertions and passes them onto the accumulator to
 // be matched against annotations
 var Analyzer = &analysis.Analyzer{
 	Name:       "nilaway_function_analyzer",
 	Doc:        _doc,
-	Run:        run,
-	ResultType: reflect.TypeOf((*Result)(nil)).Elem(),
+	Run:        analysishelper.WrapRun(run),
+	ResultType: reflect.TypeOf((*analysishelper.Result[[]annotation.FullTrigger])(nil)),
 	Requires: []*analysis.Analyzer{
 		config.Analyzer,
 		ctrlflow.Analyzer,
@@ -90,25 +82,10 @@ type functionResult struct {
 	funcDecl *ast.FuncDecl
 }
 
-func run(pass *analysis.Pass) (result interface{}, _ error) {
-	// As a last resort, we recover from a panic when running the analyzer, convert the panic to
-	// an error and return.
-	defer func() {
-		if r := recover(); r != nil {
-			// Deferred functions are executed after a result is generated, so here we modify the
-			// return value `result` in-place.
-			e := fmt.Errorf("INTERNAL PANIC: %s\n%s", r, string(debug.Stack()))
-			if retResult, ok := result.(Result); ok {
-				retResult.Errors = append(retResult.Errors, e)
-			} else {
-				result = Result{Errors: []error{e}}
-			}
-		}
-	}()
-
+func run(pass *analysis.Pass) ([]annotation.FullTrigger, error) {
 	conf := pass.ResultOf[config.Analyzer].(*config.Config)
 	if !conf.IsPkgInScope(pass.Pkg) {
-		return Result{}, nil
+		return nil, nil
 	}
 
 	// Construct experimental features. By default, enable all features on NilAway itself.
@@ -122,8 +99,13 @@ func run(pass *analysis.Pass) (result interface{}, _ error) {
 	}
 
 	ctrlflowResult := pass.ResultOf[ctrlflow.Analyzer].(*ctrlflow.CFGs)
-	funcLitMap := pass.ResultOf[anonymousfunc.Analyzer].(anonymousfunc.Result).FuncLitMap
-	funcContracts := pass.ResultOf[functioncontracts.Analyzer].(functioncontracts.Result).FunctionContracts
+	anonymousFuncResult := pass.ResultOf[anonymousfunc.Analyzer].(*analysishelper.Result[map[*ast.FuncLit]*anonymousfunc.FuncLitInfo])
+	contractsResult := pass.ResultOf[functioncontracts.Analyzer].(*analysishelper.Result[functioncontracts.Map])
+	if err := errors.Join(anonymousFuncResult.Err, contractsResult.Err); err != nil {
+		return nil, err
+	}
+
+	funcLitMap, funcContracts := anonymousFuncResult.Res, contractsResult.Res
 
 	// Create a fake ident map for the fake func decl nodes to be shared for all function contexts.
 	pkgFakeIdentMap := make(map[*ast.Ident]types.Object)
@@ -219,13 +201,13 @@ func run(pass *analysis.Pass) (result interface{}, _ error) {
 	// as if the analyses were done serially). So we first store the result triggers in order,
 	// then flatten the slice.
 	// TODO: remove this extra logic once  is done.
-	var errs []error
+	var err error
 	funcTriggers := make([][]annotation.FullTrigger, funcIndex)
 	triggerCount := 0
 	funcResults := map[*types.Func]*functionResult{}
 	for r := range funcChan {
 		if r.err != nil {
-			errs = append(errs, r.err)
+			err = errors.Join(err, r.err)
 		} else {
 			funcTriggers[r.index] = r.triggers
 			triggerCount += len(r.triggers)
@@ -251,7 +233,7 @@ func run(pass *analysis.Pass) (result interface{}, _ error) {
 		triggers = append(triggers, s...)
 	}
 
-	return Result{FullTriggers: triggers, Errors: errs}, nil
+	return triggers, err
 }
 
 // duplicateFullTriggersFromContractedFunctionsToCallers duplicates all the full triggers that have

--- a/assertion/function/analyzer_test.go
+++ b/assertion/function/analyzer_test.go
@@ -23,16 +23,28 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
+	"go.uber.org/nilaway/annotation"
 	"go.uber.org/nilaway/assertion/anonymousfunc"
 	"go.uber.org/nilaway/assertion/function/assertiontree"
 	"go.uber.org/nilaway/assertion/function/functioncontracts"
+	"go.uber.org/nilaway/util/analysishelper"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/analysistest"
 	"golang.org/x/tools/go/analysis/passes/ctrlflow"
 	"golang.org/x/tools/go/cfg"
 )
 
-func TestTimeout(t *testing.T) {
+func TestAnalyzer(t *testing.T) {
+	t.Parallel()
+
+	// Intentionally give a nil pass variable to trigger a panic, but we should recover from it
+	// and convert it to an error via the result struct.
+	r, err := Analyzer.Run(nil /* pass */)
+	require.NoError(t, err)
+	require.ErrorContains(t, r.(*analysishelper.Result[[]annotation.FullTrigger]).Err, "INTERNAL PANIC")
+}
+
+func TestCancelledContext(t *testing.T) {
 	t.Parallel()
 
 	testdata := analysistest.TestData()

--- a/assertion/function/functioncontracts/analyzer.go
+++ b/assertion/function/functioncontracts/analyzer.go
@@ -17,58 +17,31 @@
 package functioncontracts
 
 import (
-	"fmt"
 	"reflect"
-	"runtime/debug"
 
 	"go.uber.org/nilaway/config"
+	"go.uber.org/nilaway/util/analysishelper"
 	"golang.org/x/tools/go/analysis"
 )
 
 const _doc = "Read the contracts of each function in this package, returning the results."
 
-// Result is the result struct for the Analyzer.
-type Result struct {
-	// FunctionContractsMap is the map generated from reading the function contracts in the source
-	// code.
-	FunctionContracts Map
-	// Errors is the slice of errors if errors happened during analysis. We put the errors here as
-	// part of the result of this sub-analyzer so that the upper-level analyzers can decide what
-	// to do with them.
-	Errors []error
-}
-
-// Analyzer here is the analyzer than reads function contracts
+// Analyzer here is the analyzer than reads function contracts. It returns the map generated from
+// reading the function contracts in the source code.
 var Analyzer = &analysis.Analyzer{
 	Name:       "nilaway_function_contracts_analyzer",
 	Doc:        _doc,
-	Run:        run,
-	ResultType: reflect.TypeOf((*Result)(nil)).Elem(),
+	Run:        analysishelper.WrapRun(run),
+	ResultType: reflect.TypeOf((*analysishelper.Result[Map])(nil)),
 	Requires:   []*analysis.Analyzer{config.Analyzer},
 }
 
-func run(pass *analysis.Pass) (result interface{}, _ error) {
-	// As a last resort, we recover from a panic when running the analyzer, convert the panic to
-	// an error and return.
-	defer func() {
-		if r := recover(); r != nil {
-			// Deferred functions are executed after a result is generated, so here we modify the
-			// return value `result` in-place.
-			e := fmt.Errorf("INTERNAL PANIC: %s\n%s", r, string(debug.Stack()))
-			if retResult, ok := result.(Result); ok {
-				retResult.FunctionContracts = Map{}
-				retResult.Errors = append(retResult.Errors, e)
-			} else {
-				result = Result{FunctionContracts: Map{}, Errors: []error{e}}
-			}
-		}
-	}()
-
+func run(pass *analysis.Pass) (Map, error) {
 	conf := pass.ResultOf[config.Analyzer].(*config.Config)
 
 	if !conf.IsPkgInScope(pass.Pkg) {
-		return Result{FunctionContracts: Map{}}, nil
+		return Map{}, nil
 	}
 
-	return Result{FunctionContracts: collectFunctionContracts(pass)}, nil
+	return collectFunctionContracts(pass), nil
 }

--- a/assertion/function/functioncontracts/analyzer_test.go
+++ b/assertion/function/functioncontracts/analyzer_test.go
@@ -22,10 +22,21 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
+	"go.uber.org/nilaway/util/analysishelper"
 	"golang.org/x/tools/go/analysis/analysistest"
 )
 
 func TestAnalyzer(t *testing.T) {
+	t.Parallel()
+
+	// Intentionally give a nil pass variable to trigger a panic, but we should recover from it
+	// and convert it to an error via the result struct.
+	r, err := Analyzer.Run(nil /* pass */)
+	require.NoError(t, err)
+	require.ErrorContains(t, r.(*analysishelper.Result[Map]).Err, "INTERNAL PANIC")
+}
+
+func TestContractCollection(t *testing.T) {
 	t.Parallel()
 
 	testdata := analysistest.TestData()
@@ -35,8 +46,9 @@ func TestAnalyzer(t *testing.T) {
 	require.NotNil(t, r[0])
 
 	pass, result := r[0].Pass, r[0].Result
-	require.IsType(t, Result{}, result)
-	funcContractsMap := result.(Result).FunctionContracts
+	require.IsType(t, &analysishelper.Result[Map]{}, result)
+	funcContractsMap := result.(*analysishelper.Result[Map]).Res
+	require.NoError(t, result.(*analysishelper.Result[Map]).Err)
 
 	require.NotNil(t, funcContractsMap)
 

--- a/assertion/global/analyzer_test.go
+++ b/assertion/global/analyzer_test.go
@@ -1,0 +1,38 @@
+//  Copyright (c) 2024 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package global
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+	"go.uber.org/nilaway/annotation"
+	"go.uber.org/nilaway/util/analysishelper"
+)
+
+func TestAnalyzer(t *testing.T) {
+	t.Parallel()
+
+	// Intentionally give a nil pass variable to trigger a panic, but we should recover from it
+	// and convert it to an error via the result struct.
+	r, err := Analyzer.Run(nil /* pass */)
+	require.NoError(t, err)
+	require.ErrorContains(t, r.(*analysishelper.Result[[]annotation.FullTrigger]).Err, "INTERNAL PANIC")
+}
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/assertion/structfield/analyzer_test.go
+++ b/assertion/structfield/analyzer_test.go
@@ -1,0 +1,37 @@
+//  Copyright (c) 2024 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package structfield
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+	"go.uber.org/nilaway/util/analysishelper"
+)
+
+func TestAnalyzer(t *testing.T) {
+	t.Parallel()
+
+	// Intentionally give a nil pass variable to trigger a panic, but we should recover from it
+	// and convert it to an error via the result struct.
+	r, err := Analyzer.Run(nil /* pass */)
+	require.NoError(t, err)
+	require.ErrorContains(t, r.(*analysishelper.Result[*FieldContext]).Err, "INTERNAL PANIC")
+}
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/util/analysishelper/analyzer.go
+++ b/util/analysishelper/analyzer.go
@@ -1,0 +1,66 @@
+//  Copyright (c) 2024 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package analysishelper provides helper functions for the `go/analysis` package.
+package analysishelper
+
+import (
+	"fmt"
+	"runtime/debug"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+// Result is the result struct for the sub-analyzers where the actual result is accompanied by
+// an optional error.
+type Result[T any] struct {
+	// Res is the actual result from the sub-analyzer.
+	Res T
+	// Err is the optional error from the sub-analyzer.
+	Err error
+}
+
+// WrapRun wraps the run function of an analyzer to:
+// (1) convert the return type to Result[T] and put the error in the Result[T].Err field in order
+// to _not_ stop the analysis and let upper-level analyzer to decide what to do.
+// (2) recover from a panic and convert it to an error with stack traces for easier debugging.
+// This is to ensure that NilAway _never_ panics during the analysis.
+// Moreover, it also wraps the error from the sub-analyzer with the name of the analyzer to make
+// it easier to identify the source of the error.
+func WrapRun[T any](f func(*analysis.Pass) (T, error)) func(*analysis.Pass) (any, error) {
+	wrapped := func(pass *analysis.Pass) (result any, _ error) {
+		result = &Result[T]{}
+		analyzerName := ""
+		if pass != nil && pass.Analyzer != nil {
+			analyzerName = pass.Analyzer.Name
+		}
+		defer func() {
+			if r := recover(); r != nil {
+				result.(*Result[T]).Err = fmt.Errorf("INTERNAL PANIC from %q: %s\n%s", analyzerName, r, string(debug.Stack()))
+			}
+		}()
+
+		r, err := f(pass)
+		if err != nil {
+			// Prefix the error with the name of the analyzer to make it easier to identify the source
+			// of the error.
+			err = fmt.Errorf("%s: %w", analyzerName, err)
+		}
+		result.(*Result[T]).Res = r
+		result.(*Result[T]).Err = err
+		return result, nil
+	}
+
+	return wrapped
+}

--- a/util/analysishelper/analyzer_test.go
+++ b/util/analysishelper/analyzer_test.go
@@ -1,0 +1,69 @@
+//  Copyright (c) 2024 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analysishelper
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/analysis"
+)
+
+func TestWrapPanic_Panic(t *testing.T) {
+	t.Parallel()
+
+	// Test that WrapRun recovers from a panic and returns the panic as an error.
+	panickingFunc := func(*analysis.Pass) (int, error) { panic("panic") }
+	wrapped := WrapRun(panickingFunc)
+	r, err := wrapped(nil /* pass */)
+	// No error should be returned, since the converted error (from the recovered panic) is
+	// returned via the result struct.
+	require.NoError(t, err)
+
+	require.IsType(t, &Result[int]{}, r)
+	require.Empty(t, r.(*Result[int]).Res)
+	require.ErrorContains(t, r.(*Result[int]).Err, "INTERNAL PANIC")
+}
+
+func TestWrapPanic_Error(t *testing.T) {
+	t.Parallel()
+
+	// Test that WrapRun does not recover from a panic and returns the panic as an error.
+	errFunc := func(*analysis.Pass) (int, error) { return 0, errors.New("my error") }
+	wrapped := WrapRun(errFunc)
+	r, err := wrapped(nil /* pass */)
+	require.NoError(t, err)
+
+	require.IsType(t, &Result[int]{}, r)
+	require.Empty(t, r.(*Result[int]).Res)
+	require.ErrorContains(t, r.(*Result[int]).Err, "my error")
+}
+
+func TestWrapPanic_NoPanic(t *testing.T) {
+	t.Parallel()
+
+	// Test that WrapRun does not recover from a panic and returns the panic as an error.
+	nonPanickingFunc := func(*analysis.Pass) (int, error) { return 42, nil }
+	wrapped := WrapRun(nonPanickingFunc)
+	r, err := wrapped(nil)
+	// No error should be returned, since the converted error (from the recovered panic) is
+	// returned via the result struct.
+	require.NoError(t, err)
+
+	require.IsType(t, &Result[int]{}, r)
+	require.NoError(t, r.(*Result[int]).Err)
+	require.Equal(t, 42, r.(*Result[int]).Res)
+}

--- a/util/asthelper/asthelper_test.go
+++ b/util/asthelper/asthelper_test.go
@@ -1,3 +1,17 @@
+//  Copyright (c) 2024 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package asthelper
 
 import (

--- a/util/orderedmap/orderedmap_test.go
+++ b/util/orderedmap/orderedmap_test.go
@@ -1,3 +1,17 @@
+//  Copyright (c) 2024 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package orderedmap_test
 
 import (


### PR DESCRIPTION
We strive to _never_ panic in NilAway: we have deferred function calls that recover from any panics and converts it to an error, which eventually gets converted to a diagnostic with "INTERNAL PANIC" prefix for users to be aware (but not to stop the build/linting process etc.).

However, we were adding the same deferred function block for _every_ sub-analyzer we have, which introduces maintainability burden.

This PR simplifies such handling by introducing a helper function that wraps around the `Analyzer.Run` function, which:

* handles panics;
* puts the error in a field in `Result` struct to be sent via the return value, such that any error won't stop the analysis process. The upper-level analyzer will decide what to do with the error (for future graceful recovery). For now, the upper-level analyzers simply early return if there is an error, and the accumulation analyzer will convert the errors to be diagnostics.

Tests that intentionally cause a panic inside the analyzers are also added for each sub-analyzer to ensure that it won't crash the program (i.e., it is properly recovered and converted to errors).

We also take this opportunity to add a few missing license headers to some files.