### PR TITLE
Fix for handling `new` in error wrapping heuristic

### DIFF
--- a/hook/assume_return.go
+++ b/hook/assume_return.go
@@ -83,6 +83,7 @@ func isErrorWrapperFunc(pass *analysis.Pass, call *ast.CallExpr) bool {
 	if !ok {
 		return false
 	}
+
 	if util.FuncIsErrReturning(funcObj.Signature()) {
 		args := call.Args
 

--- a/hook/assume_return.go
+++ b/hook/assume_return.go
@@ -66,9 +66,6 @@ func isErrorWrapperFunc(pass *analysis.Pass, call *ast.CallExpr) bool {
 	// If the call expr is built-in `new`, then we check if its argument type implements the error interface.
 	// This case particularly gets triggered for the expression: `Wrap(new(MyErrorStruct), "message")`.
 	if obj == util.BuiltinNew {
-		if len(call.Args) == 0 {
-			return false
-		}
 		if argIdent := util.IdentOf(call.Args[0]); argIdent != nil {
 			ptr := types.NewPointer(pass.TypesInfo.TypeOf(argIdent))
 			if types.Implements(ptr, util.ErrorInterface) {

--- a/hook/assume_return.go
+++ b/hook/assume_return.go
@@ -63,6 +63,21 @@ func isErrorWrapperFunc(pass *analysis.Pass, call *ast.CallExpr) bool {
 		return false
 	}
 
+	// If the call expr is built-in such as `new(MyErrorStruct)`, then we check if its argument type implements the error interface.
+	if _, ok := obj.(*types.Builtin); ok {
+		if len(call.Args) == 0 {
+			return false
+		}
+		if argIdent := util.IdentOf(call.Args[0]); argIdent != nil {
+			ptr := types.NewPointer(pass.TypesInfo.TypeOf(argIdent))
+			if types.Implements(ptr, util.ErrorInterface) {
+				return true
+			}
+		}
+
+		return false
+	}
+
 	funcObj, ok := obj.(*types.Func)
 	if !ok {
 		return false
@@ -79,7 +94,9 @@ func isErrorWrapperFunc(pass *analysis.Pass, call *ast.CallExpr) bool {
 		}
 		for _, arg := range args {
 			if callExpr, ok := ast.Unparen(arg).(*ast.CallExpr); ok {
-				return isErrorWrapperFunc(pass, callExpr)
+				if isErrorWrapperFunc(pass, callExpr) {
+					return true
+				}
 			}
 
 			if argIdent := util.IdentOf(arg); argIdent != nil {

--- a/hook/assume_return.go
+++ b/hook/assume_return.go
@@ -63,8 +63,9 @@ func isErrorWrapperFunc(pass *analysis.Pass, call *ast.CallExpr) bool {
 		return false
 	}
 
-	// If the call expr is built-in such as `new(MyErrorStruct)`, then we check if its argument type implements the error interface.
-	if _, ok := obj.(*types.Builtin); ok {
+	// If the call expr is built-in `new`, then we check if its argument type implements the error interface.
+	// This case particularly gets triggered for the expression: `Wrap(new(MyErrorStruct), "message")`.
+	if obj == util.BuiltinNew {
 		if len(call.Args) == 0 {
 			return false
 		}

--- a/hook/assume_return.go
+++ b/hook/assume_return.go
@@ -83,7 +83,6 @@ func isErrorWrapperFunc(pass *analysis.Pass, call *ast.CallExpr) bool {
 	if !ok {
 		return false
 	}
-
 	if util.FuncIsErrReturning(funcObj.Signature()) {
 		args := call.Args
 

--- a/testdata/src/go.uber.org/errorreturn/inference/errorreturn-with-inference.go
+++ b/testdata/src/go.uber.org/errorreturn/inference/errorreturn-with-inference.go
@@ -531,6 +531,13 @@ func testErrorWrapper9() (*int, error) {
 	return new(int), nil
 }
 
+func testErrorWrapper10() (*int, error) {
+	if dummy2 {
+		return nil, Wrap(new(wrapped), "some message").WithFields(Fields{"key": "value"})
+	}
+	return new(int), nil
+}
+
 func consume(any) {}
 
 func callTestErrorWrapper(i int) {
@@ -618,6 +625,13 @@ func callTestErrorWrapper(i int) {
 	case 14:
 		m := &myErr2{}
 		consume(GetErrNamedType(m).Error())
+
+	case 15:
+		x, err := testErrorWrapper10()
+		if err != nil {
+			return
+		}
+		_ = *x
 	}
 }
 


### PR DESCRIPTION
This PR further refines the error wrapping heuristic by adding support for use of built-in `new` as argument. Example: `Wrap(new(wrapped), "some message")`.