### PR TITLE
Remove ErrorOnNilableMap handling

### DIFF
--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -526,18 +526,6 @@ func (r *RootAssertionNode) consumeIndexExpr(expr ast.Expr) {
 			Guards:     util.NoGuards(),
 		})
 	}
-
-	// reads of nilable maps should not necessarily produce errors - the flag config.ErrorOnNilableMapRead
-	// encodes this optionality and is currently set to false
-	if config.ErrorOnNilableMapRead && util.TypeIsDeeplyMap(t) {
-		r.AddConsumption(&annotation.ConsumeTrigger{
-			Annotation: &annotation.MapAccess{ConsumeTriggerTautology: &annotation.ConsumeTriggerTautology{}},
-			Expr:       expr,
-			Guards:     util.NoGuards(),
-		})
-	}
-	// there are some weird types that can show up here (*internal/abi.IntArgRegBitmap for example)
-	// so don't error out if we don't recognize the type just no-op
 }
 
 // AddComputation takes the knowledge that the expression expr has to be computed to generate any necessary assertions to

--- a/config/const.go
+++ b/config/const.go
@@ -25,11 +25,6 @@ package config
 // to lower values, making it a good compromise for precise results.
 const StableRoundLimit = 5
 
-// ErrorOnNilableMapRead configures whether reading from nil maps should be considered an error.
-// Since Go does not panic on this, right now we do not interpret it as one, but this could be
-// considered undesirable behavior and worth catching in the future.
-const ErrorOnNilableMapRead = false
-
 // NilAwayNoInferString is the string that may be inserted into the docstring for a package to prevent
 // NilAway from inferring the annotations for that package - this is useful for unit tests
 const NilAwayNoInferString = "<nilaway no inference>"


### PR DESCRIPTION
Reading from a nil map does not really panic and is actually used quite frequently in Go. When NilAway was initially developed we added a feature that errs when a nilable map is accessed, and guard it under an internal feature flag for us to see more data points. Now that NilAway is more mature and we have seen more real world examples, this PR removes such handling and the stale feature flag.