### PR TITLE
Upgrade codecov action to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,9 @@ jobs:
         run: make cover
 
       - name: Upload coverage to codecov.io
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   integration-test:
     name: Integration Test


### PR DESCRIPTION
This PR upgrades our codecov action to v4. A side effect of the upgrade is that tokenless uploads are no longer supported by the action. Therefore, we also fixes the config and give it a token stored in repository secrets.