### PR TITLE
Handle basic type alias in range statement

### DIFF
--- a/testdata/src/go.uber.org/looprange/looprange.go
+++ b/testdata/src/go.uber.org/looprange/looprange.go
@@ -199,6 +199,12 @@ func testRangeOverBasicTypes(j int) {
 		for i := range s {
 			print(i)
 		}
+	case 4:
+		type intAlias int
+		var alias intAlias = 42
+		for i := range alias {
+			print(i)
+		}
 	}
 }
 

--- a/testdata/src/go.uber.org/looprange/looprange.go
+++ b/testdata/src/go.uber.org/looprange/looprange.go
@@ -200,9 +200,15 @@ func testRangeOverBasicTypes(j int) {
 			print(i)
 		}
 	case 4:
+		type intType int
+		var s intType = 42
+		for i := range s {
+			print(i)
+		}
+	case 5:
 		type intAlias int
-		var alias intAlias = 42
-		for i := range alias {
+		var s intAlias = 42
+		for i := range s {
 			print(i)
 		}
 	}


### PR DESCRIPTION
We had handling for `range <basic_type>` (e.g., `range 10`). However, if the `<basic_type>` is type alias or a defined type where the underlying type is basic, NilAway actually crashes.

This PR fixes that and prettifies the format a little bit for readability.