### PR TITLE
Fix for chained field accesses with negative nil checks in non-conditional flows

### DIFF
--- a/testdata/src/go.uber.org/inference/inference.go
+++ b/testdata/src/go.uber.org/inference/inference.go
@@ -105,12 +105,12 @@ func retsAndTakes() {
 
 // Below test checks the working of inference in the presence of annotations
 // nonnil(x) nilable(result 0)
-func foo(x *int) *int { // want "NONNIL because it is annotated as so"
+func foo(x *int) *int { //want "NONNIL because it is annotated as so"
 	print(*x)
 	return nil
 }
 
 func callFoo() {
 	ptr := foo(nil)
-	print(*ptr) // want "NILABLE because it is annotated as so"
+	print(*ptr) //want "NILABLE because it is annotated as so"
 }

--- a/testdata/src/go.uber.org/nilcheck/nonconditionalflow.go
+++ b/testdata/src/go.uber.org/nilcheck/nonconditionalflow.go
@@ -186,7 +186,19 @@ type H struct {
 }
 
 // nilable(x)
-func testChainedAccesses(x *X) bool {
-	// Below gives False Positives for the field accesses of `f` and `g`. Fix this in a follow-up diff. Issue tracked in
-	return x != nil && x.f != nil && x.f.g != nil && x.f.g.h == 4 //want "field .* accessed" "field .* accessed" "field .* accessed"
+func testChainedAccesses(x *X, i int) bool {
+	switch i {
+	case 0:
+		return x != nil && x.f != nil && x.f.g != nil
+	case 1:
+		return x != nil && x.f != nil && x.f.g != nil && x.f.g.h == 4
+	case 2:
+		return x != nil && x.f != nil && x.f.g.h == 4 //want "field `g` accessed field `h`"
+	case 3:
+		// safe, but condition interspersed with different irrelevant checks
+		return x != nil && retNil() == nil && x.f != nil && *x.f == G{} && x.f.g != nil && dummy && x.f.g.h == 4
+	case 4:
+		return x != nil && x.f != nil && x.f.g.h == 4 && x.f.g != nil //want "field `g` accessed field `h`"
+	}
+	return false
 }


### PR DESCRIPTION
This PR enhances the support for tracking negative nil checks in non-conditional flows, particularly in the case of chained field accesses. E.g., `return x != nil && x.f != nil && x.f.g != nil && x.f.g.h == 4` reported false positives for the field accesses `x.f.g` and `x.f.g.h`. This PR fixes that problem, thereby reducing false positives.

[closes #217 ]