### PR TITLE
Add handling for `ok` in hook.ReplaceConditional`

### DIFF
--- a/assertion/function/preprocess/cfg.go
+++ b/assertion/function/preprocess/cfg.go
@@ -185,10 +185,42 @@ func (p *Preprocessor) replaceConditional(graph *cfg.CFG, block *cfg.Block) {
 	if len(block.Nodes) == 0 || len(block.Succs) != 2 {
 		return
 	}
-	call, ok := block.Nodes[len(block.Nodes)-1].(*ast.CallExpr)
-	if !ok {
+
+	lastNode := block.Nodes[len(block.Nodes)-1]
+
+	// Last node is a call expression for `if foo() { ... }` case.
+	call, ok := lastNode.(*ast.CallExpr)
+	// Otherwise, we check if it is `if ok := foo(); ok { ... }` case.
+	// Note that this would fail for the following case (canonicalized):
+	// ok := foo()
+	// if dummy {
+	//   if ok {
+	//     ...
+	//   }
+	// }
+	// (Note that the example above is canonicalized, `if dummy && ok {...}` is equivalent, and is
+	// probably more common in practice).
+	//
+	// Here we will not find the declaration of `ok` in the block. Ideally we should really find
+	// the declaration node of `ok` instead of simply checking the last node in the block (possibly
+	// with the help of SSA).
+	// TODO: implement that.
+	if !ok && len(block.Nodes) > 1 {
+		if assign, ok := block.Nodes[len(block.Nodes)-2].(*ast.AssignStmt); ok && len(assign.Lhs) == 1 && len(assign.Rhs) == 1 {
+			if ident, ok := assign.Lhs[0].(*ast.Ident); ok {
+				if cond, ok := lastNode.(*ast.Ident); ok {
+					if ident.Name == cond.Name {
+						call, _ = assign.Rhs[0].(*ast.CallExpr)
+					}
+				}
+			}
+		}
+	}
+
+	if call == nil {
 		return
 	}
+
 	replaced := hook.ReplaceConditional(p.pass, call)
 	if replaced == nil {
 		return

--- a/testdata/src/go.uber.org/trustedfunc/trustedfuncs.go
+++ b/testdata/src/go.uber.org/trustedfunc/trustedfuncs.go
@@ -1001,5 +1001,35 @@ func errorsAs(err error, num string, dummy bool) {
 		if errors.As(*nilError, &exitErr) { //want "unassigned variable `nilError` dereferenced"
 			print(*exitErr) // But this is fine!
 		}
+	case "short assignment in if statement":
+		var exitErr *exec.ExitError
+		var nilError error
+		if ok := errors.As(nilError, &exitErr); ok {
+			print(*exitErr)
+			print(ok)
+		}
+	case "short assignment in if statement with OR condition":
+		var exitErr *exec.ExitError
+		var nilError error
+		if ok := errors.As(nilError, &exitErr); ok || dummy {
+			print(*exitErr) //want "unassigned variable `exitErr` dereferenced"
+			print(ok)
+		}
+	case "short assignment in if statement with AND condition":
+		var exitErr *exec.ExitError
+		var nilError error
+		if ok := errors.As(nilError, &exitErr); ok && dummy {
+			print(*exitErr)
+			print(ok)
+		}
+	case "short assignment in if statement with AND condition":
+		var exitErr *exec.ExitError
+		var nilError error
+		if ok := errors.As(nilError, &exitErr); dummy && ok {
+			// The following is an FP: since the `dummy && ok` is canonicalized to `if dummy { if ok { } }`,
+			// our current handling fails to find the `ok := errors.As(...)` call at the end of the block.
+			print(*exitErr) //want "unassigned variable `exitErr` dereferenced"
+			print(ok)
+		}
 	}
 }

--- a/testdata/src/go.uber.org/trustedfunc/trustedfuncs.go
+++ b/testdata/src/go.uber.org/trustedfunc/trustedfuncs.go
@@ -1015,14 +1015,14 @@ func errorsAs(err error, num string, dummy bool) {
 			print(*exitErr) //want "unassigned variable `exitErr` dereferenced"
 			print(ok)
 		}
-	case "short assignment in if statement with AND condition":
+	case "short assignment in if statement with AND condition (ok && dummy)":
 		var exitErr *exec.ExitError
 		var nilError error
 		if ok := errors.As(nilError, &exitErr); ok && dummy {
 			print(*exitErr)
 			print(ok)
 		}
-	case "short assignment in if statement with AND condition":
+	case "short assignment in if statement with AND condition (dummy && ok)":
 		var exitErr *exec.ExitError
 		var nilError error
 		if ok := errors.As(nilError, &exitErr); dummy && ok {


### PR DESCRIPTION
In our `hook.ReplaceConditional` we have support for replacing a conditional with another since we know it has certain implications. E.g., `errors.As(..., &targetErr)` actually means `errors.As(..., &targetErr) && targetErr != nil`. 

This PR adds support for cases where the value is stored in the init part of the if statement, e.g., `if ok := errors.As(...); ok { ... }`. 

Note that the handling is limited: we simply check the last node within the current block. This would lead to missing cases like `if ok := errors.As(...); dummy && ok { ... }` since it would be canonicalized to `if dummy { if ok { ... } }`, and we won't find the definition of `ok` within the current block anymore (it would work if `ok` is actually placed at the beginning, e.g., `if ok && dummy {...}`. 

This is weird, but it is the simplest way to implement such support for now (and we assume it would be a common case to place `ok` as the first component of the expression anyways). 

A more general handling to get the latest declaration with the help of SSA analyzer will be done in follow-up PR.