### PR TITLE
Recognize and suppress type alias false positives

### DIFF
--- a/assertion/function/assertiontree/parse_expr_producer.go
+++ b/assertion/function/assertiontree/parse_expr_producer.go
@@ -276,16 +276,14 @@ func (r *RootAssertionNode) ParseExprAsProducer(expr ast.Expr, doNotTrack bool) 
 			// 		}
 			// 		_ = *x
 			// }
-			// TODO: this is only a temporary fix to suppress the case of type aliases for functions.
+			// TODO: this is only a temporary fix to suppress false positives caused by type aliases.
 			//  Remove this once we have implemented complete support for type aliases.
 			t := r.Pass().TypesInfo.TypeOf(fun)
-			if t != nil {
-				if _, ok := t.(*types.Alias); ok {
-					return nil, []producer.ParsedProducer{producer.ShallowParsedProducer{Producer: &annotation.ProduceTrigger{
-						Annotation: &annotation.TrustedFuncNonnil{ProduceTriggerNever: &annotation.ProduceTriggerNever{}},
-						Expr:       expr,
-					}}}
-				}
+			if _, ok := t.(*types.Alias); ok {
+				return nil, []producer.ParsedProducer{producer.ShallowParsedProducer{Producer: &annotation.ProduceTrigger{
+					Annotation: &annotation.TrustedFuncNonnil{ProduceTriggerNever: &annotation.ProduceTriggerNever{}},
+					Expr:       expr,
+				}}}
 			}
 
 			if fun != nil && !r.isFunc(fun) {

--- a/assertion/function/assertiontree/parse_expr_producer.go
+++ b/assertion/function/assertiontree/parse_expr_producer.go
@@ -23,6 +23,7 @@ import (
 	"go.uber.org/nilaway/assertion/function/producer"
 	"go.uber.org/nilaway/hook"
 	"go.uber.org/nilaway/util"
+	"go.uber.org/nilaway/util/typeshelper"
 )
 
 // ParseExprAsProducer takes an expression, and determines whether it is `trackable` - i.e. if it is a
@@ -256,13 +257,34 @@ func (r *RootAssertionNode) ParseExprAsProducer(expr ast.Expr, doNotTrack bool) 
 				//  Remove this once we have have enabled the anonymous function support.
 				funcLit := getFuncLitFromAssignment(fun)
 				if funcLit != nil {
-					sig := r.Pass().TypesInfo.TypeOf(funcLit).(*types.Signature)
-					if util.FuncIsErrReturning(sig) {
+					sig := typeshelper.GetFuncSignature(r.Pass().TypesInfo.TypeOf(funcLit))
+					if sig != nil && util.FuncIsErrReturning(sig) {
 						return nil, []producer.ParsedProducer{producer.ShallowParsedProducer{Producer: &annotation.ProduceTrigger{
 							Annotation: &annotation.TrustedFuncNonnil{ProduceTriggerNever: &annotation.ProduceTriggerNever{}},
 							Expr:       expr,
 						}}}
 					}
+				}
+			}
+
+			// Check if it is a type alias for a function type.
+			// e.g., type MyFunc func() (*int, error)
+			// func foo(f MyErrRetFunc) {
+			// 		x, err := f()
+			// 		if err != nil {
+			// 			return
+			// 		}
+			// 		_ = *x
+			// }
+			// TODO: this is only a temporary fix to suppress the case of type aliases for functions.
+			//  Remove this once we have implemented complete support for type aliases.
+			t := r.Pass().TypesInfo.TypeOf(fun)
+			if t != nil {
+				if _, ok := t.(*types.Alias); ok {
+					return nil, []producer.ParsedProducer{producer.ShallowParsedProducer{Producer: &annotation.ProduceTrigger{
+						Annotation: &annotation.TrustedFuncNonnil{ProduceTriggerNever: &annotation.ProduceTriggerNever{}},
+						Expr:       expr,
+					}}}
 				}
 			}
 

--- a/assertion/function/assertiontree/rich_check_effect.go
+++ b/assertion/function/assertiontree/rich_check_effect.go
@@ -23,6 +23,7 @@ import (
 	"go.uber.org/nilaway/annotation"
 	"go.uber.org/nilaway/util"
 	"go.uber.org/nilaway/util/asthelper"
+	"go.uber.org/nilaway/util/typeshelper"
 	"golang.org/x/tools/go/cfg"
 )
 
@@ -390,13 +391,7 @@ func NodeTriggersFuncErrRet(rootNode *RootAssertionNode, nonceGenerator *util.Gu
 	}
 
 	// Get signature of the function call (normal and anonymous both)
-	var sig *types.Signature
-	tv := rootNode.Pass().TypesInfo.Types[callExpr.Fun]
-	if tv.Type != nil {
-		if s, ok := tv.Type.(*types.Signature); ok {
-			sig = s
-		}
-	}
+	sig := typeshelper.GetFuncSignature(rootNode.Pass().TypesInfo.TypeOf(callExpr.Fun))
 
 	if sig == nil || !util.FuncIsErrReturning(sig) {
 		return nil, false

--- a/util/typeshelper/typeshelper.go
+++ b/util/typeshelper/typeshelper.go
@@ -55,3 +55,19 @@ func IsIterType(t types.Type) bool {
 	basic, ok := res.At(0).Type().Underlying().(*types.Basic)
 	return ok && basic.Kind() == types.Bool
 }
+
+// GetFuncSignature returns the signature of a function or an anonymous function.
+func GetFuncSignature(t types.Type) *types.Signature {
+	var sig *types.Signature
+	switch t2 := t.(type) {
+	case *types.Signature:
+		sig = t2
+	case *types.Alias:
+		// If the alias is a named function pointer, we extract its signature.
+		// Example: `type MyFunc func() (*int, error)`
+		if s, ok := t2.Underlying().(*types.Signature); ok {
+			sig = s
+		}
+	}
+	return sig
+}


### PR DESCRIPTION
This PR adds support for recognizing type alias, but employs a temporary fix of suppressing the false positives caused by type aliases until we implement a comprehensive reasoning support for the same.

Example of a type alias:
```

type MyErrRetFunc = func() (*int, error)

func callTypeAliasFunc(f MyErrRetFunc) {
	x, err := f()
	if err != nil {
		return
	}
	_ = *x  // False positive was earlier reported here
}
```