### PR TITLE
Separate the preprocess into a standalone package

### DIFF
--- a/assertion/function/assertiontree/backprop.go
+++ b/assertion/function/assertiontree/backprop.go
@@ -26,6 +26,7 @@ import (
 	"slices"
 
 	"go.uber.org/nilaway/annotation"
+	"go.uber.org/nilaway/assertion/function/preprocess"
 	"go.uber.org/nilaway/config"
 	"go.uber.org/nilaway/util"
 	"golang.org/x/tools/go/analysis"
@@ -823,7 +824,10 @@ func BackpropAcrossFunc(
 ) ([]annotation.FullTrigger, int, int, error) {
 	// We transform the CFG to have it reflect the implicit control flow that happens
 	// inside short-circuiting boolean expressions.
-	graph = preprocess(graph, functionContext.funcDecl, functionContext.pass)
+	preprocessor := preprocess.New(pass)
+	graph = preprocessor.CFG(graph, functionContext.funcDecl)
+
+	// Generate rick check effects.
 	richCheckBlocks, exprNonceMap := genInitialRichCheckEffects(graph, functionContext)
 	richCheckBlocks = propagateRichChecks(graph, richCheckBlocks)
 	blocks, preprocessing := blocksAndPreprocessingFromCFG(pass, graph, richCheckBlocks)

--- a/assertion/function/preprocess/preprocessor.go
+++ b/assertion/function/preprocess/preprocessor.go
@@ -1,0 +1,29 @@
+//  Copyright (c) 2024 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package preprocess hosts preprocessing logic for the input (e.g., CFGs etc.) to make it more
+// amenable to analysis.
+package preprocess
+
+import "golang.org/x/tools/go/analysis"
+
+// Preprocessor handles different preprocessing logic for different types of input.
+type Preprocessor struct {
+	pass *analysis.Pass
+}
+
+// New returns a new Preprocessor.
+func New(pass *analysis.Pass) *Preprocessor {
+	return &Preprocessor{pass: pass}
+}


### PR DESCRIPTION
This PR separates the CFG preprocessing logic out of the enormous `assertiontree` package for better code organization.