### PR TITLE
Add linting for copyright headers

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -24,8 +24,8 @@ linters-settings:
     values:
       regexp:
         any-year: \d{4}
-    template: |
-      Copyright (c) {{ any-year }} Uber Technologies, Inc.
+    template: |-
+      Copyright (c) {{ ANY-YEAR }} Uber Technologies, Inc.
     
       Licensed under the Apache License, Version 2.0 (the "License");
       you may not use this file except in compliance with the License.

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -17,3 +17,24 @@ linters:
     - paralleltest
     - revive
     - staticcheck
+    - goheader
+
+linters-settings:
+  goheader:
+    values:
+      regexp:
+        any-year: \d{4}
+    template: |
+      Copyright (c) {{ any-year }} Uber Technologies, Inc.
+    
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+    
+          http://www.apache.org/licenses/LICENSE-2.0
+    
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.

--- a/annotation/consume_trigger.go
+++ b/annotation/consume_trigger.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/annotation/copy_test.go
+++ b/annotation/copy_test.go
@@ -1,4 +1,4 @@
-//	Copyright (c) 2023 Uber Technologies, Inc.
+//  Copyright (c) 2023 Uber Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/annotation/copy_test.go
+++ b/annotation/copy_test.go
@@ -1,3 +1,4 @@
+//	Copyright (c) 2023 Uber Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/assertion/function/functioncontracts/analyzer.go
+++ b/assertion/function/functioncontracts/analyzer.go
@@ -1,4 +1,4 @@
-//	Copyright (c) 2023 Uber Technologies, Inc.
+//  Copyright (c) 2023 Uber Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/assertion/function/functioncontracts/analyzer.go
+++ b/assertion/function/functioncontracts/analyzer.go
@@ -1,4 +1,4 @@
-//  Copyright (c) 2023 Uber Technologies, Inc.
+//	Copyright (c) 2023 Uber Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -6,9 +6,10 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software distributed under the
-// License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-// express or implied. See the License for the specific language governing permissions and
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
 // limitations under the License.
 
 // Package functioncontracts implements a sub-analyzer to analyze function contracts in a package,

--- a/config/const.go
+++ b/config/const.go
@@ -1,3 +1,17 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package config
 
 // This file hosts non-user-configurable parameters --- these are for development and testing purposes only.

--- a/diagnostic/conflict.go
+++ b/diagnostic/conflict.go
@@ -1,3 +1,17 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package diagnostic
 
 import (

--- a/diagnostic/nilflow.go
+++ b/diagnostic/nilflow.go
@@ -1,3 +1,17 @@
+//	Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package diagnostic
 
 import (

--- a/inference/inferred_map_test.go
+++ b/inference/inferred_map_test.go
@@ -1,3 +1,17 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package inference
 
 import (

--- a/tools/cmd/golden-test/main.go
+++ b/tools/cmd/golden-test/main.go
@@ -1,4 +1,4 @@
-//	Copyright (c) 2023 Uber Technologies, Inc.
+//  Copyright (c) 2023 Uber Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tools/cmd/golden-test/main.go
+++ b/tools/cmd/golden-test/main.go
@@ -1,3 +1,17 @@
+//	Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package main implements the golden tests for NilAway to ensure that the errors reported on the
 // stdlib are equal between the base branch and the test branch for preventing functionality
 // regressions during development.

--- a/tools/cmd/golden-test/main_test.go
+++ b/tools/cmd/golden-test/main_test.go
@@ -1,4 +1,4 @@
-//	Copyright (c) 2023 Uber Technologies, Inc.
+//  Copyright (c) 2023 Uber Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tools/cmd/golden-test/main_test.go
+++ b/tools/cmd/golden-test/main_test.go
@@ -1,3 +1,17 @@
+//	Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/tools/cmd/integration-test/main.go
+++ b/tools/cmd/integration-test/main.go
@@ -1,3 +1,17 @@
+//	Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package main implements the integration test framework for checking cross-package inference with
 // different analyzer drivers. It compares the diagnostics reported by running NilAway separately
 // and the diagnostics specified in the comments of the `testdata/integration` project.

--- a/tools/cmd/integration-test/main.go
+++ b/tools/cmd/integration-test/main.go
@@ -1,4 +1,4 @@
-//	Copyright (c) 2023 Uber Technologies, Inc.
+//  Copyright (c) 2023 Uber Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tools/cmd/integration-test/main_test.go
+++ b/tools/cmd/integration-test/main_test.go
@@ -1,4 +1,4 @@
-//	Copyright (c) 2023 Uber Technologies, Inc.
+//  Copyright (c) 2023 Uber Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tools/cmd/integration-test/main_test.go
+++ b/tools/cmd/integration-test/main_test.go
@@ -1,3 +1,17 @@
+//	Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/tools/cmd/integration-test/standalone.go
+++ b/tools/cmd/integration-test/standalone.go
@@ -1,4 +1,4 @@
-//	Copyright (c) 2023 Uber Technologies, Inc.
+//  Copyright (c) 2023 Uber Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tools/cmd/integration-test/standalone.go
+++ b/tools/cmd/integration-test/standalone.go
@@ -1,3 +1,17 @@
+//	Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (


### PR DESCRIPTION
This PR adds `go-header` linter to check if copyright headers are properly added to the Go source files.

Due to the introduction of this linter, we have found several inconsistent and missing copyright headers in our repository and this PR fixes them all to pass the linter.