### PR TITLE
Replace custom `StripParens()` with the library `astutil.Unparen()`

### DIFF
--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -25,6 +25,7 @@ import (
 	"go.uber.org/nilaway/config"
 	"go.uber.org/nilaway/util"
 	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/ast/astutil"
 )
 
 // RootAssertionNode is the object that will be directly handled by the propagation algorithm,
@@ -1230,8 +1231,8 @@ func (r *RootAssertionNode) isStable(expr ast.Expr) bool {
 // Between two stable expressions, check if we expect them to produce the same value
 // precondition: isStable(left) && isStable(right), then checks if left and right are equal
 func (r *RootAssertionNode) eqStable(left, right ast.Expr) bool {
-	right = util.StripParens(right).(ast.Expr)
-	switch left := util.StripParens(left).(type) {
+	right = astutil.Unparen(right).(ast.Expr)
+	switch left := astutil.Unparen(left).(type) {
 	case *ast.BasicLit:
 		if right, ok := right.(*ast.BasicLit); ok {
 			return left.Value == right.Value

--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -1231,7 +1231,7 @@ func (r *RootAssertionNode) isStable(expr ast.Expr) bool {
 // Between two stable expressions, check if we expect them to produce the same value
 // precondition: isStable(left) && isStable(right), then checks if left and right are equal
 func (r *RootAssertionNode) eqStable(left, right ast.Expr) bool {
-	right = astutil.Unparen(right).(ast.Expr)
+	right = astutil.Unparen(right)
 	switch left := astutil.Unparen(left).(type) {
 	case *ast.BasicLit:
 		if right, ok := right.(*ast.BasicLit); ok {

--- a/assertion/function/assertiontree/util.go
+++ b/assertion/function/assertiontree/util.go
@@ -179,7 +179,7 @@ func inverseToken(t token.Token) token.Token {
 func AddNilCheck(pass *analysis.Pass, expr ast.Expr) (trueCheck, falseCheck RootFunc, isNoop bool) {
 	noop := func(_ *RootAssertionNode) {}
 
-	binExpr, ok := util.StripParens(expr).(*ast.BinaryExpr)
+	binExpr, ok := astutil.Unparen(expr).(*ast.BinaryExpr)
 
 	if !ok {
 		return noop, noop, true // is not a binary expression - do no work

--- a/util/util.go
+++ b/util/util.go
@@ -233,14 +233,6 @@ func ExprIsAuthentic(pass *analysis.Pass, expr ast.Expr) bool {
 	return t != nil
 }
 
-// StripParens takes an ast node and strips it of any outmost parentheses
-func StripParens(expr ast.Node) ast.Node {
-	if parenExpr, ok := expr.(*ast.ParenExpr); ok {
-		return StripParens(parenExpr.X)
-	}
-	return expr
-}
-
 // IsSliceAppendCall checks if `node` represents the builtin append(slice []Type, elems ...Type) []Type
 // call on a slice.
 // The function checks 2 things,


### PR DESCRIPTION
This PR simplifies code by deleting custom `StripParens()` and replacing it with the library function, `astutil.Unparen()`. (This PR includes no functional change.)