### PR TITLE
Support for unnamed anonymous error returning functions

### DIFF
--- a/assertion/function/assertiontree/parse_expr_producer.go
+++ b/assertion/function/assertiontree/parse_expr_producer.go
@@ -331,7 +331,7 @@ func (r *RootAssertionNode) ParseExprAsProducer(expr ast.Expr, doNotTrack bool) 
 			return nil, r.getFuncReturnProducers(fun.Sel, expr)
 
 		case *ast.FuncLit:
-			// TODO: This case can be possibly be combined with the case of *ast.Ident above.
+			// TODO: This case can possibly be combined with the case of *ast.Ident above.
 			var funcIdent *ast.Ident
 
 			if r.functionContext.functionConfig.EnableAnonymousFunc {

--- a/assertion/function/assertiontree/parse_expr_producer.go
+++ b/assertion/function/assertiontree/parse_expr_producer.go
@@ -248,6 +248,7 @@ func (r *RootAssertionNode) ParseExprAsProducer(expr ast.Expr, doNotTrack bool) 
 		// to try to subsume this switch with funcIdentFromCallExpr
 		switch fun := expr.Fun.(type) {
 		case *ast.Ident: // direct function call
+			// Handle specially if the function is an anonymous function.
 			if r.functionContext.functionConfig.EnableAnonymousFunc {
 				fun = getFuncIdent(expr, &r.functionContext)
 			} else {
@@ -328,6 +329,37 @@ func (r *RootAssertionNode) ParseExprAsProducer(expr ast.Expr, doNotTrack bool) 
 			}
 			// function call has non-literal args, so is not literal, use its return annotation
 			return nil, r.getFuncReturnProducers(fun.Sel, expr)
+
+		case *ast.FuncLit:
+			// TODO: This case can be possibly be combined with the case of *ast.Ident above.
+			var funcIdent *ast.Ident
+
+			if r.functionContext.functionConfig.EnableAnonymousFunc {
+				funcIdent = getFuncIdent(expr, &r.functionContext)
+			} else {
+				// TODO: this is a temporary fix to handle the case of anonymous functions.
+				//  Remove this once we have have enabled the anonymous function support.
+				sig := r.Pass().TypesInfo.TypeOf(fun).(*types.Signature)
+				if util.FuncIsErrReturning(sig) {
+					return nil, []producer.ParsedProducer{producer.ShallowParsedProducer{Producer: &annotation.ProduceTrigger{
+						Annotation: &annotation.TrustedFuncNonnil{ProduceTriggerNever: &annotation.ProduceTriggerNever{}},
+						Expr:       expr,
+					}}}
+				}
+			}
+
+			if funcIdent == nil {
+				return nil, nil
+			}
+
+			// non-builtin funcs
+			if !doNotTrack && litArgs() {
+				return TrackableExpr{&funcAssertionNode{
+					decl: r.ObjectOf(funcIdent).(*types.Func), args: expr.Args}}, nil
+			}
+			// function call has non-literal args, so is not literal, use its return annotation
+			// alternatively, doNotTrack was set
+			return nil, r.getFuncReturnProducers(funcIdent, expr)
 
 		default:
 			// this could result from calling a function returned anonymously from another function, such as f(4)(3), and

--- a/assertion/function/assertiontree/rich_check_effect.go
+++ b/assertion/function/assertiontree/rich_check_effect.go
@@ -23,7 +23,6 @@ import (
 	"go.uber.org/nilaway/annotation"
 	"go.uber.org/nilaway/util"
 	"go.uber.org/nilaway/util/asthelper"
-	"go.uber.org/nilaway/util/typeshelper"
 	"golang.org/x/tools/go/cfg"
 )
 
@@ -390,20 +389,14 @@ func NodeTriggersFuncErrRet(rootNode *RootAssertionNode, nonceGenerator *util.Gu
 		return nil, false
 	}
 
-	callIdent := util.FuncIdentFromCallExpr(callExpr)
-
-	if callIdent == nil {
-		// this discards the case of an anonymous function
-		// perhaps in the future we could change this
-		return nil, false
+	var sig *types.Signature
+	tv := rootNode.Pass().TypesInfo.Types[callExpr.Fun]
+	if tv.Type != nil {
+		if s, ok := tv.Type.(*types.Signature); ok {
+			sig = s
+		}
 	}
 
-	obj := rootNode.Pass().TypesInfo.ObjectOf(callIdent)
-	if obj == nil {
-		return nil, false
-	}
-
-	sig := typeshelper.GetFuncSignature(obj)
 	if sig == nil || !util.FuncIsErrReturning(sig) {
 		return nil, false
 	}

--- a/assertion/function/assertiontree/rich_check_effect.go
+++ b/assertion/function/assertiontree/rich_check_effect.go
@@ -389,6 +389,7 @@ func NodeTriggersFuncErrRet(rootNode *RootAssertionNode, nonceGenerator *util.Gu
 		return nil, false
 	}
 
+	// Get signature of the function call (normal and anonymous both)
 	var sig *types.Signature
 	tv := rootNode.Pass().TypesInfo.Types[callExpr.Fun]
 	if tv.Type != nil {

--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -164,6 +164,12 @@ func (r *RootAssertionNode) ObjectOf(ident *ast.Ident) types.Object {
 	if obj != nil {
 		return obj
 	}
+	// check if ident points to an anonymous function literal
+	if funcLit := getFuncLitFromAssignment(ident); funcLit != nil {
+		if info, ok := r.functionContext.funcLitMap[funcLit]; ok {
+			return info.FakeFuncObj
+		}
+	}
 	return r.functionContext.findFakeIdent(ident)
 }
 

--- a/testdata/src/go.uber.org/inference/inference.go
+++ b/testdata/src/go.uber.org/inference/inference.go
@@ -18,119 +18,99 @@
 
 package inference
 
-// var dummyBool bool
-// var dummyInt int
-//
-// func retsNilable1() *int {
-// 	return nil
-// }
-//
-// func retsNilable2() *int {
-// 	if dummyBool {
-// 		return &dummyInt
-// 	}
-// 	return nil
-// }
-//
-// func retsNilable3() *int {
-// 	switch dummyInt {
-// 	case dummyInt:
-// 		return retsNilable1()
-// 	case dummyInt:
-// 		return retsNilable2()
-// 	case dummyInt:
-// 		return retsNilable3()
-// 	}
-// 	return &dummyInt
-// }
-//
-// func retsNonnil1() *int {
-// 	return &dummyInt
-// }
-//
-// func retsNonnil2() *int {
-// 	if dummyBool {
-// 		return &dummyInt
-// 	}
-// 	return &dummyInt
-// }
-//
-// func retsNonnil3() *int {
-// 	switch dummyInt {
-// 	case dummyInt:
-// 		return retsNonnil1()
-// 	case dummyInt:
-// 		return retsNonnil2()
-// 	case dummyInt:
-// 		return retsNonnil3()
-// 	}
-// 	return &dummyInt
-// }
-//
-// func retsNilable4() *int {
-// 	if dummyBool {
-// 		return retsNilable3()
-// 	}
-// 	return retsNilable3()
-// }
-//
-// func takesNonnil(x *int) int {
-// 	return *x
-// }
-//
-// func takesNilable(x *int) int {
-// 	if x == nil {
-// 		return 0
-// 	}
-// 	return *x
-// }
-//
-// func retsAndTakes() {
-// 	switch dummyInt {
-// 	case dummyInt:
-// 		takesNonnil(retsNonnil1())
-// 		takesNonnil(retsNonnil2())
-// 		takesNonnil(retsNonnil3())
-//
-// 		takesNilable(retsNonnil1())
-// 		takesNilable(retsNonnil2())
-// 		takesNilable(retsNonnil3())
-//
-// 		takesNilable(retsNilable1())
-// 		takesNilable(retsNilable2())
-// 		takesNilable(retsNilable3())
-// 		takesNilable(retsNilable4())
-// 	}
-// }
-//
-// // Below test checks the working of inference in the presence of annotations
-// // nonnil(x) nilable(result 0)
-// func foo(x *int) *int { //want "NONNIL because it is annotated as so"
-// 	print(*x)
-// 	return nil
-// }
-//
-// func callFoo() {
-// 	ptr := foo(nil)
-// 	print(*ptr) //want "NILABLE because it is annotated as so"
-// }
+var dummyBool bool
+var dummyInt int
 
-var dummy2 bool
+func retsNilable1() *int {
+	return nil
+}
 
-type myErr2 struct{}
-
-func (myErr2) Error() string { return "myErr2 message" }
-
-func testme() {
-	x, err := func() (*int, error) {
-		if dummy2 {
-			return nil, &myErr2{}
-		}
-		return new(int), nil
-	}()
-
-	if err != nil {
-		return
+func retsNilable2() *int {
+	if dummyBool {
+		return &dummyInt
 	}
-	_ = *x
+	return nil
+}
+
+func retsNilable3() *int {
+	switch dummyInt {
+	case dummyInt:
+		return retsNilable1()
+	case dummyInt:
+		return retsNilable2()
+	case dummyInt:
+		return retsNilable3()
+	}
+	return &dummyInt
+}
+
+func retsNonnil1() *int {
+	return &dummyInt
+}
+
+func retsNonnil2() *int {
+	if dummyBool {
+		return &dummyInt
+	}
+	return &dummyInt
+}
+
+func retsNonnil3() *int {
+	switch dummyInt {
+	case dummyInt:
+		return retsNonnil1()
+	case dummyInt:
+		return retsNonnil2()
+	case dummyInt:
+		return retsNonnil3()
+	}
+	return &dummyInt
+}
+
+func retsNilable4() *int {
+	if dummyBool {
+		return retsNilable3()
+	}
+	return retsNilable3()
+}
+
+func takesNonnil(x *int) int {
+	return *x
+}
+
+func takesNilable(x *int) int {
+	if x == nil {
+		return 0
+	}
+	return *x
+}
+
+func retsAndTakes() {
+	switch dummyInt {
+	case dummyInt:
+		takesNonnil(retsNonnil1())
+		takesNonnil(retsNonnil2())
+		takesNonnil(retsNonnil3())
+
+		takesNilable(retsNonnil1())
+		takesNilable(retsNonnil2())
+		takesNilable(retsNonnil3())
+
+		takesNilable(retsNilable1())
+		takesNilable(retsNilable2())
+		takesNilable(retsNilable3())
+		takesNilable(retsNilable4())
+	}
+}
+
+// Below test checks the working of inference in the presence of annotations
+// nonnil(x) nilable(result 0)
+func foo(x *int) *int { //want "NONNIL because it is annotated as so"
+	print(*x)
+	return nil
+}
+
+func callFoo() {
+	ptr := foo(nil)
+	print(*ptr) //want "NILABLE because it is annotated as so"
 }

--- a/testdata/src/go.uber.org/inference/inference.go
+++ b/testdata/src/go.uber.org/inference/inference.go
@@ -18,99 +18,119 @@
 
 package inference
 
-var dummyBool bool
-var dummyInt int
+// var dummyBool bool
+// var dummyInt int
+//
+// func retsNilable1() *int {
+// 	return nil
+// }
+//
+// func retsNilable2() *int {
+// 	if dummyBool {
+// 		return &dummyInt
+// 	}
+// 	return nil
+// }
+//
+// func retsNilable3() *int {
+// 	switch dummyInt {
+// 	case dummyInt:
+// 		return retsNilable1()
+// 	case dummyInt:
+// 		return retsNilable2()
+// 	case dummyInt:
+// 		return retsNilable3()
+// 	}
+// 	return &dummyInt
+// }
+//
+// func retsNonnil1() *int {
+// 	return &dummyInt
+// }
+//
+// func retsNonnil2() *int {
+// 	if dummyBool {
+// 		return &dummyInt
+// 	}
+// 	return &dummyInt
+// }
+//
+// func retsNonnil3() *int {
+// 	switch dummyInt {
+// 	case dummyInt:
+// 		return retsNonnil1()
+// 	case dummyInt:
+// 		return retsNonnil2()
+// 	case dummyInt:
+// 		return retsNonnil3()
+// 	}
+// 	return &dummyInt
+// }
+//
+// func retsNilable4() *int {
+// 	if dummyBool {
+// 		return retsNilable3()
+// 	}
+// 	return retsNilable3()
+// }
+//
+// func takesNonnil(x *int) int {
+// 	return *x
+// }
+//
+// func takesNilable(x *int) int {
+// 	if x == nil {
+// 		return 0
+// 	}
+// 	return *x
+// }
+//
+// func retsAndTakes() {
+// 	switch dummyInt {
+// 	case dummyInt:
+// 		takesNonnil(retsNonnil1())
+// 		takesNonnil(retsNonnil2())
+// 		takesNonnil(retsNonnil3())
+//
+// 		takesNilable(retsNonnil1())
+// 		takesNilable(retsNonnil2())
+// 		takesNilable(retsNonnil3())
+//
+// 		takesNilable(retsNilable1())
+// 		takesNilable(retsNilable2())
+// 		takesNilable(retsNilable3())
+// 		takesNilable(retsNilable4())
+// 	}
+// }
+//
+// // Below test checks the working of inference in the presence of annotations
+// // nonnil(x) nilable(result 0)
+// func foo(x *int) *int { //want "NONNIL because it is annotated as so"
+// 	print(*x)
+// 	return nil
+// }
+//
+// func callFoo() {
+// 	ptr := foo(nil)
+// 	print(*ptr) //want "NILABLE because it is annotated as so"
+// }
 
-func retsNilable1() *int {
-	return nil
-}
+var dummy2 bool
 
-func retsNilable2() *int {
-	if dummyBool {
-		return &dummyInt
+type myErr2 struct{}
+
+func (myErr2) Error() string { return "myErr2 message" }
+
+func testme() {
+	x, err := func() (*int, error) {
+		if dummy2 {
+			return nil, &myErr2{}
+		}
+		return new(int), nil
+	}()
+
+	if err != nil {
+		return
 	}
-	return nil
-}
-
-func retsNilable3() *int {
-	switch dummyInt {
-	case dummyInt:
-		return retsNilable1()
-	case dummyInt:
-		return retsNilable2()
-	case dummyInt:
-		return retsNilable3()
-	}
-	return &dummyInt
-}
-
-func retsNonnil1() *int {
-	return &dummyInt
-}
-
-func retsNonnil2() *int {
-	if dummyBool {
-		return &dummyInt
-	}
-	return &dummyInt
-}
-
-func retsNonnil3() *int {
-	switch dummyInt {
-	case dummyInt:
-		return retsNonnil1()
-	case dummyInt:
-		return retsNonnil2()
-	case dummyInt:
-		return retsNonnil3()
-	}
-	return &dummyInt
-}
-
-func retsNilable4() *int {
-	if dummyBool {
-		return retsNilable3()
-	}
-	return retsNilable3()
-}
-
-func takesNonnil(x *int) int {
-	return *x
-}
-
-func takesNilable(x *int) int {
-	if x == nil {
-		return 0
-	}
-	return *x
-}
-
-func retsAndTakes() {
-	switch dummyInt {
-	case dummyInt:
-		takesNonnil(retsNonnil1())
-		takesNonnil(retsNonnil2())
-		takesNonnil(retsNonnil3())
-
-		takesNilable(retsNonnil1())
-		takesNilable(retsNonnil2())
-		takesNilable(retsNonnil3())
-
-		takesNilable(retsNilable1())
-		takesNilable(retsNilable2())
-		takesNilable(retsNilable3())
-		takesNilable(retsNilable4())
-	}
-}
-
-// Below test checks the working of inference in the presence of annotations
-// nonnil(x) nilable(result 0)
-func foo(x *int) *int { //want "NONNIL because it is annotated as so"
-	print(*x)
-	return nil
-}
-
-func callFoo() {
-	ptr := foo(nil)
-	print(*ptr) //want "NILABLE because it is annotated as so"
+	_ = *x
 }

--- a/util/typeshelper/typeshelper.go
+++ b/util/typeshelper/typeshelper.go
@@ -55,16 +55,3 @@ func IsIterType(t types.Type) bool {
 	basic, ok := res.At(0).Type().Underlying().(*types.Basic)
 	return ok && basic.Kind() == types.Bool
 }
-
-// GetFuncSignature returns the signature of a function or an anonymous function.
-func GetFuncSignature(obj types.Object) *types.Signature {
-	switch t2 := obj.(type) {
-	case *types.Func:
-		return t2.Signature()
-	case *types.Var:
-		if anonFuncSig, ok := t2.Type().(*types.Signature); ok {
-			return anonFuncSig
-		}
-	}
-	return nil
-}


### PR DESCRIPTION
This PR extends the functionality of #326 by adding support for error return functions defined as unnamed anonymous functions. Example:

```
func test() {
	x, err := func() (*int, error) {
		if dummy {
			return nil, &myErr2{}
		}
		return new(int), nil
	}()
	if err != nil {
		return
	}
	_ = *x  // safe dereference
}
```

The PR makes primarily 3 changes:

- generalize `NodeTriggersFuncErrRet` in `rich_check_effect.go` to work on function signatures.
- update case of *ast.CallExpr in `parse_producer_expr.go` to handle `*ast.FuncLit`. It is guarded by the `EnableAnonymousFunc` flag. Note that in the absence of the flag, the PR employs a temporary fix to suppress the errors, which means that we don't report false positives, but we also don't report true positives, leading to false negatives.