### PR TITLE
Support named collection type receivers

### DIFF
--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -800,7 +800,7 @@ func (r *RootAssertionNode) AddComputation(expr ast.Expr) {
 		allowNilable := false
 		if funcObj, ok := r.ObjectOf(expr.Sel).(*types.Func); ok { // Check 1:  selector expression is a method invocation
 			recv := funcObj.Type().(*types.Signature).Recv()
-			if util.TypeIsDeeplyPtr(recv.Type()) { // Check 2: receiver is a pointer receiver
+			if util.TypeIsPointer(recv.Type()) { // Check 2: receiver is an explicit or implicit pointer receiver
 				conf := r.Pass().ResultOf[config.Analyzer].(*config.Config)
 				if conf.IsPkgInScope(funcObj.Pkg()) { // Check 3: invoked method is in scope
 					// Here, `t` can only be of type interface, struct, or named, of which we only support for struct and named types.

--- a/testdata/src/go.uber.org/receivers/inference/named-types.go
+++ b/testdata/src/go.uber.org/receivers/inference/named-types.go
@@ -1,0 +1,169 @@
+package inference
+
+// Named Slice type
+
+type myIntSlice []int
+
+func (m myIntSlice) len() {
+	print(len(m))
+}
+
+func (m myIntSlice) count() int {
+	count := 0
+	for _, e := range m {
+		count = count + e
+	}
+	return count
+}
+
+func (m myIntSlice) fetch(i int) int {
+	return m[i]
+}
+
+type T struct {
+	f *int
+}
+
+type myTSlice []T
+
+// Note to navigate our test setup, we need several duplicate fetch methods to ensure that the "want" message can be triggered
+// for the appropriate fetch methods.
+
+func (m myTSlice) fetch1(i int) *int {
+	return m[i].f //want "sliced into"
+}
+
+func (m myTSlice) fetch2(i int) *int {
+	return m[i].f
+}
+
+func (m myTSlice) fetch3(i int) *int {
+	return m[i].f
+}
+
+func (m myTSlice) fetch4(i int) *int {
+	return m[i].f
+}
+
+func (m myTSlice) fetch5(i int) *int {
+	return m[i].f //want "sliced into"
+}
+
+func newMyIntSlice(input myIntSlice) myIntSlice {
+	var result myIntSlice
+	for _, t := range input {
+		result = append(result, t)
+	}
+	return result
+}
+
+func testNamedSlice(i int) {
+	switch i {
+	case 0:
+		res := map[string]myIntSlice{}
+		res["abc"].len()
+
+	case 1:
+		m := myIntSlice{1, 2, 3}
+		print(newMyIntSlice(m).count())
+		print(newMyIntSlice(nil).count())
+
+	case 2:
+		var m myTSlice
+		_ = m.fetch1(i) // error reported in "fetch1" method
+
+	case 3:
+		m := myTSlice{{f: new(int)}, {f: new(int)}, {f: new(int)}}
+		_ = m.fetch2(i)
+
+	case 4:
+		var m myTSlice
+		m = append(m, T{})
+		m[0].f = nil
+
+		_ = *m.fetch3(i) //want "dereferenced"
+
+	case 5:
+		var m myTSlice
+		m = append(m, T{})
+		m[0].f = new(int)
+
+		_ = *m.fetch4(i)
+
+	case 6:
+		var m myTSlice
+		_ = *m.fetch5(i) // error reported in "fetch5" method
+	}
+}
+
+type myIntPointers []*int
+
+func (m myIntPointers) fetch(i int) *int {
+	for x := range m {
+		if x == i {
+			return m[x]
+		}
+	}
+	return nil
+}
+
+func testNamedSliceOfPointers(i int) {
+	switch i {
+	case 0:
+		var m myIntPointers
+		_ = m.fetch(i)
+
+	case 1:
+		m := myIntPointers{new(int), new(int), new(int)}
+		_ = m.fetch(i)
+
+	case 2:
+		var m myIntPointers
+		_ = *m.fetch(i) //want "dereferenced"
+
+	case 3:
+		m := myIntPointers{new(int), new(int), new(int)}
+		*m.fetch(i) = 42 //want "dereferenced"
+
+	case 4:
+		m := myIntPointers{nil, nil}
+		_ = *m.fetch(i) //want "dereferenced"
+	}
+}
+
+// Named Map type
+type myIntMap map[string]*int
+
+func (m myIntMap) get(key string) *int {
+	return m[key]
+}
+
+func testNamedMap(i int) {
+	switch i {
+	case 0:
+		var m myIntMap
+		_ = *m.get("key") //want "dereferenced"
+
+	case 1:
+		m := myIntMap{"a": new(int), "b": new(int)}
+		if v := m.get("a"); v != nil {
+			_ = *v
+		}
+
+	case 2:
+		m := myIntMap{"a": new(int), "b": new(int)}
+		if v := m["a"]; v != nil {
+			_ = *v
+		}
+
+	case 3:
+		m := myIntMap{"a": new(int), "b": new(int)}
+		if _, ok := m["a"]; ok {
+			_ = *m["a"]
+		}
+
+	case 4:
+		var m myIntMap
+		_ = *m["a"] //want "dereferenced"
+	}
+}

--- a/util/util.go
+++ b/util/util.go
@@ -169,6 +169,17 @@ func TypeIsDeeplyInterface(t types.Type) bool {
 	return false
 }
 
+// TypeIsPointer checks whether the type `t` is an explicit or implicit pointer type, which could also be of deep type.
+// Examples of explicit pointer types are `*int`, `*S`, etc.
+// Examples of implicit pointer types are `[]int`, `map[string]*S`, `chan int`, etc.
+func TypeIsPointer(t types.Type) bool {
+	return TypeIsDeeplyPtr(t) ||
+		TypeIsDeeplySlice(t) ||
+		TypeIsDeeplyMap(t) ||
+		TypeIsDeeplyArray(t) ||
+		TypeIsDeeplyChan(t)
+}
+
 // UnwrapPtr unwraps a pointer type and returns the element type. For all other types it returns
 // the type unmodified.
 func UnwrapPtr(t types.Type) types.Type {


### PR DESCRIPTION
This PR adds support for handling named collection type receivers, which are implicitly nilable. This specifically helps address the false positives that were reported for named nil slice. Example:
```
type StringSlice []string

func (r StringSlice) hello() {
	fmt.Println("hello")
}

func main() {
	res := map[string]StringSlice{}
	res["bla"].hello()  // FP was reported here
}
```

[Closes #298 ]
[Closes #300 ]
[Closes #315 ]