### PR TITLE
Fix panics from contract analyzer

### DIFF
--- a/assertion/function/functioncontracts/analyzer.go
+++ b/assertion/function/functioncontracts/analyzer.go
@@ -138,6 +138,9 @@ func collectFunctionContracts(pass *analysis.Pass) (Map, error) {
 				// function.
 				continue
 			}
+			if fnssa.Blocks == nil {
+
+			}
 
 			// Infer contracts for a function that does not have any contracts specified.
 			wg.Add(1)

--- a/assertion/function/functioncontracts/analyzer.go
+++ b/assertion/function/functioncontracts/analyzer.go
@@ -139,9 +139,9 @@ func collectFunctionContracts(pass *analysis.Pass) (Map, error) {
 				continue
 			}
 			if len(fnssa.Blocks) == 0 {
-				// For external functions (e.g., C functions or functions from runtime), we do not
-				// actually have Go source code for them, and there will be no blocks (see the
-				// documentation of the ssa package). Therefore, we ignore such functions.
+				// For external functions whose function bodies are defined outside Go (e.g.,
+				// assembly), we do not actually have Go source code for them, and there will be no
+				// blocks (see the documentation of the ssa package). Therefore, we ignore such functions.
 				continue
 			}
 

--- a/assertion/function/functioncontracts/analyzer.go
+++ b/assertion/function/functioncontracts/analyzer.go
@@ -138,6 +138,12 @@ func collectFunctionContracts(pass *analysis.Pass) (Map, error) {
 				// function.
 				continue
 			}
+			if len(fnssa.Blocks) == 0 {
+				// For external functions (e.g., C functions or functions from runtime), we do not
+				// actually have Go source code for them, and there will be no blocks (see the
+				// documentation of the ssa package). Therefore, we ignore such functions.
+				continue
+			}
 
 			// Infer contracts for a function that does not have any contracts specified.
 			wg.Add(1)

--- a/assertion/function/functioncontracts/analyzer.go
+++ b/assertion/function/functioncontracts/analyzer.go
@@ -138,9 +138,6 @@ func collectFunctionContracts(pass *analysis.Pass) (Map, error) {
 				// function.
 				continue
 			}
-			if fnssa.Blocks == nil {
-
-			}
 
 			// Infer contracts for a function that does not have any contracts specified.
 			wg.Add(1)

--- a/assertion/function/functioncontracts/analyzer_test.go
+++ b/assertion/function/functioncontracts/analyzer_test.go
@@ -93,6 +93,7 @@ func TestInfer(t *testing.T) {
 	pass, result := r[0].Pass, r[0].Result
 	require.IsType(t, &analysishelper.Result[Map]{}, result)
 	funcContractsMap := result.(*analysishelper.Result[Map]).Res
+	require.NoError(t, result.(*analysishelper.Result[Map]).Err)
 
 	require.NotNil(t, funcContractsMap)
 

--- a/assertion/function/functioncontracts/infer.go
+++ b/assertion/function/functioncontracts/infer.go
@@ -15,7 +15,6 @@
 package functioncontracts
 
 import (
-	"fmt"
 	"go/token"
 	"go/types"
 
@@ -32,12 +31,6 @@ const _maxNumTablesPerBlock = 1024
 // returns a list of inferred contracts, which may be empty if no contract is inferred but is never
 // nil.
 func inferContracts(fn *ssa.Function) []*FunctionContract {
-	if len(fn.Blocks) == 0 {
-		panic(
-			fmt.Sprintf("The function %s (%s) has no blocks even though it declared return values",
-				fn.Name(), fn.Signature.String()))
-	}
-
 	nilnessTableSetByBB := make(map[*ssa.BasicBlock]nilnessTableSet)
 	retInstrs := getReturnInstrs(fn) // TODO: Consider *ssa.Panic
 	// No need of an expensive dataflow analysis if we can derive contracts from the return

--- a/assertion/function/functioncontracts/infer.go
+++ b/assertion/function/functioncontracts/infer.go
@@ -34,8 +34,8 @@ const _maxNumTablesPerBlock = 1024
 func inferContracts(fn *ssa.Function) []*FunctionContract {
 	if len(fn.Blocks) == 0 {
 		panic(
-			fmt.Sprintf("The function %s has no blocks even though it declared return values",
-				fn.Signature.String()))
+			fmt.Sprintf("The function %s (%s) has no blocks even though it declared return values",
+				fn.Name(), fn.Signature.String()))
 	}
 
 	nilnessTableSetByBB := make(map[*ssa.BasicBlock]nilnessTableSet)

--- a/assertion/function/functioncontracts/testdata/src/go.uber.org/functioncontracts/infer/external.go
+++ b/assertion/function/functioncontracts/testdata/src/go.uber.org/functioncontracts/infer/external.go
@@ -1,0 +1,15 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package infer

--- a/assertion/function/functioncontracts/testdata/src/go.uber.org/functioncontracts/infer/external.go
+++ b/assertion/function/functioncontracts/testdata/src/go.uber.org/functioncontracts/infer/external.go
@@ -13,3 +13,7 @@
 // limitations under the License.
 
 package infer
+
+// external is a function declaration whose body is defined outside of Go (e.g., assembly). The
+// SSA builder will not generate any blocks for this function, and we should handle this gracefully.
+func external(v *int) *int

--- a/testdata/src/go.uber.org/goquirks/goquirks.go
+++ b/testdata/src/go.uber.org/goquirks/goquirks.go
@@ -71,3 +71,6 @@ func fooThatConsumesErrs() interface{} {
 		return d
 	}
 }
+
+// external is only a function declaration whose body is defined outside Go (e.g., assembly).
+func external(v *int) *int


### PR DESCRIPTION
This PR fixes a panic from the contract analyzer where it is erroneously panicking if there are no blocks in the `*ssa.Function`. For external functions like builtin function or other C functions implemented outside Go, since we do not actually have Go sources for them, their SSA form will not have any blocks. 

This PR removes the panic and simply ignore those functions, and test cases for such functions (where functions are declared without bodies) are added to prevent future regressions. 