### PR TITLE
Refine the handling of pointers in `TypeAsDeepType`

### DIFF
--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -498,12 +498,7 @@ func (r *RootAssertionNode) AddGuardMatch(expr ast.Expr, behavior GuardMatchBeha
 	case ContinueTracking:
 		for i, consumer := range consumers {
 			if consumer.Guards.Contains(guard) && !consumer.GuardMatched {
-				consumers[i] = &annotation.ConsumeTrigger{
-					Annotation:   consumer.Annotation,
-					Expr:         consumer.Expr,
-					Guards:       consumer.Guards,
-					GuardMatched: true,
-				}
+				consumers[i].GuardMatched = true
 			}
 		}
 	case ProduceAsNonnil:

--- a/assertion/function/testdata/src/go.uber.org/backprop/fixpoint.go
+++ b/assertion/function/testdata/src/go.uber.org/backprop/fixpoint.go
@@ -141,3 +141,23 @@ func testContract() { // expect_fixpoint: 2 1 2
 	b1 := foo(a1)
 	print(*b1)
 }
+
+func foo2(a *A) *A { // expect_fixpoint: 2 1 16
+	if a == nil {
+		return nil
+	}
+	return a.aptr
+}
+
+func testContract2() { // expect_fixpoint: 2 1 9
+	b1 := foo2(&A{})
+	print(*b1)
+}
+
+type myString []*string
+
+// nilable(s[])
+func (s *myString) testNamedType() { // expect_fixpoint: 2 1 3
+	x := *s
+	_ = *x[0]
+}

--- a/assertion/function/testdata/src/go.uber.org/backprop/fixpoint.go
+++ b/assertion/function/testdata/src/go.uber.org/backprop/fixpoint.go
@@ -142,14 +142,14 @@ func testContract() { // expect_fixpoint: 2 1 2
 	print(*b1)
 }
 
-func foo2(a *A) *A { // expect_fixpoint: 2 1 16
+func foo2(a *A) *A { // expect_fixpoint: 2 1 15
 	if a == nil {
 		return nil
 	}
 	return a.aptr
 }
 
-func testContract2() { // expect_fixpoint: 2 1 9
+func testContract2() { // expect_fixpoint: 2 1 8
 	b1 := foo2(&A{})
 	print(*b1)
 }

--- a/assertion/function/testdata/src/go.uber.org/backprop/fixpoint.go
+++ b/assertion/function/testdata/src/go.uber.org/backprop/fixpoint.go
@@ -161,3 +161,12 @@ func (s *myString) testNamedType() { // expect_fixpoint: 2 1 3
 	x := *s
 	_ = *x[0]
 }
+
+func testNestedPointer() { // expect_fixpoint: 4 2 4
+	a1 := &A{}
+	for i := 0; i < 10; i++ {
+		a2 := &a1
+		(*a2).ptr = new(int)
+		*a2 = nil
+	}
+}

--- a/assertion/function/testdata/src/go.uber.org/backprop/fixpoint.go
+++ b/assertion/function/testdata/src/go.uber.org/backprop/fixpoint.go
@@ -125,3 +125,19 @@ func testNonBuiltinNestedIndex(msgSet []*MessageBlock) { // expect_fixpoint: 3 1
 		_ = *msgBlock.Messages()[len(msgBlock.Messages())-1]
 	}
 }
+
+// test for validating that only the necessary number of triggers are created, and
+// no extra triggers (e.g., deep triggers) are created.
+
+func foo(x *int) *int { // expect_fixpoint: 2 1 1
+	if x == nil {
+		return nil
+	}
+	return new(int)
+}
+
+func testContract() { // expect_fixpoint: 2 1 2
+	a1 := new(int)
+	b1 := foo(a1)
+	print(*b1)
+}

--- a/util/util.go
+++ b/util/util.go
@@ -63,8 +63,9 @@ func TypeAsDeepType(t types.Type) (types.Type, bool) {
 	case *types.Chan:
 		return t.Elem(), true
 	case *types.Pointer:
-		// Only consider pointers to deep types (e.g., `var x *[]int`) as deep type, not pointers to basic types (e.g., `var x *int`)
-		if _, ok := t.Elem().(*types.Basic); !ok {
+		// Only consider pointers to deep types (e.g., `var x *[]int`) as deep type,
+		// not pointers to basic types (e.g., `var x *int`) or struct types (e.g., `var x *S`)
+		if _, ok := t.Elem().(*types.Basic); !ok && TypeAsDeeplyStruct(t.Elem()) == nil {
 			return t.Elem(), true
 		}
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -63,10 +63,9 @@ func TypeAsDeepType(t types.Type) (types.Type, bool) {
 	case *types.Chan:
 		return t.Elem(), true
 	case *types.Pointer:
-		if _, ok := t.Elem().(*types.Basic); ok {
-			return nil, false
+		if _, ok := t.Elem().(*types.Basic); !ok {
+			return t.Elem(), true
 		}
-		return t.Elem(), true
 	}
 	return nil, false
 }

--- a/util/util.go
+++ b/util/util.go
@@ -42,8 +42,7 @@ var BuiltinAppend = types.Universe.Lookup("append")
 // BuiltinNew is the builtin "new" function object.
 var BuiltinNew = types.Universe.Lookup("new")
 
-// TypeIsDeep checks if a type is an expression that directly admits a deep nilability annotation - deep
-// nilability annotations on all other types are ignored
+// TypeIsDeep checks if a type is an expression that admits deep nilability, such as maps, slices, arrays, etc.
 func TypeIsDeep(t types.Type) bool {
 	switch t := t.(type) {
 	case *types.Slice, *types.Array, *types.Map, *types.Chan:

--- a/util/util.go
+++ b/util/util.go
@@ -63,6 +63,7 @@ func TypeAsDeepType(t types.Type) (types.Type, bool) {
 	case *types.Chan:
 		return t.Elem(), true
 	case *types.Pointer:
+		// Only consider pointers to deep types (e.g., `var x *[]int`) as deep type, not pointers to basic types (e.g., `var x *int`)
 		if _, ok := t.Elem().(*types.Basic); !ok {
 			return t.Elem(), true
 		}

--- a/util/util.go
+++ b/util/util.go
@@ -65,7 +65,7 @@ func TypeAsDeepType(t types.Type) (types.Type, bool) {
 	case *types.Pointer:
 		// Only consider pointers to deep types (e.g., `var x *[]int`) as deep type,
 		// not pointers to basic types (e.g., `var x *int`) or struct types (e.g., `var x *S`)
-		if _, ok := t.Elem().(*types.Basic); !ok && TypeAsDeeplyStruct(t.Elem()) == nil {
+		if _, ok := t.Elem().(*types.Basic); !ok && TypeAsDeeplyStruct(t.Underlying()) == nil {
 			return t.Elem(), true
 		}
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -116,16 +116,6 @@ func TypeIsDeeplyPtr(t types.Type) bool {
 	return false
 }
 
-func TypeAsDeeplyPtr(t types.Type) (*types.Pointer, bool) {
-	if p, ok := t.(*types.Pointer); ok {
-		return p, true
-	}
-	if t, ok := t.(*types.Named); ok {
-		return TypeAsDeeplyPtr(t.Underlying())
-	}
-	return nil, false
-}
-
 // TypeIsDeeplyChan returns true if `t` is of channel type, including
 // transitively through Named types
 func TypeIsDeeplyChan(t types.Type) bool {

--- a/util/util.go
+++ b/util/util.go
@@ -63,6 +63,9 @@ func TypeAsDeepType(t types.Type) (types.Type, bool) {
 	case *types.Chan:
 		return t.Elem(), true
 	case *types.Pointer:
+		if _, ok := t.Elem().(*types.Basic); ok {
+			return nil, false
+		}
 		return t.Elem(), true
 	}
 	return nil, false


### PR DESCRIPTION
This PR refines the handling of `*types.Pointer` in `TypeAsDeepType` to only consider a pointer type deep if its underlying elements are of a deep type. The implication of always considering a pointer deep was that for type like `var x *int; foo(x)`, unnecessary deep triggers were being created. The change in this PR reduces the creation of these redundant triggers.