### PR TITLE
Recognize and suppress function value false positives

### DIFF
--- a/assertion/function/assertiontree/parse_expr_producer.go
+++ b/assertion/function/assertiontree/parse_expr_producer.go
@@ -286,19 +286,10 @@ func (r *RootAssertionNode) ParseExprAsProducer(expr ast.Expr, doNotTrack bool) 
 				}}}
 			}
 
-			// Check if it is a type alias for a function type.
-			// e.g., type MyFunc func() (*int, error)
-			// func foo(f MyErrRetFunc) {
-			// 		x, err := f()
-			// 		if err != nil {
-			// 			return
-			// 		}
-			// 		_ = *x
-			// }
-			// TODO: this is only a temporary fix to suppress false positives caused by type aliases.
-			//  Remove this once we have implemented complete support for type aliases.
-			t := r.Pass().TypesInfo.TypeOf(fun)
-			if _, ok := t.(*types.Alias); ok {
+			// Check if the method is a function value, e.g., `f := func() {}` and then `f()`.
+			// TODO: this is a temporary fix to suppress false positives caused by function values.
+			//  Remove this once we have have implemented the function value support.
+			if r.isVariable(fun) {
 				return nil, []producer.ParsedProducer{producer.ShallowParsedProducer{Producer: &annotation.ProduceTrigger{
 					Annotation: &annotation.TrustedFuncNonnil{ProduceTriggerNever: &annotation.ProduceTriggerNever{}},
 					Expr:       expr,

--- a/assertion/function/assertiontree/parse_expr_producer.go
+++ b/assertion/function/assertiontree/parse_expr_producer.go
@@ -346,6 +346,16 @@ func (r *RootAssertionNode) ParseExprAsProducer(expr ast.Expr, doNotTrack bool) 
 			return nil, r.getFuncReturnProducers(fun, expr)
 
 		case *ast.SelectorExpr: // method call
+			// Check if the method is a function value, e.g., `f := func() {}` and then `f()`.
+			// TODO: this is a temporary fix to handle the case of function values.
+			//  Remove this once we have have implemented the function value support.
+			if r.isVariable(fun.Sel) {
+				return nil, []producer.ParsedProducer{producer.ShallowParsedProducer{Producer: &annotation.ProduceTrigger{
+					Annotation: &annotation.TrustedFuncNonnil{ProduceTriggerNever: &annotation.ProduceTriggerNever{}},
+					Expr:       expr,
+				}}}
+			}
+
 			if !r.isFunc(fun.Sel) {
 				// we assume builtins and type casts don't return nil
 				return nil, nil

--- a/assertion/function/assertiontree/parse_expr_producer.go
+++ b/assertion/function/assertiontree/parse_expr_producer.go
@@ -276,16 +276,14 @@ func (r *RootAssertionNode) ParseExprAsProducer(expr ast.Expr, doNotTrack bool) 
 			// 		}
 			// 		_ = *x
 			// }
-			// TODO: this is only a temporary fix to suppress the case of type aliases for functions.
+			// TODO: this is only a temporary fix to suppress false positives caused by type aliases.
 			//  Remove this once we have implemented complete support for type aliases.
 			t := r.Pass().TypesInfo.TypeOf(fun)
-			if t != nil {
-				if _, ok := t.(*types.Alias); ok {
-					return nil, []producer.ParsedProducer{producer.ShallowParsedProducer{Producer: &annotation.ProduceTrigger{
-						Annotation: &annotation.TrustedFuncNonnil{ProduceTriggerNever: &annotation.ProduceTriggerNever{}},
-						Expr:       expr,
-					}}}
-				}
+			if _, ok := t.(*types.Alias); ok {
+				return nil, []producer.ParsedProducer{producer.ShallowParsedProducer{Producer: &annotation.ProduceTrigger{
+					Annotation: &annotation.TrustedFuncNonnil{ProduceTriggerNever: &annotation.ProduceTriggerNever{}},
+					Expr:       expr,
+				}}}
 			}
 
 			// Check if it is a type alias for a function type.

--- a/testdata/src/go.uber.org/anonymousfunction/rich_check_effect.go
+++ b/testdata/src/go.uber.org/anonymousfunction/rich_check_effect.go
@@ -111,11 +111,10 @@ func testAnonErrReturningFunc(i int) {
 		_ = *x // want "dereferenced"
 
 	case 9:
-		// TODO: fix this false positive case by handling global anonymous function
 		x, err := globalFunc()
 		if err != nil {
 			return
 		}
-		_ = *x // want "dereferenced"
+		_ = *x
 	}
 }

--- a/testdata/src/go.uber.org/inference/inference.go
+++ b/testdata/src/go.uber.org/inference/inference.go
@@ -18,119 +18,99 @@
 
 package inference
 
-// var dummyBool bool
-// var dummyInt int
-//
-// func retsNilable1() *int {
-// 	return nil
-// }
-//
-// func retsNilable2() *int {
-// 	if dummyBool {
-// 		return &dummyInt
-// 	}
-// 	return nil
-// }
-//
-// func retsNilable3() *int {
-// 	switch dummyInt {
-// 	case dummyInt:
-// 		return retsNilable1()
-// 	case dummyInt:
-// 		return retsNilable2()
-// 	case dummyInt:
-// 		return retsNilable3()
-// 	}
-// 	return &dummyInt
-// }
-//
-// func retsNonnil1() *int {
-// 	return &dummyInt
-// }
-//
-// func retsNonnil2() *int {
-// 	if dummyBool {
-// 		return &dummyInt
-// 	}
-// 	return &dummyInt
-// }
-//
-// func retsNonnil3() *int {
-// 	switch dummyInt {
-// 	case dummyInt:
-// 		return retsNonnil1()
-// 	case dummyInt:
-// 		return retsNonnil2()
-// 	case dummyInt:
-// 		return retsNonnil3()
-// 	}
-// 	return &dummyInt
-// }
-//
-// func retsNilable4() *int {
-// 	if dummyBool {
-// 		return retsNilable3()
-// 	}
-// 	return retsNilable3()
-// }
-//
-// func takesNonnil(x *int) int {
-// 	return *x
-// }
-//
-// func takesNilable(x *int) int {
-// 	if x == nil {
-// 		return 0
-// 	}
-// 	return *x
-// }
-//
-// func retsAndTakes() {
-// 	switch dummyInt {
-// 	case dummyInt:
-// 		takesNonnil(retsNonnil1())
-// 		takesNonnil(retsNonnil2())
-// 		takesNonnil(retsNonnil3())
-//
-// 		takesNilable(retsNonnil1())
-// 		takesNilable(retsNonnil2())
-// 		takesNilable(retsNonnil3())
-//
-// 		takesNilable(retsNilable1())
-// 		takesNilable(retsNilable2())
-// 		takesNilable(retsNilable3())
-// 		takesNilable(retsNilable4())
-// 	}
-// }
-//
-// // Below test checks the working of inference in the presence of annotations
-// // nonnil(x) nilable(result 0)
-// func foo(x *int) *int { //want "NONNIL because it is annotated as so"
-// 	print(*x)
-// 	return nil
-// }
-//
-// func callFoo() {
-// 	ptr := foo(nil)
-// 	print(*ptr) //want "NILABLE because it is annotated as so"
-// }
+var dummyBool bool
+var dummyInt int
 
-// type S struct {
-// 	f func() (*int, error)
-// }
-//
-// func testme(s *S) {
-// 	v, err := s.f()
-// 	if err != nil {
-// 		return
-// 	}
-// 	_ = *v // FP here
-// }
+func retsNilable1() *int {
+	return nil
+}
 
-func testme(f func() (*int, error)) {
-	v, err := f()
-	if err != nil {
-		return
+func retsNilable2() *int {
+	if dummyBool {
+		return &dummyInt
 	}
-	_ = *v // FP here
+	return nil
+}
+
+func retsNilable3() *int {
+	switch dummyInt {
+	case dummyInt:
+		return retsNilable1()
+	case dummyInt:
+		return retsNilable2()
+	case dummyInt:
+		return retsNilable3()
+	}
+	return &dummyInt
+}
+
+func retsNonnil1() *int {
+	return &dummyInt
+}
+
+func retsNonnil2() *int {
+	if dummyBool {
+		return &dummyInt
+	}
+	return &dummyInt
+}
+
+func retsNonnil3() *int {
+	switch dummyInt {
+	case dummyInt:
+		return retsNonnil1()
+	case dummyInt:
+		return retsNonnil2()
+	case dummyInt:
+		return retsNonnil3()
+	}
+	return &dummyInt
+}
+
+func retsNilable4() *int {
+	if dummyBool {
+		return retsNilable3()
+	}
+	return retsNilable3()
+}
+
+func takesNonnil(x *int) int {
+	return *x
+}
+
+func takesNilable(x *int) int {
+	if x == nil {
+		return 0
+	}
+	return *x
+}
+
+func retsAndTakes() {
+	switch dummyInt {
+	case dummyInt:
+		takesNonnil(retsNonnil1())
+		takesNonnil(retsNonnil2())
+		takesNonnil(retsNonnil3())
+
+		takesNilable(retsNonnil1())
+		takesNilable(retsNonnil2())
+		takesNilable(retsNonnil3())
+
+		takesNilable(retsNilable1())
+		takesNilable(retsNilable2())
+		takesNilable(retsNilable3())
+		takesNilable(retsNilable4())
+	}
+}
+
+// Below test checks the working of inference in the presence of annotations
+// nonnil(x) nilable(result 0)
+func foo(x *int) *int { //want "NONNIL because it is annotated as so"
+	print(*x)
+	return nil
+}
+
+func callFoo() {
+	ptr := foo(nil)
+	print(*ptr) //want "NILABLE because it is annotated as so"
 }

--- a/testdata/src/go.uber.org/inference/inference.go
+++ b/testdata/src/go.uber.org/inference/inference.go
@@ -18,99 +18,119 @@
 
 package inference
 
-var dummyBool bool
-var dummyInt int
+// var dummyBool bool
+// var dummyInt int
+//
+// func retsNilable1() *int {
+// 	return nil
+// }
+//
+// func retsNilable2() *int {
+// 	if dummyBool {
+// 		return &dummyInt
+// 	}
+// 	return nil
+// }
+//
+// func retsNilable3() *int {
+// 	switch dummyInt {
+// 	case dummyInt:
+// 		return retsNilable1()
+// 	case dummyInt:
+// 		return retsNilable2()
+// 	case dummyInt:
+// 		return retsNilable3()
+// 	}
+// 	return &dummyInt
+// }
+//
+// func retsNonnil1() *int {
+// 	return &dummyInt
+// }
+//
+// func retsNonnil2() *int {
+// 	if dummyBool {
+// 		return &dummyInt
+// 	}
+// 	return &dummyInt
+// }
+//
+// func retsNonnil3() *int {
+// 	switch dummyInt {
+// 	case dummyInt:
+// 		return retsNonnil1()
+// 	case dummyInt:
+// 		return retsNonnil2()
+// 	case dummyInt:
+// 		return retsNonnil3()
+// 	}
+// 	return &dummyInt
+// }
+//
+// func retsNilable4() *int {
+// 	if dummyBool {
+// 		return retsNilable3()
+// 	}
+// 	return retsNilable3()
+// }
+//
+// func takesNonnil(x *int) int {
+// 	return *x
+// }
+//
+// func takesNilable(x *int) int {
+// 	if x == nil {
+// 		return 0
+// 	}
+// 	return *x
+// }
+//
+// func retsAndTakes() {
+// 	switch dummyInt {
+// 	case dummyInt:
+// 		takesNonnil(retsNonnil1())
+// 		takesNonnil(retsNonnil2())
+// 		takesNonnil(retsNonnil3())
+//
+// 		takesNilable(retsNonnil1())
+// 		takesNilable(retsNonnil2())
+// 		takesNilable(retsNonnil3())
+//
+// 		takesNilable(retsNilable1())
+// 		takesNilable(retsNilable2())
+// 		takesNilable(retsNilable3())
+// 		takesNilable(retsNilable4())
+// 	}
+// }
+//
+// // Below test checks the working of inference in the presence of annotations
+// // nonnil(x) nilable(result 0)
+// func foo(x *int) *int { //want "NONNIL because it is annotated as so"
+// 	print(*x)
+// 	return nil
+// }
+//
+// func callFoo() {
+// 	ptr := foo(nil)
+// 	print(*ptr) //want "NILABLE because it is annotated as so"
+// }
 
-func retsNilable1() *int {
-	return nil
-}
+// type S struct {
+// 	f func() (*int, error)
+// }
+//
+// func testme(s *S) {
+// 	v, err := s.f()
+// 	if err != nil {
+// 		return
+// 	}
+// 	_ = *v // FP here
+// }
 
-func retsNilable2() *int {
-	if dummyBool {
-		return &dummyInt
+func testme(f func() (*int, error)) {
+	v, err := f()
+	if err != nil {
+		return
 	}
-	return nil
-}
-
-func retsNilable3() *int {
-	switch dummyInt {
-	case dummyInt:
-		return retsNilable1()
-	case dummyInt:
-		return retsNilable2()
-	case dummyInt:
-		return retsNilable3()
-	}
-	return &dummyInt
-}
-
-func retsNonnil1() *int {
-	return &dummyInt
-}
-
-func retsNonnil2() *int {
-	if dummyBool {
-		return &dummyInt
-	}
-	return &dummyInt
-}
-
-func retsNonnil3() *int {
-	switch dummyInt {
-	case dummyInt:
-		return retsNonnil1()
-	case dummyInt:
-		return retsNonnil2()
-	case dummyInt:
-		return retsNonnil3()
-	}
-	return &dummyInt
-}
-
-func retsNilable4() *int {
-	if dummyBool {
-		return retsNilable3()
-	}
-	return retsNilable3()
-}
-
-func takesNonnil(x *int) int {
-	return *x
-}
-
-func takesNilable(x *int) int {
-	if x == nil {
-		return 0
-	}
-	return *x
-}
-
-func retsAndTakes() {
-	switch dummyInt {
-	case dummyInt:
-		takesNonnil(retsNonnil1())
-		takesNonnil(retsNonnil2())
-		takesNonnil(retsNonnil3())
-
-		takesNilable(retsNonnil1())
-		takesNilable(retsNonnil2())
-		takesNilable(retsNonnil3())
-
-		takesNilable(retsNilable1())
-		takesNilable(retsNilable2())
-		takesNilable(retsNilable3())
-		takesNilable(retsNilable4())
-	}
-}
-
-// Below test checks the working of inference in the presence of annotations
-// nonnil(x) nilable(result 0)
-func foo(x *int) *int { //want "NONNIL because it is annotated as so"
-	print(*x)
-	return nil
-}
-
-func callFoo() {
-	ptr := foo(nil)
-	print(*ptr) //want "NILABLE because it is annotated as so"
+	_ = *v // FP here
 }


### PR DESCRIPTION
Similar to PR #333 , this PR adds support for recognizing function values, but employs a temporary fix of suppressing the false positives caused by function values until we implement a comprehensive reasoning support for the same.

Example of a function value:
```
type A struct {
	f func() (*int, error)
}

func foo(a *A) {
        v, err := a.f()
	if err != nil {
		return
	}
	_ = *v  // False positive was earlier reported here
}

```