### PR TITLE
Fix integration tests to not group error messages

### DIFF
--- a/testdata/integration/contracts/downstream/downstream.go
+++ b/testdata/integration/contracts/downstream/downstream.go
@@ -28,5 +28,7 @@ func GiveUpstreamNil() {
 func GiveUpstreamNonnil() {
 	a := 1
 	r := upstream.NonnilToNonnil(&a)
-	print(*r) // Safe!
+	// TODO: FP: this should be safe due to the contract. We should remove this once contract
+	//  support is fixed in NilAway.
+	print(*r) //want "result 0 of `NonnilToNonnil\(\)` dereferenced"
 }

--- a/tools/cmd/integration-test/standalone.go
+++ b/tools/cmd/integration-test/standalone.go
@@ -34,7 +34,12 @@ func (d *StandaloneDriver) Run(dir string) (map[Position]string, error) {
 	}
 
 	// Run the NilAway binary on the integration test project, with redirects to an internal buffer.
-	cmd := exec.Command(filepath.Join("..", "..", "bin", "nilaway"), "-json", "-pretty-print=false", "./...")
+	cmd := exec.Command(filepath.Join("..", "..", "bin", "nilaway"),
+		"-json", "-pretty-print=false",
+		// Disable group error messages to make the output accurate for comparisons.
+		"-group-error-messages=false",
+		"./...",
+	)
 	cmd.Dir = dir
 	out, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
This PR disables the error messages when running integration tests of NilAway (against different analyzer drivers) such that the output is more accurate for comparisons.

As part of this change, we fixed one want string in testdata where one false positive was silently ignored due to grouping. It is now properly marked as FP and a TODO is added to remove it once cross-package contract support is fixed in NilAway.