### PR TITLE
Remove util.TypeOf helper function

### DIFF
--- a/assertion/function/assertiontree/backprop_util.go
+++ b/assertion/function/assertiontree/backprop_util.go
@@ -414,7 +414,7 @@ func typeIsString(t types.Type) bool {
 // nilable(result 0)
 func exprAsConsumedByAssignment(rootNode *RootAssertionNode, expr ast.Node) *annotation.ConsumeTrigger {
 	if exprType, ok := expr.(*ast.IndexExpr); ok {
-		t := util.TypeOf(rootNode.Pass(), exprType.X)
+		t := rootNode.Pass().TypesInfo.TypeOf(exprType.X)
 		if util.TypeIsDeeplyMap(t) {
 			return &annotation.ConsumeTrigger{
 				Annotation: &annotation.MapWrittenTo{ConsumeTriggerTautology: &annotation.ConsumeTriggerTautology{}},
@@ -828,7 +828,7 @@ func addReturnConsumers(rootNode *RootAssertionNode, node *ast.ReturnStmt, expr 
 	//   return s  // <-- track shallow and deep nilability of `s` here
 	// }
 	// ```
-	if util.TypeIsDeep(util.TypeOf(rootNode.Pass(), expr)) {
+	if util.TypeIsDeep(rootNode.Pass().TypesInfo.TypeOf(expr)) {
 		producer := &annotation.ProduceTrigger{
 			Annotation: exprAsDeepProducer(rootNode, expr),
 			Expr:       expr,

--- a/assertion/function/assertiontree/parse_expr_producer.go
+++ b/assertion/function/assertiontree/parse_expr_producer.go
@@ -413,8 +413,7 @@ func (r *RootAssertionNode) ParseExprAsProducer(expr ast.Expr, doNotTrack bool) 
 		}
 		if expr.Op == token.AND {
 			// we treat a struct object pointer (e.g., &A{}) and struct object (e.g., A{}) identically for creating field producers
-			t := util.TypeOf(r.Pass(), expr.X)
-			if s := util.TypeAsDeeplyStruct(t); s != nil {
+			if s := util.TypeAsDeeplyStruct(r.Pass().TypesInfo.TypeOf(expr.X)); s != nil {
 				return r.ParseExprAsProducer(expr.X, doNotTrack)
 			}
 		}

--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -703,7 +703,7 @@ func (r *RootAssertionNode) AddComputation(expr ast.Expr) {
 					//   foo(s) // <-- track shallow and deep nilability of `s` here
 					// }
 					// ```
-					if util.TypeIsDeep(util.TypeOf(r.Pass(), arg)) {
+					if util.TypeIsDeep(r.Pass().TypesInfo.TypeOf(arg)) {
 						deepProducer := &annotation.ProduceTrigger{
 							Annotation: exprAsDeepProducer(r, arg),
 							Expr:       arg,
@@ -802,9 +802,8 @@ func (r *RootAssertionNode) AddComputation(expr ast.Expr) {
 			if util.TypeIsDeeplyPtr(recv.Type()) { // Check 2: receiver is a pointer receiver
 				conf := r.Pass().ResultOf[config.Analyzer].(*config.Config)
 				if conf.IsPkgInScope(funcObj.Pkg()) { // Check 3: invoked method is in scope
-					t := util.TypeOf(r.Pass(), expr.X)
 					// Here, `t` can only be of type interface, struct, or named, of which we only support for struct and named types.
-					if !util.TypeIsDeeplyInterface(t) { // Check 4: invoking expression (caller) is of a non-interface type (e.g., struct or named)
+					if !util.TypeIsDeeplyInterface(r.Pass().TypesInfo.TypeOf(expr.X)) { // Check 4: invoking expression (caller) is of a non-interface type (e.g., struct or named)
 						allowNilable = true
 						// We are in the special case of supporting nilable receivers! Can be nilable depending on declaration annotation/inferred nilability.
 						r.AddConsumption(&annotation.ConsumeTrigger{

--- a/assertion/global/globalvarinit.go
+++ b/assertion/global/globalvarinit.go
@@ -68,7 +68,7 @@ func getGlobalConsumers(pass *analysis.Pass, valspec *ast.ValueSpec) []*annotati
 
 	for i, name := range valspec.Names {
 		// Types that are not nilable are eliminated here
-		if !util.TypeBarsNilness(util.TypeOf(pass, name)) && !util.IsEmptyExpr(name) {
+		if !util.TypeBarsNilness(pass.TypesInfo.TypeOf(name)) && !util.IsEmptyExpr(name) {
 			v := pass.TypesInfo.ObjectOf(name).(*types.Var)
 			consumers[i] = &annotation.ConsumeTrigger{
 				Annotation: &annotation.GlobalVarAssign{

--- a/util/util.go
+++ b/util/util.go
@@ -176,11 +176,6 @@ func UnwrapPtr(t types.Type) types.Type {
 	return t
 }
 
-// TypeOf returns the type of the passed AST expression
-func TypeOf(pass *analysis.Pass, expr ast.Expr) types.Type {
-	return pass.TypesInfo.TypeOf(expr)
-}
-
 // FuncIdentFromCallExpr return a function identified from a call expression, nil otherwise
 // nilable(result 0)
 func FuncIdentFromCallExpr(expr *ast.CallExpr) *ast.Ident {
@@ -242,7 +237,7 @@ func IsSliceAppendCall(node *ast.CallExpr, pass *analysis.Pass) (*types.Slice, b
 	if funcName, ok := node.Fun.(*ast.Ident); ok {
 		if declObj := pass.TypesInfo.Uses[funcName]; declObj != nil {
 			if declObj.String() == "builtin append" {
-				if sliceType, ok := TypeOf(pass, node.Args[0]).(*types.Slice); ok {
+				if sliceType, ok := pass.TypesInfo.TypeOf(node.Args[0]).(*types.Slice); ok {
 					return sliceType, true
 				}
 			}


### PR DESCRIPTION
This PR simply removes the helper function `util.TypeOf`. Although it shortens the call from `pass.TypesInfo.TypeOf`, it increases the cognitive load such that we do not know which we should use in NilAway's codebase and we don't know if `util.TypeOf` has any special handling (it doesn't!). Moreover, we're using a mixture of these two functionally-identical expressions in our codebase.

Removal of such a helper function reduces confusions and helps maintainability.