### PR TITLE
Sort conflicts such that diagnostics are always grouped under the first diagnostic

### DIFF
--- a/.github/workflows/golden-test.yml
+++ b/.github/workflows/golden-test.yml
@@ -47,7 +47,7 @@ jobs:
             // is too long.
             const pattern = /(<details>)([\s\S]*?)(<\/details>)/;
             
-            const body = rawData.replace(rawData, function(match, p1, p2, p3) {
+            const body = rawData.replace(pattern, function(match, p1, p2, p3) {
               if (p2.length > 10000) {
                 return p1 + p2.substring(0, 5000) + '\n\n ...(truncated)...\n\n' + p2.substring(p2.length - 5000) + p3;
               }

--- a/.github/workflows/golden-test.yml
+++ b/.github/workflows/golden-test.yml
@@ -45,7 +45,7 @@ jobs:
             // GitHub API has a limit of 65536 bytes for a comment body, so here we shrink the 
             // diff part (anything between <details> and </details>) to 10,000 characters if it
             // is too long.
-            const pattern = /(<details>)([\s\S]*?)(<\/details>)/g;
+            const pattern = /(<details>)([\s\S]*?)(<\/details>)/;
             
             const body = rawData.replace(rawData, function(match, p1, p2, p3) {
               if (p2.length > 10000) {

--- a/.github/workflows/golden-test.yml
+++ b/.github/workflows/golden-test.yml
@@ -47,7 +47,7 @@ jobs:
             // is too long.
             const pattern = /(<details>)([\s\S]*?)(<\/details>)/g;
             
-            const body = body.replace(rawData, function(match, p1, p2, p3) {
+            const body = rawData.replace(rawData, function(match, p1, p2, p3) {
               if (p2.length > 10000) {
                 return p1 + p2.substring(0, 5000) + '\n\n ...(truncated)...\n\n' + p2.substring(p2.length - 5000) + p3;
               }

--- a/.github/workflows/golden-test.yml
+++ b/.github/workflows/golden-test.yml
@@ -42,6 +42,19 @@ jobs:
             const repo = context.repo.repo;
             const body = await fsp.readFile(`${{ runner.temp }}/golden-test-result.md`, 'utf8');
             
+            // GitHub API has a limit of 65536 bytes for a comment body, so here we shrink the 
+            // diff part (anything between <details> and </details>) to 10,000 characters if it
+            // is too long.
+            const pattern = /(<details>)([\s\S]*?)(<\/details>)/g;
+            
+            const body = body.replace(pattern, function(match, p1, p2, p3) {
+              if (p2.length > 10000) {
+                return p1 + p2.substring(0, 5000) + '\n\n ...(truncated)...\n\n' + p2.substring(p2.length - 5000) + p3;
+              }
+              // No need to change anything if it is not too long.
+              return match;
+            });        
+
             // First find the comments made by the bot.
             const comments = await github.rest.issues.listComments({
               owner: owner,

--- a/.github/workflows/golden-test.yml
+++ b/.github/workflows/golden-test.yml
@@ -37,17 +37,17 @@ jobs:
           script: |
             const fsp = require('fs').promises;
             
-            const issue_number = context.issue.number;
+            const issueNumber = context.issue.number;
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const body = await fsp.readFile(`${{ runner.temp }}/golden-test-result.md`, 'utf8');
+            const rawData = await fsp.readFile(`${{ runner.temp }}/golden-test-result.md`, 'utf8');
             
             // GitHub API has a limit of 65536 bytes for a comment body, so here we shrink the 
             // diff part (anything between <details> and </details>) to 10,000 characters if it
             // is too long.
             const pattern = /(<details>)([\s\S]*?)(<\/details>)/g;
             
-            const body = body.replace(pattern, function(match, p1, p2, p3) {
+            const body = body.replace(rawData, function(match, p1, p2, p3) {
               if (p2.length > 10000) {
                 return p1 + p2.substring(0, 5000) + '\n\n ...(truncated)...\n\n' + p2.substring(p2.length - 5000) + p3;
               }
@@ -59,7 +59,7 @@ jobs:
             const comments = await github.rest.issues.listComments({
               owner: owner,
               repo: repo,
-              issue_number: issue_number
+              issue_number: issueNumber
             });
             const botComment = comments.data.find(comment => comment.user.login === 'github-actions[bot]' && comment.body.startsWith('## Golden Test'));
             
@@ -75,7 +75,7 @@ jobs:
               await github.rest.issues.createComment({
                 owner: owner,
                 repo: repo,
-                issue_number: issue_number,
+                issue_number: issueNumber,
                 body: body
               });
             }

--- a/diagnostic/conflict.go
+++ b/diagnostic/conflict.go
@@ -21,9 +21,12 @@ import (
 )
 
 type conflict struct {
-	pos              token.Pos   // stores position where the error should be reported (note that this field is used only within the current, and should NOT be exported)
-	flow             nilFlow     // stores nil flow from source to dereference point
-	similarConflicts []*conflict // stores other conflicts that are similar to this one
+	// position is the package-independent position where the conflict should be reported.
+	position token.Position
+	// flow stores nil flow from source to dereference point
+	flow nilFlow
+	// similarConflicts stores other conflicts that are similar to this one.
+	similarConflicts []*conflict
 }
 
 func (c *conflict) String() string {

--- a/nilaway.go
+++ b/nilaway.go
@@ -36,7 +36,6 @@ var Analyzer = &analysis.Analyzer{
 	Requires:  []*analysis.Analyzer{config.Analyzer, accumulation.Analyzer},
 }
 
-// nilable(result 0)
 func run(pass *analysis.Pass) (interface{}, error) {
 	conf := pass.ResultOf[config.Analyzer].(*config.Config)
 	deferredErrors := pass.ResultOf[accumulation.Analyzer].([]analysis.Diagnostic)

--- a/testdata/src/go.uber.org/anonymousfunction/argument_passing_implicitly.go
+++ b/testdata/src/go.uber.org/anonymousfunction/argument_passing_implicitly.go
@@ -36,8 +36,8 @@ func testNilFlowFromClosure() {
 	t = nil
 
 	func() {
-		print(*t) // (error here grouped with the error on the next line)
 		print(*t) //want "literal `nil`"
+		print(*t) // (error here grouped with the error on the above line)
 	}()
 
 	t = &i


### PR DESCRIPTION
We had user reports internally that the diagnostics are not always grouped under the first diagnostic, making it a little bit annoying to see a diagnostic at L35 and reports "with similar errors at L5".

This PR sorts the conflicts in the diagnostic engine before returning the converted diagnostics, such that diagnostics are always grouped under the first diagnostic.

(This is a recreated PR from #216 which got accidentally merged into a testing branch)