### PR TITLE
Removing unused parameter from `BuildExpr()`

### DIFF
--- a/assertion/function/assertiontree/assertion_node.go
+++ b/assertion/function/assertiontree/assertion_node.go
@@ -18,7 +18,6 @@ import (
 	"go/ast"
 
 	"go.uber.org/nilaway/annotation"
-	"golang.org/x/tools/go/analysis"
 )
 
 // An AssertionNode is the root of a tree of assertions, so it contains parent and child pointers, as well as a set
@@ -50,7 +49,7 @@ type AssertionNode interface {
 	// BuildExpr takes an expression, and builds a new one by wrapping it in a new AST expression
 	// corresponding to this node
 	// nilable(param 1)
-	BuildExpr(*analysis.Pass, ast.Expr) ast.Expr
+	BuildExpr(ast.Expr) ast.Expr
 
 	// Root returns the RootAssertionNode at the root of the tree this assertion node is part of,
 	// if it is part of such a tree - otherwise returns nil

--- a/assertion/function/assertiontree/fld_assertion_node.go
+++ b/assertion/function/assertiontree/fld_assertion_node.go
@@ -20,7 +20,6 @@ import (
 	"go/types"
 
 	"go.uber.org/nilaway/annotation"
-	"golang.org/x/tools/go/analysis"
 )
 
 type fldAssertionNode struct {
@@ -74,7 +73,7 @@ func (f *fldAssertionNode) DefaultTrigger() annotation.ProducingAnnotationTrigge
 }
 
 // BuildExpr for a field node adds that field access to the expression `expr`
-func (f *fldAssertionNode) BuildExpr(_ *analysis.Pass, expr ast.Expr) ast.Expr {
+func (f *fldAssertionNode) BuildExpr(expr ast.Expr) ast.Expr {
 	if f.Root() == nil {
 		panic("f.BuildExpr should only be called on nodes present in a valid assertion tree")
 	}

--- a/assertion/function/assertiontree/func_assertion_node.go
+++ b/assertion/function/assertiontree/func_assertion_node.go
@@ -21,7 +21,6 @@ import (
 
 	"go.uber.org/nilaway/annotation"
 	"go.uber.org/nilaway/util"
-	"golang.org/x/tools/go/analysis"
 )
 
 type funcAssertionNode struct {
@@ -53,7 +52,7 @@ func (f *funcAssertionNode) DefaultTrigger() annotation.ProducingAnnotationTrigg
 }
 
 // BuildExpr for a function node adds that function to `expr` as a method call
-func (f *funcAssertionNode) BuildExpr(_ *analysis.Pass, expr ast.Expr) ast.Expr {
+func (f *funcAssertionNode) BuildExpr(expr ast.Expr) ast.Expr {
 	if f.Root() == nil {
 		panic("f.BuildExpr should only be called on nodes present in a valid assertion tree")
 	}

--- a/assertion/function/assertiontree/index_assertion_node.go
+++ b/assertion/function/assertiontree/index_assertion_node.go
@@ -19,7 +19,6 @@ import (
 	"go/types"
 
 	"go.uber.org/nilaway/annotation"
-	"golang.org/x/tools/go/analysis"
 )
 
 type indexAssertionNode struct {
@@ -45,7 +44,7 @@ func (i *indexAssertionNode) DefaultTrigger() annotation.ProducingAnnotationTrig
 }
 
 // BuildExpr for an index node adds that index to `expr`
-func (i *indexAssertionNode) BuildExpr(_ *analysis.Pass, expr ast.Expr) ast.Expr {
+func (i *indexAssertionNode) BuildExpr(expr ast.Expr) ast.Expr {
 	return &ast.IndexExpr{
 		X:      expr,
 		Lbrack: 0,

--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -92,7 +92,7 @@ func (r *RootAssertionNode) DefaultTrigger() annotation.ProducingAnnotationTrigg
 }
 
 // BuildExpr is not well defined for root nodes
-func (r *RootAssertionNode) BuildExpr(*analysis.Pass, ast.Expr) ast.Expr {
+func (r *RootAssertionNode) BuildExpr(_ ast.Expr) ast.Expr {
 	panic("BuildExpr() not defined for RootAssertionNodes")
 }
 
@@ -379,7 +379,7 @@ func (r *RootAssertionNode) triggerProductions(node AssertionNode, producer *ann
 	var processChildren func(ast.Expr, AssertionNode)
 	processChildren = func(producingSubexpr ast.Expr, node AssertionNode) {
 		for _, child := range node.Children() {
-			producingExpr := child.BuildExpr(r.Pass(), producingSubexpr)
+			producingExpr := child.BuildExpr(producingSubexpr)
 
 			matchConsumeTriggers(child, &annotation.ProduceTrigger{
 				Annotation: child.DefaultTrigger(),
@@ -996,7 +996,7 @@ type RootFunc = func(*RootAssertionNode)
 func (r *RootAssertionNode) ProcessEntry() {
 	for len(r.Children()) > 0 {
 		child := r.Children()[0]
-		builtExpr := child.BuildExpr(r.Pass(), nil)
+		builtExpr := child.BuildExpr(nil)
 
 		if r.functionContext.functionConfig.EnableStructInitCheck {
 			// process field Assertion nodes of function parameters

--- a/assertion/function/assertiontree/var_assertion_node.go
+++ b/assertion/function/assertiontree/var_assertion_node.go
@@ -21,7 +21,6 @@ import (
 
 	"go.uber.org/nilaway/annotation"
 	"go.uber.org/nilaway/util"
-	"golang.org/x/tools/go/analysis"
 )
 
 type varAssertionNode struct {
@@ -68,7 +67,7 @@ func (v *varAssertionNode) DefaultTrigger() annotation.ProducingAnnotationTrigge
 	if !util.TypeIsDeeplyPtr(v.decl.Type()) {
 		if structType := util.TypeAsDeeplyStruct(v.decl.Type()); structType != nil {
 			if v.Root().functionContext.functionConfig.EnableStructInitCheck {
-				v.Root().addProductionForVarFieldNode(v, v.BuildExpr(v.Root().Pass(), nil))
+				v.Root().addProductionForVarFieldNode(v, v.BuildExpr(nil))
 			}
 			return &annotation.ProduceTriggerNever{} // indicating that the struct object itself is not nil
 		}
@@ -78,7 +77,7 @@ func (v *varAssertionNode) DefaultTrigger() annotation.ProducingAnnotationTrigge
 }
 
 // BuildExpr for a varAssertionNode returns the underlying variable's AST node
-func (v *varAssertionNode) BuildExpr(_ *analysis.Pass, _ ast.Expr) ast.Expr {
+func (v *varAssertionNode) BuildExpr(_ ast.Expr) ast.Expr {
 	if v.Root() == nil {
 		panic("v.BuildExpr should only be called on nodes present in a valid assertion tree")
 	}


### PR DESCRIPTION
This PR simplifies the `BuildExpr` function by removing the unused parameter `*analysis.Pass`.