### PR TITLE
Truncate output of golden test output due to GH limit

### DIFF
--- a/.github/workflows/golden-test.yml
+++ b/.github/workflows/golden-test.yml
@@ -47,7 +47,7 @@ jobs:
             // is too long.
             const pattern = /(<details>)([\s\S]*?)(<\/details>)/;
             
-            const body = rawData.replace(rawData, function(match, p1, p2, p3) {
+            const body = rawData.replace(pattern, function(match, p1, p2, p3) {
               if (p2.length > 10000) {
                 return p1 + p2.substring(0, 5000) + '\n\n ...(truncated)...\n\n' + p2.substring(p2.length - 5000) + p3;
               }

--- a/.github/workflows/golden-test.yml
+++ b/.github/workflows/golden-test.yml
@@ -45,7 +45,7 @@ jobs:
             // GitHub API has a limit of 65536 bytes for a comment body, so here we shrink the 
             // diff part (anything between <details> and </details>) to 10,000 characters if it
             // is too long.
-            const pattern = /(<details>)([\s\S]*?)(<\/details>)/g;
+            const pattern = /(<details>)([\s\S]*?)(<\/details>)/;
             
             const body = rawData.replace(rawData, function(match, p1, p2, p3) {
               if (p2.length > 10000) {

--- a/.github/workflows/golden-test.yml
+++ b/.github/workflows/golden-test.yml
@@ -47,7 +47,7 @@ jobs:
             // is too long.
             const pattern = /(<details>)([\s\S]*?)(<\/details>)/g;
             
-            const body = body.replace(rawData, function(match, p1, p2, p3) {
+            const body = rawData.replace(rawData, function(match, p1, p2, p3) {
               if (p2.length > 10000) {
                 return p1 + p2.substring(0, 5000) + '\n\n ...(truncated)...\n\n' + p2.substring(p2.length - 5000) + p3;
               }

--- a/.github/workflows/golden-test.yml
+++ b/.github/workflows/golden-test.yml
@@ -42,6 +42,19 @@ jobs:
             const repo = context.repo.repo;
             const body = await fsp.readFile(`${{ runner.temp }}/golden-test-result.md`, 'utf8');
             
+            // GitHub API has a limit of 65536 bytes for a comment body, so here we shrink the 
+            // diff part (anything between <details> and </details>) to 10,000 characters if it
+            // is too long.
+            const pattern = /(<details>)([\s\S]*?)(<\/details>)/g;
+            
+            const body = body.replace(pattern, function(match, p1, p2, p3) {
+              if (p2.length > 10000) {
+                return p1 + p2.substring(0, 5000) + '\n\n ...(truncated)...\n\n' + p2.substring(p2.length - 5000) + p3;
+              }
+              // No need to change anything if it is not too long.
+              return match;
+            });        
+
             // First find the comments made by the bot.
             const comments = await github.rest.issues.listComments({
               owner: owner,

--- a/.github/workflows/golden-test.yml
+++ b/.github/workflows/golden-test.yml
@@ -37,17 +37,17 @@ jobs:
           script: |
             const fsp = require('fs').promises;
             
-            const issue_number = context.issue.number;
+            const issueNumber = context.issue.number;
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const body = await fsp.readFile(`${{ runner.temp }}/golden-test-result.md`, 'utf8');
+            const rawData = await fsp.readFile(`${{ runner.temp }}/golden-test-result.md`, 'utf8');
             
             // GitHub API has a limit of 65536 bytes for a comment body, so here we shrink the 
             // diff part (anything between <details> and </details>) to 10,000 characters if it
             // is too long.
             const pattern = /(<details>)([\s\S]*?)(<\/details>)/g;
             
-            const body = body.replace(pattern, function(match, p1, p2, p3) {
+            const body = body.replace(rawData, function(match, p1, p2, p3) {
               if (p2.length > 10000) {
                 return p1 + p2.substring(0, 5000) + '\n\n ...(truncated)...\n\n' + p2.substring(p2.length - 5000) + p3;
               }
@@ -59,7 +59,7 @@ jobs:
             const comments = await github.rest.issues.listComments({
               owner: owner,
               repo: repo,
-              issue_number: issue_number
+              issue_number: issueNumber
             });
             const botComment = comments.data.find(comment => comment.user.login === 'github-actions[bot]' && comment.body.startsWith('## Golden Test'));
             
@@ -75,7 +75,7 @@ jobs:
               await github.rest.issues.createComment({
                 owner: owner,
                 repo: repo,
-                issue_number: issue_number,
+                issue_number: issueNumber,
                 body: body
               });
             }


### PR DESCRIPTION
GitHub has a hard limit on the length of the comment to be 65535. Since our golden test results are posted as a GH comment in each PR, sometimes if the change is too large we hit such limit.

This PR replaces the middle part of the diff with `... (truncated) ...` in the comment if it gets too large.