### PR TITLE
Add modeling for `errors.As` in the generalized hook framework

### DIFF
--- a/hook/replace_conditional.go
+++ b/hook/replace_conditional.go
@@ -1,3 +1,17 @@
+//  Copyright (c) 2024 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package hook
 
 import (

--- a/hook/replace_conditional.go
+++ b/hook/replace_conditional.go
@@ -1,0 +1,49 @@
+package hook
+
+import (
+	"go/ast"
+	"go/token"
+	"regexp"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+// ReplaceConditional replaces a call to a matched function with the returned expression. This is
+// useful for modeling stdlib and 3rd party functions that return a single boolean value, which
+// implies nilability of the arguments. For example, `errors.As(err, &target)` implies
+// `target != nil`, so it can be replaced with `target != nil`.
+//
+// If the call does not match any known function, nil is returned.
+func ReplaceConditional(pass *analysis.Pass, call *ast.CallExpr) ast.Expr {
+	for sig, act := range _replaceConditionals {
+		if sig.match(pass, call) {
+			return act(call, pass)
+		}
+	}
+	return nil
+}
+
+type replaceConditionalAction func(call *ast.CallExpr, p *analysis.Pass) ast.Expr
+
+// _errorAsAction replaces a call to `errors.As(err, &target)` with the expression `target != nil`.
+var _errorAsAction replaceConditionalAction = func(call *ast.CallExpr, p *analysis.Pass) ast.Expr {
+	if len(call.Args) != 2 {
+		return nil
+	}
+	unaryExpr, ok := call.Args[1].(*ast.UnaryExpr)
+	if !ok {
+		return nil
+	}
+	if unaryExpr.Op != token.AND {
+		return nil
+	}
+	return newNilBinaryExpr(unaryExpr.X, token.NEQ)
+}
+
+var _replaceConditionals = map[trustedFuncSig]replaceConditionalAction{
+	{
+		kind:           _func,
+		enclosingRegex: regexp.MustCompile(`^errors$`),
+		funcNameRegex:  regexp.MustCompile(`^As$`),
+	}: _errorAsAction,
+}

--- a/hook/replace_conditional.go
+++ b/hook/replace_conditional.go
@@ -50,7 +50,7 @@ type replaceConditionalAction func(pass *analysis.Pass, call *ast.CallExpr) ast.
 // assumes the target is non-nil after such check [1]. So here we make this assumption as well.
 //
 // [1] https://pkg.go.dev/errors#As
-var _errorAsAction replaceConditionalAction = func(pass *analysis.Pass, call *ast.CallExpr) ast.Expr {
+var _errorAsAction replaceConditionalAction = func(_ *analysis.Pass, call *ast.CallExpr) ast.Expr {
 	if len(call.Args) != 2 {
 		return nil
 	}

--- a/testdata/src/go.uber.org/testing/trustedfuncs.go
+++ b/testdata/src/go.uber.org/testing/trustedfuncs.go
@@ -995,5 +995,11 @@ func errorsAs(err error, num string, dummy bool) {
 			print(*exitErr) //want "unassigned variable `exitErr` dereferenced"
 			print(*anotherErr) //want "unassigned variable `anotherErr` dereferenced"
 		}
+	case "nil dereference in first argument":
+		var exitErr *exec.ExitError
+		var nilError *error
+		if errors.As(*nilError, &exitErr) { //want "unassigned variable `nilError` dereferenced"
+			print(*exitErr) // But this is fine!
+		}
 	}
 }

--- a/testdata/src/go.uber.org/testing/trustedfuncs.go
+++ b/testdata/src/go.uber.org/testing/trustedfuncs.go
@@ -20,6 +20,9 @@ This package aims to test any nilaway behavior specific to accomdating tests, su
 package testing
 
 import (
+	"errors"
+	"os/exec"
+
 	"go.uber.org/testing/github.com/stretchr/testify/assert"
 	"go.uber.org/testing/github.com/stretchr/testify/require"
 	"go.uber.org/testing/github.com/stretchr/testify/suite"
@@ -953,4 +956,12 @@ func testEmpty(t *testing.T, i int, a []int, mp map[int]*int) interface{} {
 	}
 
 	return 0
+}
+
+func errorsAs(err error) {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		exitErr.Exited()
+	}
+	print(exitErr.Exited())
 }


### PR DESCRIPTION
This PR introduces a new hook point in the CFG preprocessing logic to replace conditionals with equivalent expressions (along with a few simple renames and comment additions for better readability).

With the new hook, we are introducing modeling for `errors.As(err, &target)` since it is equivalent to `errors.As(err, &target) && target != nil`. This makes the implication explicit such that NilAway is able to understand it during the analysis.

Note that technically `target` can still be nil even if `errors.As(err, &target)` is true. For example, if err is a typed nil (e.g., `var err *exec.ExitError`), then `errors.As` would actually find a match, but `target` would be set to the typed nil value, resulting in a `nil` target. However, in practice this should rarely happen such that even the official documentation assumes the target is non-nil after such check [1]. So here we make this assumption as well.

[1] https://pkg.go.dev/errors#As

Fixes #95