### PR TITLE
Move grouping flag to the top

### DIFF
--- a/accumulation/analyzer.go
+++ b/accumulation/analyzer.go
@@ -132,7 +132,7 @@ func run(pass *analysis.Pass) (result interface{}, _ error) {
 		// sites unless we really have a reason they have to be determined.
 		inferenceEngine.ObservePackage(assertionsResult.Res)
 		inferredMap = inferenceEngine.InferredMap()
-		diagnostics = diagnosticEngine.Diagnostics(true /* grouping */)
+		diagnostics = diagnosticEngine.Diagnostics(conf.GroupErrorMessages)
 
 	case inference.NoInfer:
 		// In non-inference case - use the classical assertionNode.CheckErrors method to determine error outputs

--- a/config/config.go
+++ b/config/config.go
@@ -30,6 +30,8 @@ import (
 type Config struct {
 	// PrettyPrint indicates whether the error messages should be pretty printed.
 	PrettyPrint bool
+	// GroupErrorMessages indicates whether similar error messages should be grouped.
+	GroupErrorMessages bool
 	// ExperimentalStructInitEnable indicates whether experimental struct initialization is enabled.
 	ExperimentalStructInitEnable bool
 	// ExperimentalAnonymousFuncEnable indicates whether experimental anonymous function support is enabled.
@@ -121,6 +123,8 @@ var Analyzer = &analysis.Analyzer{
 const (
 	// PrettyPrintFlag is the flag for pretty printing the error messages.
 	PrettyPrintFlag = "pretty-print"
+	// GroupErrorMessagesFlag is the flag for grouping similar error messages.
+	GroupErrorMessagesFlag = "group-error-messages"
 	// IncludePkgsFlag is the flag name for include package prefixes.
 	IncludePkgsFlag = "include-pkgs"
 	// ExcludePkgsFlag is the flag name for exclude package prefixes.
@@ -140,6 +144,7 @@ func newFlagSet() flag.FlagSet {
 	// We do not keep the returned pointer to the flags because we will not use them directly here.
 	// Instead, we will use the flags through the analyzer's Flags field later.
 	_ = fs.Bool(PrettyPrintFlag, true, "Pretty print the error messages")
+	_ = fs.Bool(GroupErrorMessagesFlag, true, "Group similar error messages")
 	_ = fs.String(IncludePkgsFlag, "", "Comma-separated list of packages to analyze")
 	_ = fs.String(ExcludePkgsFlag, "", "Comma-separated list of packages to exclude from analysis")
 	_ = fs.String(ExcludeFileDocStringsFlag, "", "Comma-separated list of docstrings to exclude from analysis")
@@ -152,7 +157,8 @@ func newFlagSet() flag.FlagSet {
 func run(pass *analysis.Pass) (any, error) {
 	// Set up default values for the config.
 	conf := &Config{
-		PrettyPrint: true,
+		PrettyPrint:        true,
+		GroupErrorMessages: true,
 		// If the user does not provide an include list, we give an empty package prefix to catch
 		// all packages.
 		includePkgs: []string{""},
@@ -161,6 +167,9 @@ func run(pass *analysis.Pass) (any, error) {
 	// Override default values if the user provides flags.
 	if prettyPrint, ok := pass.Analyzer.Flags.Lookup(PrettyPrintFlag).Value.(flag.Getter).Get().(bool); ok {
 		conf.PrettyPrint = prettyPrint
+	}
+	if groupErrorMessages, ok := pass.Analyzer.Flags.Lookup(GroupErrorMessagesFlag).Value.(flag.Getter).Get().(bool); ok {
+		conf.GroupErrorMessages = groupErrorMessages
 	}
 	if enableStructInit, ok := pass.Analyzer.Flags.Lookup(ExperimentalStructInitEnableFlag).Value.(flag.Getter).Get().(bool); ok {
 		conf.ExperimentalStructInitEnable = enableStructInit

--- a/nilaway_test.go
+++ b/nilaway_test.go
@@ -124,9 +124,11 @@ func TestPrettyPrint(t *testing.T) { //nolint:paralleltest
 
 func TestGroupErrorMessages(t *testing.T) { //nolint:paralleltest
 	// We specifically do not set this test to be parallel such that this test is run separately
-	// from the parallel tests. This makes it possible to set the group error messages flag to true for
-	// testing and false for the other tests.
+	// from the parallel tests. This makes it possible to test the group error messages flag independently
+	// without affecting the other tests.
 	testdata := analysistest.TestData()
+
+	defaultValue := config.Analyzer.Flags.Lookup(config.GroupErrorMessagesFlag).Value.String()
 
 	err := config.Analyzer.Flags.Set(config.GroupErrorMessagesFlag, "true")
 	require.NoError(t, err)
@@ -138,7 +140,7 @@ func TestGroupErrorMessages(t *testing.T) { //nolint:paralleltest
 
 	// Reset the flag to its default value.
 	defer func() {
-		err := config.Analyzer.Flags.Set(config.GroupErrorMessagesFlag, "true")
+		err := config.Analyzer.Flags.Set(config.GroupErrorMessagesFlag, defaultValue)
 		require.NoError(t, err)
 	}()
 }

--- a/nilaway_test.go
+++ b/nilaway_test.go
@@ -122,6 +122,21 @@ func TestPrettyPrint(t *testing.T) { //nolint:paralleltest
 	analysistest.Run(t, testdata, Analyzer, "prettyprint")
 }
 
+func TestGroupErrorMessages(t *testing.T) { //nolint:paralleltest
+	// We specifically do not set this test to be parallel such that this test is run separately
+	// from the parallel tests. This makes it possible to set the group error messages flag to true for
+	// testing and false for the other tests.
+	testdata := analysistest.TestData()
+
+	err := config.Analyzer.Flags.Set(config.GroupErrorMessagesFlag, "true")
+	require.NoError(t, err)
+	analysistest.Run(t, testdata, Analyzer, "grouping/enabled")
+
+	err = config.Analyzer.Flags.Set(config.GroupErrorMessagesFlag, "false")
+	require.NoError(t, err)
+	analysistest.Run(t, testdata, Analyzer, "grouping/disabled")
+}
+
 func TestMain(m *testing.M) {
 	flags := map[string]string{
 		// Pretty print should be turned off for easier error message matching in test files.

--- a/nilaway_test.go
+++ b/nilaway_test.go
@@ -135,6 +135,12 @@ func TestGroupErrorMessages(t *testing.T) { //nolint:paralleltest
 	err = config.Analyzer.Flags.Set(config.GroupErrorMessagesFlag, "false")
 	require.NoError(t, err)
 	analysistest.Run(t, testdata, Analyzer, "grouping/disabled")
+
+	// Reset the flag to its default value.
+	defer func() {
+		err := config.Analyzer.Flags.Set(config.GroupErrorMessagesFlag, "true")
+		require.NoError(t, err)
+	}()
 }
 
 func TestMain(m *testing.M) {

--- a/testdata/src/grouping/disabled/main.go
+++ b/testdata/src/grouping/disabled/main.go
@@ -1,0 +1,9 @@
+// Package disabled is meant to check if our group-error-messages flag has effect.
+package disabled
+
+// When the group-error-messages flag is set to false, the two dereference error messages should be reported separately.
+func test() {
+	var x *int
+	_ = *x //want "dereferenced"
+	_ = *x //want "dereferenced"
+}

--- a/testdata/src/grouping/enabled/main.go
+++ b/testdata/src/grouping/enabled/main.go
@@ -1,0 +1,9 @@
+// Package grouping is meant to check if our group-error-messages flag has effect.
+package enabled
+
+// When the group-error-messages flag is set to true, the two dereference error messages should be grouped together.
+func test() {
+	var x *int
+	_ = *x //want "Same nil source could also cause potential nil panic"
+	_ = *x
+}

--- a/tools/cmd/golden-test/main.go
+++ b/tools/cmd/golden-test/main.go
@@ -134,7 +134,7 @@ func Run(writer io.Writer, baseBranch, testBranch string) error {
 
 		// Run the built NilAway binary on the stdlib and parse the diagnostics.
 		var buf bytes.Buffer
-		cmd := exec.Command("bin/nilaway", "-include-errors-in-files", "/", "-json", "-pretty-print=false", "std")
+		cmd := exec.Command("bin/nilaway", "-include-errors-in-files", "/", "-json", "-pretty-print=false", "-group-error-messages=true", "std")
 		cmd.Stdout = &buf
 		// Inherit env vars such that users can control the resource usages via GOMEMLIMIT, GOGC
 		// etc. env vars.


### PR DESCRIPTION
This PR creates and moves the flag for grouping similar error messages to the top.