### PR TITLE
Support for "always safe" for error returning and ok-form functions

### DIFF
--- a/accumulation/analyzer.go
+++ b/accumulation/analyzer.go
@@ -186,9 +186,10 @@ func checkErrors(triggers []annotation.FullTrigger, annMap annotation.Map, diagn
 	// Delete all "always safe" special handlers, since they are not meant to be tested for the no infer case
 	finalTriggers := make([]annotation.FullTrigger, 0, len(filteredTriggers))
 	for _, trigger := range filteredTriggers {
-		if _, ok := trigger.Consumer.Annotation.(*annotation.UseAsReturnForAlwaysSafePath); !ok {
-			finalTriggers = append(finalTriggers, trigger)
+		if c, ok := trigger.Consumer.Annotation.(*annotation.UseAsReturn); ok && c.IsTrackingAlwaysSafe {
+			continue
 		}
+		finalTriggers = append(finalTriggers, trigger)
 	}
 
 	for _, trigger := range finalTriggers {

--- a/accumulation/analyzer.go
+++ b/accumulation/analyzer.go
@@ -183,7 +183,15 @@ func checkErrors(triggers []annotation.FullTrigger, annMap annotation.Map, diagn
 		},
 	)
 
+	// Delete all "always safe" special handlers, since they are not meant to be tested for the no infer case
+	finalTriggers := make([]annotation.FullTrigger, 0, len(filteredTriggers))
 	for _, trigger := range filteredTriggers {
+		if _, ok := trigger.Consumer.Annotation.(*annotation.UseAsReturnForAlwaysSafePath); !ok {
+			finalTriggers = append(finalTriggers, trigger)
+		}
+	}
+
+	for _, trigger := range finalTriggers {
 		// Skip checking any full triggers we created by duplicating from contracted functions
 		// to the caller function.
 		if !trigger.CreatedFromDuplication && trigger.Check(annMap) {

--- a/annotation/consume_trigger.go
+++ b/annotation/consume_trigger.go
@@ -1092,8 +1092,9 @@ func DuplicateReturnConsumer(t *ConsumeTrigger, location token.Position) *Consum
 // used for functions with contracts since we need to duplicate the sites for context sensitivity.
 type UseAsReturn struct {
 	*TriggerIfNonNil
-	IsNamedReturn bool
-	RetStmt       *ast.ReturnStmt
+	IsNamedReturn        bool
+	IsTrackingAlwaysSafe bool
+	RetStmt              *ast.ReturnStmt
 }
 
 // equals returns true if the passed ConsumingAnnotationTrigger is equal to this one
@@ -1101,6 +1102,7 @@ func (u *UseAsReturn) equals(other ConsumingAnnotationTrigger) bool {
 	if other, ok := other.(*UseAsReturn); ok {
 		return u.TriggerIfNonNil.equals(other.TriggerIfNonNil) &&
 			u.IsNamedReturn == other.IsNamedReturn &&
+			u.IsTrackingAlwaysSafe == other.IsTrackingAlwaysSafe &&
 			u.RetStmt == other.RetStmt
 	}
 	return false
@@ -1870,76 +1872,6 @@ func (f FldEscapePrestring) String() string {
 	sb.WriteString(fmt.Sprintf("field `%s` escaped out of our analysis scope (presumed nilable)", f.FieldName))
 	sb.WriteString(f.AssignmentStr)
 	return sb.String()
-}
-
-// UseAsReturnForAlwaysSafePath is when a value flows to a point where it is returned from a rich check effect function, namely,
-// error retuning functions and ok-form functions. This consumer is used at the inference stage to determine if the
-// rich check effect function is always safe to return a non-nil value.
-type UseAsReturnForAlwaysSafePath struct {
-	*TriggerIfNonNil
-
-	IsNamedReturn bool
-	RetStmt       *ast.ReturnStmt
-}
-
-// equals returns true if the passed ConsumingAnnotationTrigger is equal to this one
-func (u *UseAsReturnForAlwaysSafePath) equals(other ConsumingAnnotationTrigger) bool {
-	if other, ok := other.(*UseAsReturnForAlwaysSafePath); ok {
-		return u.TriggerIfNonNil.equals(other.TriggerIfNonNil) &&
-			u.IsNamedReturn == other.IsNamedReturn &&
-			u.RetStmt == other.RetStmt
-	}
-	return false
-}
-
-// Copy returns a deep copy of this ConsumingAnnotationTrigger
-func (u *UseAsReturnForAlwaysSafePath) Copy() ConsumingAnnotationTrigger {
-	copyConsumer := *u
-	copyConsumer.TriggerIfNonNil = u.TriggerIfNonNil.Copy().(*TriggerIfNonNil)
-	return &copyConsumer
-}
-
-// Prestring returns this UseAsNonErrorRetDependentOnErrorRetNilability as a Prestring
-func (u *UseAsReturnForAlwaysSafePath) Prestring() Prestring {
-	retAnn := u.Ann.(*RetAnnotationKey)
-	return UseAsReturnForAlwaysSafePathPrestring{
-		retAnn.FuncDecl.Name(),
-		retAnn.RetNum,
-		retAnn.FuncDecl.Type().(*types.Signature).Results().At(retAnn.RetNum).Name(),
-		retAnn.FuncDecl.Type().(*types.Signature).Results().Len() - 1,
-		u.IsNamedReturn,
-		u.assignmentFlow.String(),
-	}
-}
-
-// UseAsReturnForAlwaysSafePathPrestring is a Prestring storing the needed information to compactly encode a UseAsReturnForAlwaysSafePath
-type UseAsReturnForAlwaysSafePathPrestring struct {
-	FuncName      string
-	RetNum        int
-	RetName       string
-	ErrRetNum     int
-	IsNamedReturn bool
-	AssignmentStr string
-}
-
-func (u UseAsReturnForAlwaysSafePathPrestring) String() string {
-	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("returned from `%s()`", u.FuncName))
-	if u.IsNamedReturn {
-		sb.WriteString(fmt.Sprintf(" via named return `%s`", u.RetName))
-	} else {
-		sb.WriteString(fmt.Sprintf(" in position %d", u.RetNum))
-	}
-	sb.WriteString(u.AssignmentStr)
-	return sb.String()
-}
-
-// overriding position value to point to the raw return statement, which is the source of the potential error
-func (u *UseAsReturnForAlwaysSafePath) customPos() (token.Pos, bool) {
-	if u.IsNamedReturn {
-		return u.RetStmt.Pos(), true
-	}
-	return 0, false
 }
 
 // UseAsNonErrorRetDependentOnErrorRetNilability is when a value flows to a point where it is returned from an error returning function

--- a/annotation/consume_trigger.go
+++ b/annotation/consume_trigger.go
@@ -1872,7 +1872,9 @@ func (f FldEscapePrestring) String() string {
 	return sb.String()
 }
 
-// UseAsReturnForAlwaysSafePath is when a value flows to a point where it is returned from an error returning function
+// UseAsReturnForAlwaysSafePath is when a value flows to a point where it is returned from a rich check effect function, namely,
+// error retuning functions and ok-form functions. This consumer is used at the inference stage to determine if the
+// rich check effect function is always safe to return a non-nil value.
 type UseAsReturnForAlwaysSafePath struct {
 	*TriggerIfNonNil
 

--- a/annotation/consume_trigger_test.go
+++ b/annotation/consume_trigger_test.go
@@ -59,7 +59,6 @@ var initStructsConsumingAnnotationTrigger = []any{
 	&UseAsErrorRetWithNilabilityUnknown{TriggerIfNonNil: &TriggerIfNonNil{Ann: newMockKey()}},
 	&ArgPassDeep{TriggerIfDeepNonNil: &TriggerIfDeepNonNil{Ann: newMockKey()}},
 	&UseAsReturnDeep{TriggerIfDeepNonNil: &TriggerIfDeepNonNil{Ann: newMockKey()}},
-	&UseAsReturnForAlwaysSafePath{TriggerIfNonNil: &TriggerIfNonNil{Ann: newMockKey()}},
 }
 
 // ConsumingAnnotationTriggerEqualsTestSuite tests for the `equals` method of all the structs that implement

--- a/annotation/consume_trigger_test.go
+++ b/annotation/consume_trigger_test.go
@@ -59,6 +59,7 @@ var initStructsConsumingAnnotationTrigger = []any{
 	&UseAsErrorRetWithNilabilityUnknown{TriggerIfNonNil: &TriggerIfNonNil{Ann: newMockKey()}},
 	&ArgPassDeep{TriggerIfDeepNonNil: &TriggerIfDeepNonNil{Ann: newMockKey()}},
 	&UseAsReturnDeep{TriggerIfDeepNonNil: &TriggerIfDeepNonNil{Ann: newMockKey()}},
+	&UseAsReturnForAlwaysSafePath{TriggerIfNonNil: &TriggerIfNonNil{Ann: newMockKey()}},
 }
 
 // ConsumingAnnotationTriggerEqualsTestSuite tests for the `equals` method of all the structs that implement

--- a/annotation/produce_trigger.go
+++ b/annotation/produce_trigger.go
@@ -755,12 +755,15 @@ func (f FldReturnPrestring) String() string {
 // context sensitivity.
 type FuncReturn struct {
 	*TriggerIfNilable
+
+	IsFromRichCheckEffectFunc bool
 }
 
 // equals returns true if the passed ProducingAnnotationTrigger is equal to this one
 func (f *FuncReturn) equals(other ProducingAnnotationTrigger) bool {
 	if other, ok := other.(*FuncReturn); ok {
-		return f.TriggerIfNilable.equals(other.TriggerIfNilable)
+		return f.TriggerIfNilable.equals(other.TriggerIfNilable) &&
+			f.IsFromRichCheckEffectFunc == other.IsFromRichCheckEffectFunc
 	}
 	return false
 }

--- a/assertion/function/assertiontree/backprop.go
+++ b/assertion/function/assertiontree/backprop.go
@@ -237,13 +237,14 @@ func backpropAcrossReturn(rootNode *RootAssertionNode, node *ast.ReturnStmt) err
 						triggerAlwaysSafe := annotation.FullTrigger{
 							Producer: trigger.Producer,
 							Consumer: &annotation.ConsumeTrigger{
-								Annotation: &annotation.UseAsReturnForAlwaysSafePath{
+								Annotation: &annotation.UseAsReturn{
 									TriggerIfNonNil: &annotation.TriggerIfNonNil{
 										Ann: annotation.RetKeyFromRetNum(
 											rootNode.ObjectOf(rootNode.FuncNameIdent()).(*types.Func),
 											i,
 										)},
-									RetStmt: node,
+									RetStmt:              node,
+									IsTrackingAlwaysSafe: true,
 								},
 								Expr:         trigger.Consumer.Expr,
 								Guards:       trigger.Consumer.Guards,

--- a/assertion/function/assertiontree/backprop.go
+++ b/assertion/function/assertiontree/backprop.go
@@ -207,7 +207,7 @@ func backpropAcrossReturn(rootNode *RootAssertionNode, node *ast.ReturnStmt) err
 						isErrReturning := util.FuncIsErrReturning(funcObj)
 						isOkReturning := util.FuncIsOkReturning(funcObj)
 
-						rootNode.AddNewTriggers(annotation.FullTrigger{
+						trigger := annotation.FullTrigger{
 							Producer: &annotation.ProduceTrigger{
 								// since the value is being returned directly, only its shallow nilability
 								// matters (but deep would matter if we were enforcing correct variance)
@@ -230,7 +230,28 @@ func backpropAcrossReturn(rootNode *RootAssertionNode, node *ast.ReturnStmt) err
 								// interpreted as guarded
 								GuardMatched: isErrReturning || isOkReturning,
 							},
-						})
+						}
+
+						// This is a duplicate trigger for tracking "always safe" paths. The analysis of these triggers
+						// will be processed at the inference stage.
+						triggerAlwaysSafe := annotation.FullTrigger{
+							Producer: trigger.Producer,
+							Consumer: &annotation.ConsumeTrigger{
+								Annotation: &annotation.UseAsReturnForAlwaysSafePath{
+									TriggerIfNonNil: &annotation.TriggerIfNonNil{
+										Ann: annotation.RetKeyFromRetNum(
+											rootNode.ObjectOf(rootNode.FuncNameIdent()).(*types.Func),
+											i,
+										)},
+									RetStmt: node,
+								},
+								Expr:         trigger.Consumer.Expr,
+								Guards:       trigger.Consumer.Guards,
+								GuardMatched: trigger.Consumer.GuardMatched,
+							},
+						}
+
+						rootNode.AddNewTriggers(trigger, triggerAlwaysSafe)
 					}
 				}
 				rootNode.AddComputation(call)

--- a/assertion/function/assertiontree/backprop_util.go
+++ b/assertion/function/assertiontree/backprop_util.go
@@ -268,6 +268,9 @@ func handleErrorReturns(rootNode *RootAssertionNode, retStmt *ast.ReturnStmt, re
 	errRetExpr := results[errRetIndex]     // n-th expression
 	nonErrRetExpr := results[:errRetIndex] // n-1 expressions
 
+	// default tracking to support potential "always safe" cases
+	createReturnConsumersForAlwaysSafe(rootNode, nonErrRetExpr, retStmt, isNamedReturn)
+
 	// check if the error return is at all guarding any nilable returns, such as pointers, maps, and slices
 	if isErrorReturnNil(rootNode, errRetExpr) {
 		// if error is the only return expression in the statement, then create a consumer for it, else create consumers for the non-error return expressions
@@ -329,6 +332,9 @@ func handleBooleanReturns(rootNode *RootAssertionNode, retStmt *ast.ReturnStmt, 
 		return false
 	}
 
+	// default tracking to support potential "always safe" cases
+	createReturnConsumersForAlwaysSafe(rootNode, nMinusOneRetExpr, retStmt, isNamedReturn)
+
 	// If return is "true", then track its n-1 returns. Create return consume triggers for all n-1 return expressions.
 	// If return is "false", then do nothing, since we don't track boolean values.
 	if val {
@@ -366,6 +372,31 @@ func createGeneralReturnConsumers(rootNode *RootAssertionNode, results []ast.Exp
 				IsNamedReturn: isNamedReturn,
 				RetStmt:       retStmt},
 			Expr:   results[i],
+			Guards: util.NoGuards(),
+		})
+	}
+}
+
+// createReturnConsumersForAlwaysSafe creates return consumers for the non-return expressions in the return statement
+// for tracking potential "always safe" cases
+func createReturnConsumersForAlwaysSafe(rootNode *RootAssertionNode, nonErrResults []ast.Expr, retStmt *ast.ReturnStmt, isNamedReturn bool) {
+	for i := range nonErrResults {
+		// don't do anything if the expression is a blank identifier ("_")
+		if util.IsEmptyExpr(nonErrResults[i]) {
+			continue
+		}
+
+		rootNode.AddConsumption(&annotation.ConsumeTrigger{
+			Annotation: &annotation.UseAsReturnForAlwaysSafePath{
+				TriggerIfNonNil: &annotation.TriggerIfNonNil{
+					Ann: &annotation.RetAnnotationKey{
+						FuncDecl: rootNode.FuncObj(),
+						RetNum:   i,
+					},
+				},
+				IsNamedReturn: isNamedReturn,
+				RetStmt:       retStmt},
+			Expr:   nonErrResults[i],
 			Guards: util.NoGuards(),
 		})
 	}

--- a/assertion/function/assertiontree/backprop_util.go
+++ b/assertion/function/assertiontree/backprop_util.go
@@ -387,15 +387,16 @@ func createReturnConsumersForAlwaysSafe(rootNode *RootAssertionNode, nonErrResul
 		}
 
 		rootNode.AddConsumption(&annotation.ConsumeTrigger{
-			Annotation: &annotation.UseAsReturnForAlwaysSafePath{
+			Annotation: &annotation.UseAsReturn{
 				TriggerIfNonNil: &annotation.TriggerIfNonNil{
 					Ann: &annotation.RetAnnotationKey{
 						FuncDecl: rootNode.FuncObj(),
 						RetNum:   i,
 					},
 				},
-				IsNamedReturn: isNamedReturn,
-				RetStmt:       retStmt},
+				IsNamedReturn:        isNamedReturn,
+				IsTrackingAlwaysSafe: true,
+				RetStmt:              retStmt},
 			Expr:   nonErrResults[i],
 			Guards: util.NoGuards(),
 		})

--- a/assertion/function/assertiontree/parse_expr_producer.go
+++ b/assertion/function/assertiontree/parse_expr_producer.go
@@ -481,6 +481,7 @@ func (r *RootAssertionNode) getFuncReturnProducers(ident *ast.Ident, expr *ast.C
 						// such as "error-nonnil" or "always-nonnil"
 						NeedsGuard: (isErrReturning || isOkReturning) && i != numResults-1,
 					},
+					IsFromRichCheckEffectFunc: isErrReturning || isOkReturning,
 				},
 				Expr: expr,
 			},

--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -269,8 +269,7 @@ func (r *RootAssertionNode) AddConsumption(consumer *annotation.ConsumeTrigger) 
 					Consumer: consumer,
 				})
 			}
-
-			return // expr is not trackable, but cannot be nil, so do nothing
+			return
 		}
 		if len(producers) != 1 {
 			panic("multiply-returning function call was passed to AddConsumption")

--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -258,7 +258,9 @@ func (r *RootAssertionNode) AddConsumption(consumer *annotation.ConsumeTrigger) 
 	path, producers := r.ParseExprAsProducer(consumer.Expr, false)
 	if path == nil { // expr is not trackable
 		if producers == nil {
-			if _, ok := consumer.Annotation.(*annotation.UseAsReturnForAlwaysSafePath); ok {
+			// Here we can infer that the expression is non-nil by definition. Instead of ignoring creation of a trigger,
+			// particularly for always safe tracking, we create a trigger with ProduceTriggerNever.
+			if c, ok := consumer.Annotation.(*annotation.UseAsReturn); ok && c.IsTrackingAlwaysSafe {
 				r.AddNewTriggers(annotation.FullTrigger{
 					Producer: &annotation.ProduceTrigger{
 						Annotation: &annotation.ProduceTriggerNever{},

--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -258,6 +258,16 @@ func (r *RootAssertionNode) AddConsumption(consumer *annotation.ConsumeTrigger) 
 	path, producers := r.ParseExprAsProducer(consumer.Expr, false)
 	if path == nil { // expr is not trackable
 		if producers == nil {
+			if _, ok := consumer.Annotation.(*annotation.UseAsReturnForAlwaysSafePath); ok {
+				r.AddNewTriggers(annotation.FullTrigger{
+					Producer: &annotation.ProduceTrigger{
+						Annotation: &annotation.ProduceTriggerNever{},
+						Expr:       consumer.Expr,
+					},
+					Consumer: consumer,
+				})
+			}
+
 			return // expr is not trackable, but cannot be nil, so do nothing
 		}
 		if len(producers) != 1 {

--- a/inference/engine.go
+++ b/inference/engine.go
@@ -217,14 +217,10 @@ func (e *Engine) ObservePackage(pkgFullTriggers []annotation.FullTrigger) {
 	}
 
 	// Filter out the triggers that are to be deleted.
-	var filteredPkgFullTriggers []annotation.FullTrigger
-	for i, t := range pkgFullTriggers {
-		if triggersToBeDeleted[i] {
-			continue
-		}
-		filteredPkgFullTriggers = append(filteredPkgFullTriggers, t)
-	}
-	pkgFullTriggers = filteredPkgFullTriggers
+	pkgFullTriggers = slices.DeleteFunc(pkgFullTriggers, func(t annotation.FullTrigger) bool {
+		index := slices.Index(pkgFullTriggers, t)
+		return triggersToBeDeleted[index]
+	})
 
 	// Separate out triggers with UseAsNonErrorRetDependentOnErrorRetNilability consumer from other triggers.
 	// This is needed since whether UseAsNonErrorRetDependentOnErrorRetNilability triggers should be fired

--- a/inference/engine.go
+++ b/inference/engine.go
@@ -180,10 +180,10 @@ func (e *Engine) mapGuardMissingAndReturnToFuncSite(triggers []annotation.FullTr
 // observeImplication. Before all assertions are sorted and handled thus, the annotations read for
 // the package are iterated over and observed via calls to observeSiteExplanation as a <Val>BecauseAnnotation.
 func (e *Engine) ObservePackage(pkgFullTriggers []annotation.FullTrigger) {
-	// As Step 1, we do a pre-analysis of "guard missing" triggers to verify their dereferences are always safe,
-	// and hence can be safely deleted. Specifically, this analyis of "always safe" paths is focussed on the rich check
-	// effect functions, namely error returning functions and ok-returning functions. The process is to find all
-	// guard missing triggers reaching a function return site, and then check if all the return triggers
+	// As Step 1, we do a pre-analysis of "guard missing" triggers to verify if their dereferences are always nil-safe,
+	// and hence can be deleted to not report a false positive error. Specifically, this analyis of "always safe" paths
+	// is focussed on the rich check effect functions, namely error returning functions and ok-returning functions.
+	// The process is to find all guard missing triggers reaching a function return site, and then check if all the return triggers
 	// to that function site are non-nil. If so, we can safely delete all the guard-missing triggers for this function site.
 	triggersToBeDeleted := make(map[int]bool)
 	mapSiteGuardMissing, mapSiteReturn := e.mapGuardMissingAndReturnToFuncSite(pkgFullTriggers)

--- a/nilaway_test.go
+++ b/nilaway_test.go
@@ -38,7 +38,7 @@ func TestNilAway(t *testing.T) {
 		patterns []string
 	}{
 		{name: "Inference", patterns: []string{"go.uber.org/inference"}},
-		{name: "Contracts", patterns: []string{"go.uber.org/contracts", "go.uber.org/contracts/namedtypes"}},
+		{name: "Contracts", patterns: []string{"go.uber.org/contracts", "go.uber.org/contracts/namedtypes", "go.uber.org/contracts/inference"}},
 		{name: "Testing", patterns: []string{"go.uber.org/testing"}},
 		{name: "ErrorReturn", patterns: []string{"go.uber.org/errorreturn", "go.uber.org/errorreturn/inference"}},
 		{name: "Maps", patterns: []string{"go.uber.org/maps"}},

--- a/testdata/src/go.uber.org/contracts/inference/userdefinedfunctions-with-inference.go
+++ b/testdata/src/go.uber.org/contracts/inference/userdefinedfunctions-with-inference.go
@@ -1,0 +1,167 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package contracts: This file tests the contract of "ok" form for user defined and standard library functions in
+// full inference mode.
+
+package inference
+
+var dummy bool
+
+const falseVal = false
+const trueVal = true
+
+// ***** below tests check the handling for "always safe" cases and their variants *****
+
+func retAlwaysNonnilPtrBool(i int) (*int, bool) {
+	switch i {
+	case 0:
+		return new(int), false
+	case 1:
+		return &i, trueVal
+	case 2:
+		return new(int), falseVal
+	}
+	return new(int), true
+}
+
+func retAlwaysNilPtrBool(i int) (*int, bool) {
+	switch i {
+	case 0:
+		return nil, false
+	case 1:
+		return nil, trueVal
+	case 2:
+		return nil, falseVal
+	}
+	return nil, true
+}
+
+func retSometimesNilPtrBool(i int) (*int, bool) {
+	switch i {
+	case 0:
+		return nil, false
+	case 1:
+		return nil, falseVal
+	case 2:
+		return new(int), trueVal
+	}
+	return new(int), true
+}
+
+func testAlwaysSafe(i int) {
+	switch i {
+	// always safe
+	case 0:
+		x, _ := retAlwaysNonnilPtrBool(i)
+		print(*x)
+	case 1:
+		if x, ok := retAlwaysNonnilPtrBool(i); ok {
+			print(*x)
+		}
+	case 2:
+		if x, ok := retAlwaysNonnilPtrBool(i); ok {
+			print(*x)
+		}
+	case 3:
+		x, _ := retAlwaysNonnilPtrBool(i)
+		y, _ := retAlwaysNonnilPtrBool(i)
+		print(*x)
+		print(*y)
+	case 4:
+		x, okx := retAlwaysNonnilPtrBool(i)
+		y, oky := retAlwaysNonnilPtrBool(i)
+
+		if oky {
+			print(*x)
+		}
+		if okx {
+			print(*y)
+		}
+
+	// always unsafe
+	case 5:
+		x, _ := retAlwaysNilPtrBool(i)
+		print(*x) //want "dereferenced"
+	case 6:
+		if x, ok := retAlwaysNilPtrBool(i); ok {
+			print(*x) //want "dereferenced"
+		}
+
+	// conditionally safe
+	case 7:
+		x, _ := retSometimesNilPtrBool(i)
+		print(*x) //want "dereferenced"
+	case 8:
+		if x, ok := retSometimesNilPtrBool(i); ok {
+			print(*x)
+		}
+	}
+}
+
+// Test always safe through multiple hops. Currently, we support only immediate function call for "always safe" tracking.
+// Hence, the below cases are expected to report errors.
+// TODO: add support for multiple hops to address the false positives
+
+func m1() (*int, bool) {
+	return m2()
+}
+
+func m2() (*int, bool) {
+	v, ok := m3()
+	if !ok {
+		// makes non-error return always non-nil
+		return new(int), false
+	}
+	y := *v + 1
+	return &y, true
+}
+
+func m3() (*int, bool) {
+	if dummy {
+		return nil, false
+	}
+	return new(int), true
+}
+
+type S struct {
+	f *int
+}
+
+func f1(i int) (*int, bool) {
+	switch i {
+	case 0:
+		// direct non-nil non-error return value
+		return new(int), false
+	case 1:
+		s := &S{f: new(int)}
+		// indirect non-nil non-error return value via a field read
+		return s.f, true
+	case 2:
+	}
+	// indirect non-nil non-error return value via a function return
+	return retAlwaysNonnilPtrBool(i)
+}
+
+func testAlwaysSafeMultipleHops() {
+	// TODO: call to m1() should be reported as always safe. This is a false positive since currently we are limiting the
+	//  "always safe" tracking to only immediate function call, not chained error returning function calls.
+	v1, _ := m1()
+	print(*v1) //want "dereferenced"
+
+	// TODO: call to f1() should be reported as always safe. This is a false positive since currently we are limiting the
+	// analysis of "return statements" to only the directly determinable cases (e.g., new(int), &S{}, NegativeNilCheck), not through multiple hops.
+	v2, _ := f1(0)
+	print(*v2) //want "dereferenced"
+}


### PR DESCRIPTION
This PR adds support for "always safe" case for rich check effect functions, namely error returning functions and ok-form functions.

The support for always safe tracking is currently limited to: 

1. directly determinable cases of "non-nil" return
```
      (a) return &S{}, errors.New(...)  // supported
      (b) return new(S), errors.New(...)  // supported
      (c) if s != nil {
               return s, errors.New(...)  // supported
          }
  
      (d) return getS(), errors.New(...)  // not supported
      (e) return x.y.z.f, errors.New(...)   // not supported
```

2. immediate function call only
```
func errRetFunc() (*S, error) {
      return &S{}, errors.New(...)
}

func wrapErrRetFunc() (*S, error) {
      return errRetFunc()
}

func test1() {
       // supported
       v, _ := errRetFunc()    // immediate function call, supported
       _ = *v

       // not supported
       v, _ := wrapErrRetFunc()  // multiple hops, not supported
       _ = *v
}
```