### PR TITLE
Fix grouping of error messages when authentic producer expr is unavailable

### DIFF
--- a/diagnostic/conflict.go
+++ b/diagnostic/conflict.go
@@ -66,8 +66,11 @@ func groupConflicts(allConflicts []conflict) []conflict {
 
 		// Handle the case of single assertion conflict separately
 		if len(c.flow.nilPath) == 0 && len(c.flow.nonnilPath) == 1 {
-			// This is the case of single assertion conflict. Use producer position and repr from the non-nil path as the key.
-			if p := c.flow.nonnilPath[0]; p.producerPosition.IsValid() {
+			// This is the case of single assertion conflict. Use producer position and repr from the non-nil path as
+			// the key, if present, else use the producer and consumer repr as a heuristic key to group conflicts.
+			p := c.flow.nonnilPath[0]
+			key = p.producerRepr + ";" + p.consumerRepr
+			if p.producerPosition.IsValid() {
 				key = p.producerPosition.String() + ": " + p.producerRepr
 			}
 		}

--- a/nilaway_test.go
+++ b/nilaway_test.go
@@ -64,7 +64,7 @@ func TestNilAway(t *testing.T) {
 		{name: "Generics", patterns: []string{"go.uber.org/generics"}},
 		{name: "FunctionContracts", patterns: []string{"go.uber.org/functioncontracts", "go.uber.org/functioncontracts/inference"}},
 		{name: "Constants", patterns: []string{"go.uber.org/consts"}},
-		{name: "ErrorMessage", patterns: []string{"go.uber.org/errormessage"}},
+		{name: "ErrorMessage", patterns: []string{"go.uber.org/errormessage", "go.uber.org/errormessage/inference"}},
 		{name: "LoopRange", patterns: []string{"go.uber.org/looprange"}},
 	}
 

--- a/testdata/src/go.uber.org/errormessage/errormessage-assignment-flow.go
+++ b/testdata/src/go.uber.org/errormessage/errormessage-assignment-flow.go
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This package tests _single_ package inference. Due to limitations of `analysistest` framework,
-// multi-package inference is tested by our integration test suites. Please see
-// `testdata/README.md` for more details.
+// This package tests error messages for assignment flow tracking.
 
 // <nilaway no inference>
 package errormessage

--- a/testdata/src/go.uber.org/errormessage/inference/errormessage-with-inferece.go
+++ b/testdata/src/go.uber.org/errormessage/inference/errormessage-with-inferece.go
@@ -1,0 +1,65 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This package tests error messages for the inference mode.
+
+package inference
+
+// Below test checks error messages for single assertion conflicts when the producer expression is not authentic, i.e.,
+// it is built from assertion nodes and hence not found in the original AST.
+
+type S struct {
+	f map[int]*S
+	g string
+}
+
+type T struct {
+	m map[string]S
+}
+
+// Here, although the two error messages are similar for test1 and test2, they should not be grouped together as they are
+// from different functions.
+func (t *T) test1(str string) {
+	p := t.m[str]
+	_ = *p.f[0] //want "dereferenced"
+}
+
+func (t *T) test2(str string) {
+	p := t.m[str]
+	_ = *p.f[0] //want "dereferenced"
+}
+
+// Here, the error messages for the two dereferences in test3 are similar and should be grouped together.
+func (t *T) test3(str string) {
+	p := t.m[str]
+	_ = *p.f[0] //want "Same nil source could also cause potential nil panic"
+	_ = *p.f[1]
+}
+
+// Here, the two error messages in test4 are similar, and ideally they should be grouped together.
+// However, since producer position is unavailable, NilAway uses a heuristic combined of the producer and consumer
+// error messages to group them, and in this case the consumer messages are different: "dereferenced" and "accessed field".
+// Hence, they are not grouped together.
+func (t *T) test4(str string) {
+	p := t.m[str]
+	_ = *p.f[0]  //want "dereferenced"
+	_ = p.f[1].f //want "accessed field"
+}
+
+// Similar to test4, here the error messages are not grouped since the accessed fields in consumer messages are different.
+func (t *T) test5(str string) {
+	p := t.m[str]
+	_ = p.f[0].f //want "accessed field `f`"
+	_ = p.f[1].g //want "accessed field `g`"
+}


### PR DESCRIPTION
This PR fixes the incorrect grouping of error messages, which specifically occurs in the case of `Single Assertion Conflicts` when the authentic producer expression is unavailable.