### PR TITLE
Implement the plugin interface for golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,6 @@ install-golangci-lint:
 		@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOBIN) v$(REQUIRED_GOLANGCI_LINT_VERSION)
     endif
 
-
 .PHONY: golangci-lint
 golangci-lint: install-golangci-lint
 	@echo "[lint] $(shell $(GOBIN)/golangci-lint version)"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PROJECT_ROOT = $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 export GOBIN = $(PROJECT_ROOT)/bin
 
 GOLANGCI_LINT_VERSION := $(shell $(GOBIN)/golangci-lint version --format short 2>/dev/null)
-REQUIRED_GOLANGCI_LINT_VERSION := $(shell awk '/^version:/ {print $2}' .custom-gcl.yaml)
+REQUIRED_GOLANGCI_LINT_VERSION := $(shell cat .golangci.version)
 
 # Directories containing independent Go modules.
 MODULE_DIRS = . ./tools

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PROJECT_ROOT = $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 export GOBIN = $(PROJECT_ROOT)/bin
 
 GOLANGCI_LINT_VERSION := $(shell $(GOBIN)/golangci-lint version --format short 2>/dev/null)
-REQUIRED_GOLANGCI_LINT_VERSION := $(shell cat .golangci.version)
+REQUIRED_GOLANGCI_LINT_VERSION := $(shell awk '/^version:/ {print $2}' .custom-gcl.yaml)
 
 # Directories containing independent Go modules.
 MODULE_DIRS = . ./tools
@@ -50,6 +50,7 @@ install-golangci-lint:
 		@echo "[lint] installing golangci-lint v$(REQUIRED_GOLANGCI_LINT_VERSION) since current version is \"$(GOLANGCI_LINT_VERSION)\""
 		@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOBIN) v$(REQUIRED_GOLANGCI_LINT_VERSION)
     endif
+
 
 .PHONY: golangci-lint
 golangci-lint: install-golangci-lint

--- a/README.md
+++ b/README.md
@@ -64,8 +64,7 @@ nilaway -include-pkgs="<YOUR_PKG_PREFIX>,<YOUR_PKG_PREFIX_2>" ./...
 
 ### golangci-lint (>= v1.57.0)
 
-NilAway, in its current form, still reports a fair number of false positives. This makes NilAway
-fail to be merged with [golangci-lint][golangci-lint] and be offered as a linter
+NilAway, in its current form, can report false positives. This unfortunately hinders its immediate merging in [golangci-lint][golangci-lint] and be offered as a linter
 (see [PR#4045][pr-4045]). Therefore, you need to build NilAway as a plugin to golangci-lint to be
 executed as a private linter. There are two plugin systems in golangci-lint, and it is much easier
 to use the [Module Plugin System][golangci-lint-module-plugin] (introduced since v1.57.0), and it

--- a/README.md
+++ b/README.md
@@ -62,6 +62,65 @@ Then, run the linter by:
 nilaway -include-pkgs="<YOUR_PKG_PREFIX>,<YOUR_PKG_PREFIX_2>" ./...
 ```
 
+### golangci-lint (>= v1.57.0)
+
+NilAway, in its current form, still reports a fair number of false positives. This makes NilAway
+fail to be merged with [golangci-lint][golangci-lint] and be offered as a linter
+(see [PR#4045][pr-4045]). Therefore, you need to build NilAway as a plugin to golangci-lint to be
+executed as a private linter. There are two plugin systems in golangci-lint, and it is much easier
+to use the [Module Plugin System][golangci-lint-module-plugin] (introduced since v1.57.0), and it
+is the only supported approach to run NilAway in golangci-lint.
+
+(1) Create a `.custom-gcl.yml` file at the root of the repository if you have not done so, add the
+following content:
+
+```yaml
+# This has to be >= v1.57.0 for module plugin system support.
+version: v1.57.0
+plugins:
+  - module: "go.uber.org/nilaway"
+    import: "go.uber.org/nilaway/cmd/gclplugin"
+    version: latest # Or a fixed version for reproducible builds.
+```
+
+(2) Add NilAway to the linter configuration file `.golangci.yaml`:
+
+```yaml
+linters-settings:
+  custom:
+    nilaway:
+      type: "module"
+      description: Static analysis tool to detect potential nil panics in Go code.
+      settings:
+        # Settings must be a "map from string to string" to mimic command line flags: the keys are
+        # flag names and the values are the values to the particular flags.
+        include-pkgs: "<YOUR_PACKAGE_PREFIXES>"
+# NilAway can be referred to as `nilaway` just like any other golangci-lint analyzers in other 
+# parts of the configuration file.
+```
+
+(3) Build a custom golangci-lint binary with NilAway included:
+
+```shell
+# Note that your `golangci-lint` to bootstrap the custom binary must also be version >= v1.57.0.
+$ golangci-lint custom
+```
+
+By default, the custom binary will be built at `.` with the name `custom-gcl`, which can be further
+customized in `.custom-gcl.yml` file (see [Module Plugin System][golangci-lint-module-plugin] for
+instructions).
+
+> [!TIP]  
+> Cache the custom binary to avoid having to build it again to save resources, you can use the
+> hash of the `.custom-gcl.yml` file as the cache key.
+
+(4) Run the custom binary instead of `golangci-lint`:
+
+```shell
+# Arguments are the same as `golangci-lint`.
+$ ./custom-gcl run ./...
+```
+
 ### Bazel/nogo
 
 Running with bazel/nogo requires slightly more efforts. First follow the instructions from [rules_go][rules-go], 
@@ -104,65 +163,6 @@ $ bazel build --keep_going //...
 
 (5) See [nogo documentation][nogo-configure-analyzers] on how to pass a configuration JSON to the nogo driver, and see 
 our [wiki page][nogo-configure-nilaway] on how to pass configurations to NilAway.
-
-### golangci-lint (>= v1.57.0)
-
-NilAway, in its current form, still reports a fair number of false positives. This makes NilAway 
-fail to be merged with [golangci-lint][golangci-lint] and be offered as a linter 
-(see [PR#4045][pr-4045]). Therefore, you need to build NilAway as a plugin to golangci-lint to be
-executed as a private linter. There are two plugin systems in golangci-lint, and it is much easier
-to use the [Module Plugin System][golangci-lint-module-plugin] (introduced since v1.57.0), and it 
-is the only supported approach to run NilAway in golangci-lint.
-
-(1) Create a `.custom-gcl.yml` file at the root of the repository if you have not done so, add the
-following content:
-
-```yaml
-# This has to be >= v1.57.0 for module plugin system support.
-version: v1.57.0
-plugins:
-  - module: "go.uber.org/nilaway"
-    import: "go.uber.org/nilaway/cmd/gclplugin"
-    version: latest # Or a fixed version for reproducible builds.
-```
-
-(2) Add NilAway to the linter configuration file `.golangci.yaml`:
-
-```yaml
-linters-settings:
-  custom:
-    nilaway:
-      type: "module"
-      description: Static analysis tool to detect potential nil panics in Go code.
-      settings:
-        # Settings must be a "map from string to string" to mimic command line flags: the keys are
-        # flag names and the values are the values to the particular flags.
-        include-pkgs: "<YOUR_PACKAGE_PREFIXES>"
-# NilAway can be referred to as `nilaway` just like any other golangci-lint analyzers in other 
-# parts of the configuration file.
-```
-
-(3) Build a custom golangci-lint binary with NilAway included:
-
-```shell
-# Note that your `golangci-lint` to bootstrap the custom binary must also be version >= v1.57.0.
-$ golangci-lint custom
-```
-
-By default, the custom binary will be built at `.` with the name `custom-gcl`, which can be further
-customized in `.custom-gcl.yml` file (see [Module Plugin System][golangci-lint-module-plugin] for 
-instructions).
-
-> [!TIP]  
-> Cache the custom binary to avoid having to build it again to save resources, you can use the
-> hash of the `.custom-gcl.yml` file as the cache key.
-
-(4) Run the custom binary instead of `golangci-lint`:
-
-```shell
-# Arguments are the same as `golangci-lint`.
-$ ./custom-gcl run ./...
-```
 
 ## Code Examples
 

--- a/README.md
+++ b/README.md
@@ -64,11 +64,12 @@ nilaway -include-pkgs="<YOUR_PKG_PREFIX>,<YOUR_PKG_PREFIX_2>" ./...
 
 ### golangci-lint (>= v1.57.0)
 
-NilAway, in its current form, can report false positives. This unfortunately hinders its immediate merging in [golangci-lint][golangci-lint] and be offered as a linter
-(see [PR#4045][pr-4045]). Therefore, you need to build NilAway as a plugin to golangci-lint to be
-executed as a private linter. There are two plugin systems in golangci-lint, and it is much easier
-to use the [Module Plugin System][golangci-lint-module-plugin] (introduced since v1.57.0), and it
-is the only supported approach to run NilAway in golangci-lint.
+NilAway, in its current form, can report false positives. This unfortunately hinders its immediate 
+merging in [golangci-lint][golangci-lint] and be offered as a linter (see [PR#4045][pr-4045]). 
+Therefore, you need to build NilAway as a plugin to golangci-lint to be executed as a private 
+linter. There are two plugin systems in golangci-lint, and it is much easier to use the 
+[Module Plugin System][golangci-lint-module-plugin] (introduced since v1.57.0), and it is the only 
+supported approach to run NilAway in golangci-lint.
 
 (1) Create a `.custom-gcl.yml` file at the root of the repository if you have not done so, add the
 following content:

--- a/cmd/gclplugin/gclplugin.go
+++ b/cmd/gclplugin/gclplugin.go
@@ -1,0 +1,71 @@
+//  Copyright (c) 2024 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package gclplugin implements the golangci-lint's module plugin interface for NilAway to be used
+// as a private linter in golangci-lint. See more details at
+// https://golangci-lint.run/plugins/module-plugins/.
+package gclplugin
+
+import (
+	"fmt"
+
+	"github.com/golangci/plugin-module-register/register"
+	"go.uber.org/nilaway"
+	"go.uber.org/nilaway/config"
+	"golang.org/x/tools/go/analysis"
+)
+
+func init() {
+	register.Plugin("nilaway", New)
+}
+
+// New returns the golangci-lint plugin that wraps the NilAway analyzer.
+func New(settings any) (register.LinterPlugin, error) {
+	// Parse the settings to the correct type (map[string]string) similar to command line flags.
+	s, ok := settings.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("expect NilAway's configurations to a map from string to "+
+			"string (similar to command line flags), got %T", settings)
+	}
+	conf := make(map[string]string, len(s))
+	for k, v := range s {
+		vStr, ok := v.(string)
+		if !ok {
+			return nil, fmt.Errorf("expect NilAway's configuration values for %q to be strings, got %T", k, v)
+		}
+		conf[k] = vStr
+	}
+
+	return &NilAwayPlugin{conf: conf}, nil
+}
+
+// NilAwayPlugin is the NilAway plugin wrapper for golangci-lint.
+type NilAwayPlugin struct {
+	conf map[string]string
+}
+
+// BuildAnalyzers builds the NilAway analyzer with the configurations applied to the config analyzer.
+func (p *NilAwayPlugin) BuildAnalyzers() ([]*analysis.Analyzer, error) {
+	// Apply the configurations to the config analyzer.
+	for k, v := range p.conf {
+		if err := config.Analyzer.Flags.Set(k, v); err != nil {
+			return nil, fmt.Errorf("set config flag %s with %s: %w", k, v, err)
+		}
+	}
+
+	return []*analysis.Analyzer{nilaway.Analyzer}, nil
+}
+
+// GetLoadMode returns the load mode of the NilAway plugin (requiring types info).
+func (p *NilAwayPlugin) GetLoadMode() string { return register.LoadModeTypesInfo }

--- a/cmd/gclplugin/gclplugin_test.go
+++ b/cmd/gclplugin/gclplugin_test.go
@@ -26,7 +26,7 @@ import (
 func TestPlugin(t *testing.T) {
 	t.Parallel()
 
-	plugin, err := New(map[string]string{"pretty-print": "false"})
+	plugin, err := New(map[string]any{"pretty-print": "false"})
 	require.NoError(t, err)
 	require.NotNil(t, plugin)
 
@@ -51,7 +51,7 @@ func TestPlugin_IncorrectSettingsType(t *testing.T) {
 func TestPlugin_IncorrectSettings(t *testing.T) {
 	t.Parallel()
 
-	plugin, err := New(map[string]string{"invalid": "123"})
+	plugin, err := New(map[string]any{"invalid": "123"})
 	// The settings are applied when we build the analyzers, so the error should be thrown there.
 	require.NoError(t, err)
 	require.NotNil(t, plugin)

--- a/cmd/gclplugin/gclplugin_test.go
+++ b/cmd/gclplugin/gclplugin_test.go
@@ -1,0 +1,62 @@
+//  Copyright (c) 2024 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gclplugin
+
+import (
+	"testing"
+
+	"github.com/golangci/plugin-module-register/register"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/nilaway"
+	"go.uber.org/nilaway/config"
+)
+
+func TestPlugin(t *testing.T) {
+	t.Parallel()
+
+	plugin, err := New(map[string]string{"pretty-print": "false"})
+	require.NoError(t, err)
+	require.NotNil(t, plugin)
+
+	require.Equal(t, register.LoadModeTypesInfo, plugin.GetLoadMode())
+	analyzers, err := plugin.BuildAnalyzers()
+	require.NoError(t, err)
+	require.Len(t, analyzers, 1)
+	require.Equal(t, nilaway.Analyzer, analyzers[0])
+
+	// The config flag should be set to the value passed in the settings.
+	require.Equal(t, "false", config.Analyzer.Flags.Lookup(config.PrettyPrintFlag).Value.String())
+}
+
+func TestPlugin_IncorrectSettingsType(t *testing.T) {
+	t.Parallel()
+
+	plugin, err := New(map[string]any{"pretty-print": "false", "invalid": []string{"123", "234"}})
+	require.Error(t, err)
+	require.Nil(t, plugin)
+}
+
+func TestPlugin_IncorrectSettings(t *testing.T) {
+	t.Parallel()
+
+	plugin, err := New(map[string]string{"invalid": "123"})
+	// The settings are applied when we build the analyzers, so the error should be thrown there.
+	require.NoError(t, err)
+	require.NotNil(t, plugin)
+
+	analyzers, err := plugin.BuildAnalyzers()
+	require.ErrorContains(t, err, "invalid")
+	require.Empty(t, analyzers)
+}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/golangci/plugin-module-register v0.1.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.5.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module go.uber.org/nilaway
 go 1.21
 
 require (
+	github.com/golangci/plugin-module-register v0.1.1
 	github.com/google/go-cmp v0.6.0
 	github.com/klauspost/compress v1.17.6
 	github.com/stretchr/testify v1.8.4
@@ -12,7 +13,6 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/golangci/plugin-module-register v0.1.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.5.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/golangci/plugin-module-register v0.1.1 h1:TCmesur25LnyJkpsVrupv1Cdzo+2f7zX0H6Jkw1Ol6c=
+github.com/golangci/plugin-module-register v0.1.1/go.mod h1:TTpqoB6KkwOJMV8u7+NyXMrkwwESJLOkfl9TxR1DGFc=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/klauspost/compress v1.17.6 h1:60eq2E/jlfwQXtvZEeBUYADs+BwKBWURIY+Gj2eRGjI=


### PR DESCRIPTION
Since golangci-lint v1.57.0, it offers a new [Module Plugin System](https://golangci-lint.run/plugins/module-plugins/), which is a lot more robust and easier to use than the plain Go plugin system. This unlocks the possibility of running NilAway in golangci-lint as a private linter.

This PR implements the require interface for the module plugin system for golangci-lint and updates the README to list the instructions on how to run NilAway with golangci-lint.

With this, our official recommendation to run NilAway would be to either run it via golangci-lint or bazel/nogo, the standalone checker is only provided for evaluation purposes due to its limitations (lack of fact caching, lack of support for conditional build etc.).

This also closes #175 since it is no longer required.

We should switch our own linting task and CI to run NilAway via golangci-lint as well, but that will happen in follow-up PRs.