### PR TITLE
Add support for short-circuit `||` in non-conditional flows

### DIFF
--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -572,6 +572,9 @@ func (r *RootAssertionNode) AddComputation(expr ast.Expr) {
 		// Considering the above example,
 		// round 1: expr.Y: x.f.g == 1, and expr.X: x != nil && x.f != nil =>  AddNilCheck() returns noop since Y is not a nil check and X is non-atomic.
 		// round 2: expr.Y: x.f != nil, and expr.X: x != nil => AddNilCheck() returns successfully for both X and Y, where Y marks x.f.g as safe and X marks x.f as safe
+		//
+		// A similar approach is followed for the `||` operator, where we only need to care about the false branch since the
+		// Y expression won't be executed if the X expression is true.
 		if expr.Op == token.LAND {
 			for _, e := range [...]ast.Expr{expr.Y, expr.X} {
 				if trueNilCheck, _, isNoop := AddNilCheck(r.Pass(), e); !isNoop {

--- a/testdata/src/go.uber.org/inference/inference.go
+++ b/testdata/src/go.uber.org/inference/inference.go
@@ -18,112 +18,99 @@
 
 package inference
 
-// var dummyBool bool
-// var dummyInt int
-//
-// func retsNilable1() *int {
-// 	return nil
-// }
-//
-// func retsNilable2() *int {
-// 	if dummyBool {
-// 		return &dummyInt
-// 	}
-// 	return nil
-// }
-//
-// func retsNilable3() *int {
-// 	switch dummyInt {
-// 	case dummyInt:
-// 		return retsNilable1()
-// 	case dummyInt:
-// 		return retsNilable2()
-// 	case dummyInt:
-// 		return retsNilable3()
-// 	}
-// 	return &dummyInt
-// }
-//
-// func retsNonnil1() *int {
-// 	return &dummyInt
-// }
-//
-// func retsNonnil2() *int {
-// 	if dummyBool {
-// 		return &dummyInt
-// 	}
-// 	return &dummyInt
-// }
-//
-// func retsNonnil3() *int {
-// 	switch dummyInt {
-// 	case dummyInt:
-// 		return retsNonnil1()
-// 	case dummyInt:
-// 		return retsNonnil2()
-// 	case dummyInt:
-// 		return retsNonnil3()
-// 	}
-// 	return &dummyInt
-// }
-//
-// func retsNilable4() *int {
-// 	if dummyBool {
-// 		return retsNilable3()
-// 	}
-// 	return retsNilable3()
-// }
-//
-// func takesNonnil(x *int) int {
-// 	return *x
-// }
-//
-// func takesNilable(x *int) int {
-// 	if x == nil {
-// 		return 0
-// 	}
-// 	return *x
-// }
-//
-// func retsAndTakes() {
-// 	switch dummyInt {
-// 	case dummyInt:
-// 		takesNonnil(retsNonnil1())
-// 		takesNonnil(retsNonnil2())
-// 		takesNonnil(retsNonnil3())
-//
-// 		takesNilable(retsNonnil1())
-// 		takesNilable(retsNonnil2())
-// 		takesNilable(retsNonnil3())
-//
-// 		takesNilable(retsNilable1())
-// 		takesNilable(retsNilable2())
-// 		takesNilable(retsNilable3())
-// 		takesNilable(retsNilable4())
-// 	}
-// }
-//
-// // Below test checks the working of inference in the presence of annotations
-// // nonnil(x) nilable(result 0)
-// func foo(x *int) *int { //want "NONNIL because it is annotated as so"
-// 	print(*x)
-// 	return nil
-// }
-//
-// func callFoo() {
-// 	ptr := foo(nil)
-// 	print(*ptr) //want "NILABLE because it is annotated as so"
-// }
+var dummyBool bool
+var dummyInt int
 
-// nilable(v)
-func testme(v, x *int) bool {
-	// This is currently a false negative
-	// (v == nil || x != nil) && *v == 1
-	return !(v != nil && x == nil) && *v == 1
-	// if !(v != nil && x == nil) && *v == 1 {
-	// 	return true
-	// }
+func retsNilable1() *int {
+	return nil
+}
 
-	// return x == nil || *x == 1
-	// return x != nil || *x == 1
+func retsNilable2() *int {
+	if dummyBool {
+		return &dummyInt
+	}
+	return nil
+}
+
+func retsNilable3() *int {
+	switch dummyInt {
+	case dummyInt:
+		return retsNilable1()
+	case dummyInt:
+		return retsNilable2()
+	case dummyInt:
+		return retsNilable3()
+	}
+	return &dummyInt
+}
+
+func retsNonnil1() *int {
+	return &dummyInt
+}
+
+func retsNonnil2() *int {
+	if dummyBool {
+		return &dummyInt
+	}
+	return &dummyInt
+}
+
+func retsNonnil3() *int {
+	switch dummyInt {
+	case dummyInt:
+		return retsNonnil1()
+	case dummyInt:
+		return retsNonnil2()
+	case dummyInt:
+		return retsNonnil3()
+	}
+	return &dummyInt
+}
+
+func retsNilable4() *int {
+	if dummyBool {
+		return retsNilable3()
+	}
+	return retsNilable3()
+}
+
+func takesNonnil(x *int) int {
+	return *x
+}
+
+func takesNilable(x *int) int {
+	if x == nil {
+		return 0
+	}
+	return *x
+}
+
+func retsAndTakes() {
+	switch dummyInt {
+	case dummyInt:
+		takesNonnil(retsNonnil1())
+		takesNonnil(retsNonnil2())
+		takesNonnil(retsNonnil3())
+
+		takesNilable(retsNonnil1())
+		takesNilable(retsNonnil2())
+		takesNilable(retsNonnil3())
+
+		takesNilable(retsNilable1())
+		takesNilable(retsNilable2())
+		takesNilable(retsNilable3())
+		takesNilable(retsNilable4())
+	}
+}
+
+// Below test checks the working of inference in the presence of annotations
+// nonnil(x) nilable(result 0)
+func foo(x *int) *int { //want "NONNIL because it is annotated as so"
+	print(*x)
+	return nil
+}
+
+func callFoo() {
+	ptr := foo(nil)
+	print(*ptr) //want "NILABLE because it is annotated as so"
 }

--- a/testdata/src/go.uber.org/nilcheck/nonconditionalflow.go
+++ b/testdata/src/go.uber.org/nilcheck/nonconditionalflow.go
@@ -34,7 +34,11 @@ func testReturn(i int, v *int) bool {
 	case 2:
 		return v == nil && x != nil && *v == 1 //want "dereferenced"
 	case 3:
-		return (v == nil || x != nil) && *v == 1 //want "dereferenced"
+		//  It is a false negative. Currently NilAway cannot reason about such complex expressions in a nonconditional
+		//  setting. Such code patterns are perhaps not that common in practice, and hence we are not prioritizing
+		//  this at the moment.
+		// TODO: fix this in a follow-up PR.
+		return (v == nil || x != nil) && *v == 1
 	case 4:
 		return (x != nil && *v == 1) && (v != nil && *x == 0) //want "dereferenced"
 	case 5:
@@ -42,7 +46,11 @@ func testReturn(i int, v *int) bool {
 	case 6:
 		return v != nil || dummy && *v == 1 //want "dereferenced"
 	case 7:
-		return (nil != v || nil == v) && *v == 1 //want "dereferenced"
+		//  It is a false negative. Currently NilAway cannot reason about complex expressions like this since it does
+		//  not have full SAT solving capability. Such code patterns are perhaps not that common in practice, and
+		//  hence we are not prioritizing this at the moment.
+		// TODO: fix this in a follow-up diff.
+		return (nil != v || nil == v) && *v == 1
 	case 8:
 		return retNil() != nil && *retNil() == 1
 	case 9:
@@ -71,11 +79,30 @@ func testReturn(i int, v *int) bool {
 	case 20:
 		return !(v != v) || *v == 1 //want "dereferenced"
 	case 21:
-		// This is currently a false negative
+		// This is currently a false negative, since NilAway loses track of the effect of the negation on compound
+		// logical expressions in recursive calls. Note that NilAway can handle negations well, if the enclosed
+		// expression is atomic. For example, `!(v != nil) && *v == 1` is handled correctly.
+		// Such code patterns are perhaps not that common in practice, and hence we are not prioritizing this at the moment.
+		// TODO: fix this in a follow-up PR.
 		return !(v != nil && x == nil) && *v == 1
-		// if !(v != nil && x == nil) && *v == 1 {
-		// 	return true
-		// }
+	case 22:
+		return v == nil || *v == 1
+	case 23:
+		return v != nil || *v == 1 //want "dereferenced"
+	case 24:
+		return v == nil || x == nil || *v == 1
+	case 25:
+		return (x == nil || *v == 1) || (v == nil || *x == 0) //want "dereferenced"
+	case 26:
+		return v == nil || x == nil || *v == 1 || *x == 0
+	case 27:
+		return v != nil || x == nil || *v == 1 || *x == 0 //want "dereferenced"
+	case 28:
+		return (!(v != nil)) || *v == 1
+	case 29:
+		return retNil() == nil || *retNil() == 1
+	case 30:
+		return v == nil || dummy || *v == 1
 	}
 	return true
 }
@@ -95,7 +122,11 @@ func testAssignment(i int, v *int) bool {
 	case 2:
 		x = v == nil && y != nil && *v == 1 //want "dereferenced"
 	case 3:
-		x = (v == nil || y != nil) && *v == 1 //want "dereferenced"
+		//  It is a false negative. Currently NilAway cannot reason about such complex expressions in a nonconditional
+		//  setting. Such code patterns are perhaps not that common in practice, and hence we are not prioritizing
+		//  this at the moment.
+		// TODO: fix this in a follow-up PR.
+		x = (v == nil || y != nil) && *v == 1
 	case 4:
 		x = (y != nil && *v == 1) && (v != nil && *y == 0) //want "dereferenced"
 	case 5:
@@ -104,11 +135,21 @@ func testAssignment(i int, v *int) bool {
 		z := v != nil || dummy && *v == 1 //want "dereferenced"
 		x = z
 	case 7:
-		x = (nil != v || nil == v) && *v == 1 //want "dereferenced"
+		//  It is a false negative. Currently NilAway cannot reason about such complex expressions in a nonconditional
+		//  setting. Such code patterns are perhaps not that common in practice, and hence we are not prioritizing
+		//  this at the moment.
+		// TODO: fix this in a follow-up PR.
+		x = (nil != v || nil == v) && *v == 1
 	case 8:
 		x = retNil() != nil && *retNil() == 1
 	case 9:
 		x = *v == 1 && v != nil //want "dereferenced"
+	case 10:
+		x = v == nil || *v == 1
+	case 11:
+		x = v != nil || *v == 1 //want "dereferenced"
+	case 12:
+		x = v == nil || y != nil || *v == 1
 	}
 	return x
 }
@@ -128,7 +169,11 @@ func testParam(i int, v *int) {
 	case 2:
 		takesBool(v == nil && x != nil && *v == 1) //want "dereferenced"
 	case 3:
-		takesBool((v == nil || x != nil) && *v == 1) //want "dereferenced"
+		//  It is a false negative. Currently NilAway cannot reason about such complex expressions in a nonconditional
+		//  setting. Such code patterns are perhaps not that common in practice, and hence we are not prioritizing
+		//  this at the moment.
+		// TODO: fix this in a follow-up PR.
+		takesBool((v == nil || x != nil) && *v == 1)
 	case 4:
 		takesBool((x != nil && *v == 1) && (v != nil && *x == 0)) //want "dereferenced"
 	case 5:
@@ -136,11 +181,21 @@ func testParam(i int, v *int) {
 	case 6:
 		takesBool(v != nil || dummy && *v == 1) //want "dereferenced"
 	case 7:
-		takesBool((nil != v || nil == v) && *v == 1) //want "dereferenced"
+		//  It is a false negative. Currently NilAway cannot reason about such complex expressions in a nonconditional
+		//  setting. Such code patterns are perhaps not that common in practice, and hence we are not prioritizing
+		//  this at the moment.
+		// TODO: fix this in a follow-up PR.
+		takesBool((nil != v || nil == v) && *v == 1)
 	case 8:
 		takesBool(retNil() != nil && *retNil() == 1)
 	case 9:
 		takesBool(*v == 1 && v != nil) //want "dereferenced"
+	case 10:
+		takesBool(v == nil || *v == 1)
+	case 11:
+		takesBool(v != nil || *v == 1) //want "dereferenced"
+	case 12:
+		takesBool(v == nil || x != nil || *v == 1)
 	}
 }
 
@@ -205,6 +260,15 @@ func testChainedAccesses(x *X, i int) bool {
 		return x != nil && retNil() == nil && x.f != nil && *x.f == G{} && x.f.g != nil && dummy && x.f.g.h == 4
 	case 4:
 		return x != nil && x.f != nil && x.f.g.h == 4 && x.f.g != nil //want "field `g` accessed field `h`"
+	case 5:
+		return x == nil || x.f == nil || x.f.g == nil || x.f.g.h == 1
+	case 6:
+		return x == nil || x.f == nil || x.f.g.h == 4 //want "field `g` accessed field `h`"
+	case 7:
+		// safe, but condition interspersed with different irrelevant checks
+		return x == nil || retNil() == nil || x.f == nil || *x.f == G{} || x.f.g == nil || dummy || x.f.g.h == 4
+	case 8:
+		return x == nil || x.f == nil || x.f.g.h == 4 || x.f.g == nil //want "field `g` accessed field `h`"
 	}
 	return false
 }
@@ -243,7 +307,11 @@ func testLenChecks(s []int, i int) bool {
 	case 13:
 		return len(s) < 0 && len(t) > 0 && s[0] == 1 //want "sliced into"
 	case 14:
-		return (len(s) == 0 || len(t) > 0) && s[0] == 1 //want "sliced into"
+		//  It is a false negative. Currently NilAway cannot reason about such complex expressions in a nonconditional
+		//  setting. Such code patterns are perhaps not that common in practice, and hence we are not prioritizing
+		//  this at the moment.
+		// TODO: fix this in a follow-up PR.
+		return (len(s) == 0 || len(t) > 0) && s[0] == 1
 	case 15:
 		return (len(t) > 0 && s[0] == 1) && (len(s) > 0 && t[0] == 0) //want "sliced into"
 	case 16:
@@ -251,23 +319,29 @@ func testLenChecks(s []int, i int) bool {
 	case 17:
 		return len(s) > 0 || dummy && s[0] == 1 //want "sliced into"
 	case 18:
-		return (0 == len(s) || 0 > len(s)) && s[0] == 1 //want "sliced into"
-	}
-	return false
-}
-
-// ---- test cases with short-circuit OR ----
-
-func testShortCircuitOr(i int) bool {
-	var x *int
-
-	switch i {
-	case 0:
-		return x == nil || *x == 1
-	case 1:
-		return x != nil || *x == 1 //want "dereferenced"
-	case 2:
-
+		//  It is a false negative. Currently NilAway cannot reason about such complex expressions in a nonconditional
+		//  setting. Such code patterns are perhaps not that common in practice, and hence we are not prioritizing
+		//  this at the moment.
+		// TODO: fix this in a follow-up PR.
+		return (0 == len(s) || 0 > len(s)) && s[0] == 1
+	case 19:
+		return len(s) <= 0 || s[0] == 1
+	case 20:
+		return len(s) <= 0 || s[i] == 1
+	case 21:
+		return len(s) < 0 || s[0] == 1 //want "sliced into"
+	case 22:
+		return 0 >= len(s) || s[0] == 1
+	case 23:
+		return 0 < len(s) || s[0] == 1 //want "sliced into"
+	case 24:
+		return len(s) != 0 || s[0] == 1 //want "sliced into"
+	case 25:
+		return len(s) != 1 || s[0] == 1
+	case 26:
+		return len(t) < 0 || len(s) != len(t) || s[0] == 1
+	case 27:
+		return !(len(s) < 0) || s[0] == 1 //want "sliced into"
 	}
 	return false
 }


### PR DESCRIPTION
This PR adds support for short-circuit `||` in non-conditional flows, thereby reducing false positives. For example,
```
return x == nil || *x == 1
```
was reported as a false positive, since NilAway only analyzed `&&`.

We apply logic similar to the handling of `&&`. Because this analysis resides in the recursion of the short-circuit expression, where we have limited context visibility, it makes it difficult to accurately analyze complex expressions. Therefore, with extending support for `||`, we had to trade-off some of the precision we previously had with only the `&&` support. However, we made this tough choice since empirically we observed that complex cases that we had to trade-off did not occur frequently enough, while simple `||` patterns were more prevalent. I have created issue #226 to keep a track of the comprehensive support that we plan to add in the future.

[closes #92 ]