### PR TITLE
Handle custom iterator funcs

### DIFF
--- a/testdata/src/go.uber.org/looprange/looprange.go
+++ b/testdata/src/go.uber.org/looprange/looprange.go
@@ -223,3 +223,47 @@ func testIter() {
 		print(*v) // FN: we do not really handle iterators for now, the elements from iterators are assumed to be nonnil.
 	}
 }
+
+// Custom iterator functions introduced in Go 1.23
+
+func iteratorNoArgs(yield func() bool) {
+	for i := 0; i < 3; i++ {
+		if !yield() {
+			break
+		}
+	}
+}
+
+func iteratorWithKey(yield func(*int) bool) {
+	one := 1
+	data := []*int{&one, nil}
+	for _, i := range data {
+		if !yield(i) {
+			break
+		}
+	}
+}
+
+func iteratorWithKeyValue(yield func(int, *string) bool) {
+	one := "one"
+	data := map[int]*string{1: &one, 42: nil}
+	for k, v := range data {
+		if !yield(k, v) {
+			break
+		}
+	}
+}
+
+func useCustomIters() {
+	for range iteratorNoArgs {
+	}
+
+	for k := range iteratorWithKey {
+		print(*k) // FN: we do not really handle iterators for now, the elements from iterators are assumed to be nonnil.
+	}
+
+	for k, v := range iteratorWithKeyValue {
+		print(k)
+		print(*v) // FN: we do not really handle iterators for now, the elements from iterators are assumed to be nonnil.
+	}
+}

--- a/util/typeshelper/typeshelper.go
+++ b/util/typeshelper/typeshelper.go
@@ -1,3 +1,18 @@
+//  Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package typeshelper implements utility functions for the go/types package.
 package typeshelper
 
 import (

--- a/util/typeshelper/typeshelper.go
+++ b/util/typeshelper/typeshelper.go
@@ -1,0 +1,42 @@
+package typeshelper
+
+import (
+	"go/types"
+)
+
+// IsIterType returns true if the underlying type is an iterator func:
+//
+// func(func() bool)
+// func(func(K) bool)
+// func(func(K, V) bool)
+//
+// See more at https://tip.golang.org/doc/go1.23.
+func IsIterType(t types.Type) bool {
+	// Ensure it is a function signature.
+	sig, ok := t.Underlying().(*types.Signature)
+	if !ok {
+		return false
+	}
+
+	// Ensure it has exactly one parameter (the yield func).
+	params := sig.Params()
+	if params.Len() != 1 {
+		return false
+	}
+
+	// Ensure the single parameter is a function type (the yield func).
+	paramType, ok := params.At(0).Type().Underlying().(*types.Signature)
+	if !ok {
+		return false
+	}
+
+	// Ensure the yield func takes fewer than 2 arguments and returns exactly one boolean value.
+	res := paramType.Results()
+	if paramType.Params().Len() > 2 || res.Len() != 1 {
+		return false
+	}
+
+	// Final check: ensure the return type of the yield func is a boolean.
+	basic, ok := res.At(0).Type().Underlying().(*types.Basic)
+	return ok && basic.Kind() == types.Bool
+}

--- a/util/typeshelper/typeshelper_test.go
+++ b/util/typeshelper/typeshelper_test.go
@@ -36,15 +36,16 @@ func TestIsIterType(t *testing.T) {
 		{"InvalidNonFunc", "int", false},
 		{"InvalidFuncWrongReturn", "func(func(int) int)", false},
 		{"InvalidFuncNoBool", "func(func(int, string))", false},
+		{"InvalidFuncTooManyArgs", "func(func() bool, string)", false},
+		{"InvalidFuncNotFuncType", "func(bool)", false},
 	}
 
-	fset := token.NewFileSet()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
 			pkg := types.NewPackage("testpkg", "testpkg")
-			typeInfo, err := types.Eval(fset, pkg, 0, tt.typeStr)
+			typeInfo, err := types.Eval(token.NewFileSet(), pkg, 0, tt.typeStr)
 			if err != nil {
 				t.Fatalf("failed to evaluate type: %v", err)
 			}

--- a/util/typeshelper/typeshelper_test.go
+++ b/util/typeshelper/typeshelper_test.go
@@ -1,3 +1,17 @@
+//  Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package typeshelper
 
 import (

--- a/util/typeshelper/typeshelper_test.go
+++ b/util/typeshelper/typeshelper_test.go
@@ -1,0 +1,42 @@
+package typeshelper
+
+import (
+	"go/token"
+	"go/types"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsIterType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		typeStr string
+		want    bool
+	}{
+		{"ValidIterator0", "func(func() bool)", true},
+		{"ValidIterator1", "func(func(int) bool)", true},
+		{"ValidIterator2", "func(func(int, string) bool)", true},
+		{"InvalidNonFunc", "int", false},
+		{"InvalidFuncWrongReturn", "func(func(int) int)", false},
+		{"InvalidFuncNoBool", "func(func(int, string))", false},
+	}
+
+	fset := token.NewFileSet()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			pkg := types.NewPackage("testpkg", "testpkg")
+			typeInfo, err := types.Eval(fset, pkg, 0, tt.typeStr)
+			if err != nil {
+				t.Fatalf("failed to evaluate type: %v", err)
+			}
+
+			got := IsIterType(typeInfo.Type)
+			require.Equal(t, tt.want, got, "IsIterType(%s) = %v, want %v", tt.typeStr, got, tt.want)
+		})
+	}
+}


### PR DESCRIPTION
We added handling for `iter.Seq` and `iter.Seq2` in NilAway such that at least it does not crash (though we assume the return values are always non-nil until better support is added). 

However, Go 1.23 actually introduces more powerful iter-over-func feature, where any of the following func types can be used in range statement:

```
func(func() bool)
func(func(K) bool)
func(func(K, V) bool)
```

and `iter.Seq` and `iter.Seq2` are simply generic type wrapper around the second and third type.

This PR adds general handling for iter-over-func feature (in the same manner: we assume the return values are nonnil). Moreover, we added a `util/typeshelper` package to host our own utility library for `types` package. 

We should be migrating some of the functions from `util` to `tyepshelper`, but that can be done in follow-up PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced support for flexible iteration patterns, leveraging the latest language improvements.
  - Introduced custom iterator capabilities that enable more versatile processing of various data structures.
  
- **Tests**
  - Added comprehensive test coverage to ensure the reliability and accuracy of the new iteration features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->