### PR TITLE
Define a `RelToCwd` helper function to simplify codebase

### DIFF
--- a/diagnostic/conflict.go
+++ b/diagnostic/conflict.go
@@ -18,10 +18,10 @@ import (
 	"fmt"
 	"go/ast"
 	"go/token"
-	"path/filepath"
 	"strings"
 
 	"go.uber.org/nilaway/config"
+	"go.uber.org/nilaway/util/tokenhelper"
 	"golang.org/x/tools/go/analysis"
 )
 
@@ -62,7 +62,7 @@ func (c *conflict) addSimilarConflict(conflict conflict) {
 }
 
 // groupConflicts groups conflicts with the same nil path together and update conflicts list.
-func groupConflicts(allConflicts []conflict, pass *analysis.Pass, cwd string) []conflict {
+func groupConflicts(allConflicts []conflict, pass *analysis.Pass) []conflict {
 	conflictsMap := make(map[string]int)  // key: nil path string, value: index in `allConflicts`
 	indicesToIgnore := make(map[int]bool) // indices of conflicts to be ignored from `allConflicts`, since they are grouped with other conflicts
 
@@ -95,11 +95,7 @@ func groupConflicts(allConflicts []conflict, pass *analysis.Pass, cwd string) []
 				// from different functions. To handle such cases, we prepend the enclosing function name to the key.
 				conf := pass.ResultOf[config.Analyzer].(*config.Config)
 				for _, file := range pass.Files {
-					// `fileName` stores the complete file path relative to the current working directory
-					fileName := pass.Fset.Position(file.FileStart).Filename
-					if fn, err := filepath.Rel(cwd, fileName); err == nil {
-						fileName = fn
-					}
+					fileName := tokenhelper.RelToCwd(pass.Fset.Position(file.FileStart).Filename)
 					// Check if the file is in scope and the conflict position is in the same file
 					if !conf.IsFileInScope(file) || fileName != c.position.Filename {
 						continue

--- a/diagnostic/engine.go
+++ b/diagnostic/engine.go
@@ -19,7 +19,6 @@ package diagnostic
 
 import (
 	"cmp"
-	"fmt"
 	"go/token"
 	"slices"
 

--- a/diagnostic/engine.go
+++ b/diagnostic/engine.go
@@ -21,13 +21,12 @@ import (
 	"cmp"
 	"fmt"
 	"go/token"
-	"os"
-	"path/filepath"
 	"slices"
 
 	"go.uber.org/nilaway/annotation"
 	"go.uber.org/nilaway/inference"
 	"go.uber.org/nilaway/util"
+	"go.uber.org/nilaway/util/tokenhelper"
 	"golang.org/x/tools/go/analysis"
 )
 
@@ -46,20 +45,10 @@ type Engine struct {
 	// for faster lookup when converting correct upstream position back to local token.Pos for
 	// reporting purposes.
 	files map[string]fileInfo
-	// cwd is the current working directory for trimming the file names to get truly package- and
-	// build-system- (bazel for example adds a random sandbox prefix) independent positions.
-	cwd string
 }
 
 // NewEngine creates a new diagnostic engine.
 func NewEngine(pass *analysis.Pass) *Engine {
-	// Find the current working directory (e.g., random sandbox prefix if using bazel) for trimming
-	// the file names.
-	cwd, err := os.Getwd()
-	if err != nil {
-		panic(fmt.Sprintf("cannot get current working directory: %v", err))
-	}
-
 	// Iterate all files within the Fset (which includes upstream and current-package files), and
 	// store the mapping between its file name (modulo the possible build-system prefix) and the
 	// token.File object. This is needed for converting correct upstream position back to local
@@ -67,13 +56,9 @@ func NewEngine(pass *analysis.Pass) *Engine {
 	// [inference.primitivizer.toPosition] for more detailed explanations.
 	files := make(map[string]fileInfo)
 	pass.Fset.Iterate(func(file *token.File) bool {
-		name, err := filepath.Rel(cwd, file.Name())
-		if err != nil {
-			// For files that are not in the execroot (e.g., stdlib files start with "$GOROOT", and
-			// upstream files that do not have the build-system prefix), we can simply use the
-			// original file name.
-			name = file.Name()
-		}
+		// For files that are not in the execroot (e.g., stdlib files start with "$GOROOT", and
+		// upstream files that do not have the build-system prefix), it simply returns the original.
+		name := tokenhelper.RelToCwd(file.Name())
 
 		// The file will be fake (conceptually "\n" * 65535) if it is imported from archive. So we
 		// check if there are any gaps between the line starts to determine if the file is fake.
@@ -93,7 +78,7 @@ func NewEngine(pass *analysis.Pass) *Engine {
 		return true
 	})
 
-	return &Engine{pass: pass, files: files, cwd: cwd}
+	return &Engine{pass: pass, files: files}
 }
 
 // Diagnostics generates diagnostics from the internally-stored conflicts. The grouping parameter
@@ -114,7 +99,7 @@ func (e *Engine) Diagnostics(grouping bool) []analysis.Diagnostic {
 	conflicts := e.conflicts
 	if grouping {
 		// Group conflicts with the same nil path together for concise reporting.
-		conflicts = groupConflicts(e.conflicts, e.pass, e.cwd)
+		conflicts = groupConflicts(e.conflicts, e.pass)
 	}
 
 	// Build diagnostics from conflicts.
@@ -135,12 +120,8 @@ func (e *Engine) AddSingleAssertionConflict(trigger annotation.FullTrigger) {
 	flow.addNonNilPathNode(producer, consumer)
 
 	position := e.pass.Fset.Position(trigger.Consumer.Expr.Pos())
-	// Try to trim the build system prefix (i.e., the current working directory) from the position.
-	// If NilAway is running in a driver that does not add such prefix, we will hit an error here,
-	// but that is fine, and we just do not need to do anything.
-	if filename, err := filepath.Rel(e.cwd, position.Filename); err == nil {
-		position.Filename = filename
-	}
+	// Try to trim the build system prefix (i.e., the current working directory) if present.
+	position.Filename = tokenhelper.RelToCwd(position.Filename)
 	e.conflicts = append(e.conflicts, conflict{
 		position: position,
 		flow:     flow,

--- a/util/tokenhelper/tokenhelper.go
+++ b/util/tokenhelper/tokenhelper.go
@@ -1,0 +1,25 @@
+package tokenhelper
+
+import (
+	"os"
+	"path/filepath"
+)
+
+var _cwd = func() string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		panic("failed to get current working directory: " + err.Error())
+	}
+	return cwd
+}()
+
+// RelToCwd returns the relative path of the given filename with respect to the current
+// working directory (retrieved during initialization). If the filename is not a child of
+// the current working directory, it returns the filename itself.
+func RelToCwd(filename string) string {
+	rel, err := filepath.Rel(_cwd, filename)
+	if err != nil {
+		return rel
+	}
+	return filename
+}

--- a/util/tokenhelper/tokenhelper.go
+++ b/util/tokenhelper/tokenhelper.go
@@ -21,18 +21,15 @@ import (
 	"path/filepath"
 )
 
-var _cwd = func() string {
-	cwd, err := os.Getwd()
-	if err != nil {
-		panic("failed to get current working directory: " + err.Error())
-	}
-	return cwd
-}()
+var _cwd, _cwdErr = os.Getwd()
 
 // RelToCwd returns the relative path of the given filename with respect to the current
 // working directory (retrieved during initialization). If the filename is not a child of
 // the current working directory, it returns the filename itself.
 func RelToCwd(filename string) string {
+	if _cwdErr != nil {
+		panic("failed to get current working directory: " + _cwdErr.Error())
+	}
 	rel, err := filepath.Rel(_cwd, filename)
 	if err == nil {
 		return rel

--- a/util/tokenhelper/tokenhelper.go
+++ b/util/tokenhelper/tokenhelper.go
@@ -1,3 +1,19 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package tokenhelper hosts helper functions that enhance the `token` package (e.g., around
+// position and file path formatting etc.).
 package tokenhelper
 
 import (

--- a/util/tokenhelper/tokenhelper_test.go
+++ b/util/tokenhelper/tokenhelper_test.go
@@ -12,30 +12,34 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package tokenhelper hosts helper functions that enhance the `token` package (e.g., around
-// position and file path formatting etc.).
 package tokenhelper
 
 import (
 	"os"
 	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
-var _cwd = func() string {
-	cwd, err := os.Getwd()
-	if err != nil {
-		panic("failed to get current working directory: " + err.Error())
-	}
-	return cwd
-}()
+func TestRelToCwd(t *testing.T) {
+	t.Parallel()
 
-// RelToCwd returns the relative path of the given filename with respect to the current
-// working directory (retrieved during initialization). If the filename is not a child of
-// the current working directory, it returns the filename itself.
-func RelToCwd(filename string) string {
-	rel, err := filepath.Rel(_cwd, filename)
-	if err == nil {
-		return rel
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	testcases := []struct {
+		give string
+		want string
+	}{
+		{give: filepath.Join(cwd, "testdata", "foo.go"), want: filepath.Join("testdata", "foo.go")},
+		{give: filepath.Join("testdata", "foo.go"), want: filepath.Join("testdata", "foo.go")},
 	}
-	return filename
+	for _, tc := range testcases {
+		t.Run(tc.give, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tc.want, RelToCwd(tc.give))
+		})
+	}
 }


### PR DESCRIPTION
Since we rely on this functionality in quite a few places throughout the codebase (for trimming the build system prefixes), and getting cwd from `os.Getwd()` every time is tedious and ugly.