### PR TITLE
Better support json format

### DIFF
--- a/cmd/nilaway/main.go
+++ b/cmd/nilaway/main.go
@@ -132,6 +132,5 @@ func main() {
 	}
 	flag.StringVar(&_includeErrorsInFiles, "include-errors-in-files", wd, "A comma-separated list of file prefixes to report errors, default is current working directory.")
 	flag.StringVar(&_excludeErrorsInFiles, "exclude-errors-in-files", "", "A comma-separated list of file prefixes to exclude from error reporting. This takes precedence over include-errors-in-files.")
-
 	singlechecker.Main(Analyzer)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -26,10 +26,13 @@ import (
 	"golang.org/x/tools/go/analysis"
 )
 
+const JsonFormat = "json"
+
 // Config is the struct that stores the user-configurable options for NilAway.
 type Config struct {
 	// PrettyPrint indicates whether the error messages should be pretty printed.
 	PrettyPrint bool
+	Format      string
 	// GroupErrorMessages indicates whether similar error messages should be grouped.
 	GroupErrorMessages bool
 	// ExperimentalStructInitEnable indicates whether experimental struct initialization is enabled.
@@ -123,6 +126,7 @@ var Analyzer = &analysis.Analyzer{
 const (
 	// PrettyPrintFlag is the flag for pretty printing the error messages.
 	PrettyPrintFlag = "pretty-print"
+	FormatFlag      = "format"
 	// GroupErrorMessagesFlag is the flag for grouping similar error messages.
 	GroupErrorMessagesFlag = "group-error-messages"
 	// IncludePkgsFlag is the flag name for include package prefixes.
@@ -144,6 +148,7 @@ func newFlagSet() flag.FlagSet {
 	// We do not keep the returned pointer to the flags because we will not use them directly here.
 	// Instead, we will use the flags through the analyzer's Flags field later.
 	_ = fs.Bool(PrettyPrintFlag, true, "Pretty print the error messages")
+	_ = fs.String(FormatFlag, "", "Pretty print the error messages")
 	_ = fs.Bool(GroupErrorMessagesFlag, true, "Group similar error messages")
 	_ = fs.String(IncludePkgsFlag, "", "Comma-separated list of packages to analyze")
 	_ = fs.String(ExcludePkgsFlag, "", "Comma-separated list of packages to exclude from analysis")
@@ -167,6 +172,9 @@ func run(pass *analysis.Pass) (any, error) {
 	// Override default values if the user provides flags.
 	if prettyPrint, ok := pass.Analyzer.Flags.Lookup(PrettyPrintFlag).Value.(flag.Getter).Get().(bool); ok {
 		conf.PrettyPrint = prettyPrint
+	}
+	if format, ok := pass.Analyzer.Flags.Lookup(FormatFlag).Value.(flag.Getter).Get().(string); ok {
+		conf.Format = format
 	}
 	if groupErrorMessages, ok := pass.Analyzer.Flags.Lookup(GroupErrorMessagesFlag).Value.(flag.Getter).Get().(bool); ok {
 		conf.GroupErrorMessages = groupErrorMessages

--- a/nilaway.go
+++ b/nilaway.go
@@ -40,7 +40,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	conf := pass.ResultOf[config.Analyzer].(*config.Config)
 	deferredErrors := pass.ResultOf[accumulation.Analyzer].([]analysis.Diagnostic)
 	for _, e := range deferredErrors {
-		if conf.PrettyPrint {
+		if conf.PrettyPrint && conf.Format == config.JsonFormat {
 			e.Message = util.PrettyPrintErrorMessage(e.Message)
 		}
 		pass.Report(e)


### PR DESCRIPTION
This PR is aimed to provide a better suport for the json format.

## Current Issue
 
For the orginal json flag provided by [checker.go](https://github.com/golang/tools/blob/0e7ccc0478c322a6b32fb9f74ebfc42e4f965ee9/go/analysis/internal/checker/checker.go#L510), it's impossible to get `analysisflags.JSON` from nilaway. There is a conflict bettwen the `pretty-print` and `json` output currently due to the code https://github.com/uber-go/nilaway/blob/e90288479601315af13b7fdd3ccd6b50c53a8e7c/nilaway.go#L43.
As the default `conf.PrettyPrint ` is true, so the output will be messy when try to output as json.
<img width="1303" alt="image" src="https://github.com/uber-go/nilaway/assets/12164075/4b199a3b-7151-43a8-ba88-12052859ad00">

## Pros
* To import the `format` flag, it's possible to implement the output format by nilaway itself.
* It's possible to implement more format without the limits of [tools](https://github.com/golang/tools)

Can use this flag like this:
```
nilaway -format="json" ./...
```