### PR TITLE
Suppress struct field assigned errors until we add object sensitivity

### DIFF
--- a/accumulation/analyzer.go
+++ b/accumulation/analyzer.go
@@ -127,6 +127,14 @@ func run(pass *analysis.Pass) (result interface{}, _ error) {
 	)
 	switch mode {
 	case inference.FullInfer:
+		// Filter triggers
+		for _, t := range assertionsResult.Res {
+			if _, ok := t.Consumer.Annotation.(*annotation.FldAssign); ok {
+				// update its producer to be non-nil
+				t.Producer.Annotation = &annotation.ProduceTriggerNever{}
+			}
+		}
+
 		// Incorporate assertions from this package one-by-one into the inferredAnnotationMap, possibly
 		// determining local and upstream sites in the process. This is guaranteed not to determine any
 		// sites unless we really have a reason they have to be determined.

--- a/accumulation/analyzer.go
+++ b/accumulation/analyzer.go
@@ -127,13 +127,15 @@ func run(pass *analysis.Pass) (result interface{}, _ error) {
 	)
 	switch mode {
 	case inference.FullInfer:
-		// // Filter triggers
-		// for _, t := range assertionsResult.Res {
-		// 	if _, ok := t.Consumer.Annotation.(*annotation.FldAssign); ok {
-		// 		// update its producer to be non-nil
-		// 		t.Producer.Annotation = &annotation.ProduceTriggerNever{}
-		// 	}
-		// }
+		// TODO: This is a suppression added for handling of struct field assignments. We plan to add
+		//  object sensitivity to NilAway in the future, which will allow us to be more precise in struct fields'
+		//  handling. Remove this suppression once we have the object sensitivity implemented (issue #339).
+		for _, t := range assertionsResult.Res {
+			if _, ok := t.Consumer.Annotation.(*annotation.FldAssign); ok {
+				// update its producer to be non-nil
+				t.Producer.Annotation = &annotation.ProduceTriggerNever{}
+			}
+		}
 
 		// Incorporate assertions from this package one-by-one into the inferredAnnotationMap, possibly
 		// determining local and upstream sites in the process. This is guaranteed not to determine any

--- a/accumulation/analyzer.go
+++ b/accumulation/analyzer.go
@@ -127,13 +127,13 @@ func run(pass *analysis.Pass) (result interface{}, _ error) {
 	)
 	switch mode {
 	case inference.FullInfer:
-		// Filter triggers
-		for _, t := range assertionsResult.Res {
-			if _, ok := t.Consumer.Annotation.(*annotation.FldAssign); ok {
-				// update its producer to be non-nil
-				t.Producer.Annotation = &annotation.ProduceTriggerNever{}
-			}
-		}
+		// // Filter triggers
+		// for _, t := range assertionsResult.Res {
+		// 	if _, ok := t.Consumer.Annotation.(*annotation.FldAssign); ok {
+		// 		// update its producer to be non-nil
+		// 		t.Producer.Annotation = &annotation.ProduceTriggerNever{}
+		// 	}
+		// }
 
 		// Incorporate assertions from this package one-by-one into the inferredAnnotationMap, possibly
 		// determining local and upstream sites in the process. This is guaranteed not to determine any

--- a/assertion/function/assertiontree/backprop_util.go
+++ b/assertion/function/assertiontree/backprop_util.go
@@ -648,13 +648,14 @@ func exprAsAssignmentConsumer(rootNode *RootAssertionNode, expr ast.Node, exprRH
 			}
 		}
 
-		return &annotation.FldAssign{
-			TriggerIfNonNil: &annotation.TriggerIfNonNil{
-				Ann: &annotation.FieldAnnotationKey{
-					FieldDecl: rootNode.ObjectOf(expr.Sel).(*types.Var),
-				},
-			},
-		}, nil
+		// return &annotation.FldAssign{
+		// 	TriggerIfNonNil: &annotation.TriggerIfNonNil{
+		// 		Ann: &annotation.FieldAnnotationKey{
+		// 			FieldDecl: rootNode.ObjectOf(expr.Sel).(*types.Var),
+		// 		},
+		// 	},
+		// }, nil
+		return nil, nil
 	case *ast.StarExpr:
 		return handleDeepAssignmentToExpr(expr.X)
 	case *ast.IndexExpr:

--- a/assertion/function/assertiontree/backprop_util.go
+++ b/assertion/function/assertiontree/backprop_util.go
@@ -648,14 +648,13 @@ func exprAsAssignmentConsumer(rootNode *RootAssertionNode, expr ast.Node, exprRH
 			}
 		}
 
-		// return &annotation.FldAssign{
-		// 	TriggerIfNonNil: &annotation.TriggerIfNonNil{
-		// 		Ann: &annotation.FieldAnnotationKey{
-		// 			FieldDecl: rootNode.ObjectOf(expr.Sel).(*types.Var),
-		// 		},
-		// 	},
-		// }, nil
-		return nil, nil
+		return &annotation.FldAssign{
+			TriggerIfNonNil: &annotation.TriggerIfNonNil{
+				Ann: &annotation.FieldAnnotationKey{
+					FieldDecl: rootNode.ObjectOf(expr.Sel).(*types.Var),
+				},
+			},
+		}, nil
 	case *ast.StarExpr:
 		return handleDeepAssignmentToExpr(expr.X)
 	case *ast.IndexExpr:

--- a/nilaway_test.go
+++ b/nilaway_test.go
@@ -46,7 +46,7 @@ func TestNilAway(t *testing.T) {
 	}{
 		{name: "Inference", patterns: []string{"go.uber.org/inference"}},
 		{name: "Contracts", patterns: []string{"go.uber.org/contracts", "go.uber.org/contracts/namedtypes", "go.uber.org/contracts/inference"}},
-		{name: "TrustedFunc", patterns: []string{"go.uber.org/trustedfunc"}},
+		{name: "TrustedFunc", patterns: []string{"go.uber.org/trustedfunc", "go.uber.org/trustedfunc/inference"}},
 		{name: "ErrorReturn", patterns: []string{"go.uber.org/errorreturn", "go.uber.org/errorreturn/inference"}},
 		{name: "Maps", patterns: []string{"go.uber.org/maps"}},
 		{name: "Slices", patterns: []string{"go.uber.org/slices", "go.uber.org/slices/inference"}},

--- a/testdata/src/go.uber.org/deepnil/inference/deepnil-with-inference.go
+++ b/testdata/src/go.uber.org/deepnil/inference/deepnil-with-inference.go
@@ -196,7 +196,9 @@ func testDeepLocalInterprocedural(i int) {
 	case 10:
 		a := &A{}
 		a.f = nil
-		_ = *deepLocalReturn10(a)[0] //want "deep read from result 0 of `deepLocalReturn10.*` dereferenced"
+		// TODO: Error should be reported on the line below. It is currently not reported because of the suppression of
+		//  struct field assignment logic that we added until we add object sensitivity for precise handling (issue #339).
+		_ = *deepLocalReturn10(a)[0] // "deep read from result 0 of `deepLocalReturn10.*` dereferenced"
 	}
 }
 

--- a/testdata/src/go.uber.org/inference/inference.go
+++ b/testdata/src/go.uber.org/inference/inference.go
@@ -180,3 +180,17 @@ func NewS() (*S, error) {
 	}
 	return nil, myErr{}
 }
+
+type S2 struct {
+	Field *int
+}
+
+func foo() {
+	s := &S2{}
+	s.Field = nil
+}
+
+func bar() {
+	s := &S2{Field: new(int)}
+	print(*s.Field)
+}

--- a/testdata/src/go.uber.org/inference/inference.go
+++ b/testdata/src/go.uber.org/inference/inference.go
@@ -18,179 +18,126 @@
 
 package inference
 
-import (
-	"stubs/github.com/stretchr/testify/suite"
-)
+var dummyBool bool
+var dummyInt int
 
-// var dummyBool bool
-// var dummyInt int
-//
-// func retsNilable1() *int {
-// 	return nil
-// }
-//
-// func retsNilable2() *int {
-// 	if dummyBool {
-// 		return &dummyInt
-// 	}
-// 	return nil
-// }
-//
-// func retsNilable3() *int {
-// 	switch dummyInt {
-// 	case dummyInt:
-// 		return retsNilable1()
-// 	case dummyInt:
-// 		return retsNilable2()
-// 	case dummyInt:
-// 		return retsNilable3()
-// 	}
-// 	return &dummyInt
-// }
-//
-// func retsNonnil1() *int {
-// 	return &dummyInt
-// }
-//
-// func retsNonnil2() *int {
-// 	if dummyBool {
-// 		return &dummyInt
-// 	}
-// 	return &dummyInt
-// }
-//
-// func retsNonnil3() *int {
-// 	switch dummyInt {
-// 	case dummyInt:
-// 		return retsNonnil1()
-// 	case dummyInt:
-// 		return retsNonnil2()
-// 	case dummyInt:
-// 		return retsNonnil3()
-// 	}
-// 	return &dummyInt
-// }
-//
-// func retsNilable4() *int {
-// 	if dummyBool {
-// 		return retsNilable3()
-// 	}
-// 	return retsNilable3()
-// }
-//
-// func takesNonnil(x *int) int {
-// 	return *x
-// }
-//
-// func takesNilable(x *int) int {
-// 	if x == nil {
-// 		return 0
-// 	}
-// 	return *x
-// }
-//
-// func retsAndTakes() {
-// 	switch dummyInt {
-// 	case dummyInt:
-// 		takesNonnil(retsNonnil1())
-// 		takesNonnil(retsNonnil2())
-// 		takesNonnil(retsNonnil3())
-//
-// 		takesNilable(retsNonnil1())
-// 		takesNilable(retsNonnil2())
-// 		takesNilable(retsNonnil3())
-//
-// 		takesNilable(retsNilable1())
-// 		takesNilable(retsNilable2())
-// 		takesNilable(retsNilable3())
-// 		takesNilable(retsNilable4())
-// 	}
-// }
-//
-// // Below test checks the working of inference in the presence of annotations
-// // nonnil(x) nilable(result 0)
-// func foo(x *int) *int { //want "NONNIL because it is annotated as so"
-// 	print(*x)
-// 	return nil
-// }
-//
-// func callFoo() {
-// 	ptr := foo(nil)
-// 	print(*ptr) //want "NILABLE because it is annotated as so"
-// }
+func retsNilable1() *int {
+	return nil
+}
 
-// type S struct {
-// 	f *int
-// }
-//
-// var dummy bool
-//
-// type myErr2 struct{}
-//
-// func (myErr2) Error() string { return "myErr2 message" }
-//
-// func retPtrErr() (*int, error) {
-// 	if dummy {
-// 		return nil, &myErr2{}
-// 	}
-// 	return new(int), nil
-// }
-//
-// func test(s *S) {
-// 	var err error
-// 	s.f, err = retPtrErr()
-// 	if err != nil {
-// 		return
-// 	}
-// 	print(*s.f)
-// }
+func retsNilable2() *int {
+	if dummyBool {
+		return &dummyInt
+	}
+	return nil
+}
+
+func retsNilable3() *int {
+	switch dummyInt {
+	case dummyInt:
+		return retsNilable1()
+	case dummyInt:
+		return retsNilable2()
+	case dummyInt:
+		return retsNilable3()
+	}
+	return &dummyInt
+}
+
+func retsNonnil1() *int {
+	return &dummyInt
+}
+
+func retsNonnil2() *int {
+	if dummyBool {
+		return &dummyInt
+	}
+	return &dummyInt
+}
+
+func retsNonnil3() *int {
+	switch dummyInt {
+	case dummyInt:
+		return retsNonnil1()
+	case dummyInt:
+		return retsNonnil2()
+	case dummyInt:
+		return retsNonnil3()
+	}
+	return &dummyInt
+}
+
+func retsNilable4() *int {
+	if dummyBool {
+		return retsNilable3()
+	}
+	return retsNilable3()
+}
+
+func takesNonnil(x *int) int {
+	return *x
+}
+
+func takesNilable(x *int) int {
+	if x == nil {
+		return 0
+	}
+	return *x
+}
+
+func retsAndTakes() {
+	switch dummyInt {
+	case dummyInt:
+		takesNonnil(retsNonnil1())
+		takesNonnil(retsNonnil2())
+		takesNonnil(retsNonnil3())
+
+		takesNilable(retsNonnil1())
+		takesNilable(retsNonnil2())
+		takesNilable(retsNonnil3())
+
+		takesNilable(retsNilable1())
+		takesNilable(retsNilable2())
+		takesNilable(retsNilable3())
+		takesNilable(retsNilable4())
+	}
+}
+
+// Below test checks the working of inference in the presence of annotations
+// nonnil(x) nilable(result 0)
+func foo(x *int) *int { //want "NONNIL because it is annotated as so"
+	print(*x)
+	return nil
+}
+
+func callFoo() {
+	ptr := foo(nil)
+	print(*ptr) //want "NILABLE because it is annotated as so"
+}
 
 type S struct {
-	f *int
-}
-
-type SSuite struct {
-	suite.Suite
-	S *S
-}
-
-func (s *SSuite) SetupTest() {
-	var err error
-	s.S, err = NewS()
-	if err != nil {
-		return
-	}
-	// s.NoError(err)
-	print(s.S.f) // safe
-}
-
-func (s *SSuite) TestField() {
-	print(s.S.f) // FP reported here
-}
-
-var dummy bool
-
-type myErr struct{}
-
-func (myErr) Error() string { return "myErr message" }
-
-func NewS() (*S, error) {
-	if dummy {
-		return &S{}, nil
-	}
-	return nil, myErr{}
-}
-
-type S2 struct {
 	Field *int
 }
 
-func foo() {
-	s := &S2{}
+func f1() *S {
+	s := &S{}
 	s.Field = nil
+	print(*s.Field) //want "dereferenced"
+	return s
 }
 
-func bar() {
-	s := &S2{Field: new(int)}
-	print(*s.Field)
+func f2() *S {
+	s := &S{Field: new(int)}
+	print(*s.Field) // safe
+	return s
+}
+
+func f3() {
+	s1 := f1()
+	// TODO: Error should be reported on the line below. It is currently not reported because of the suppression of
+	//  struct field assignment logic that we added until we add object sensitivity for precise handling (issue #339).
+	print(*s1.Field) // "dereferenced"
+
+	s2 := f2()
+	print(*s2.Field) // safe
 }

--- a/testdata/src/go.uber.org/inference/inference.go
+++ b/testdata/src/go.uber.org/inference/inference.go
@@ -18,99 +18,165 @@
 
 package inference
 
-var dummyBool bool
-var dummyInt int
+import (
+	"stubs/github.com/stretchr/testify/suite"
+)
 
-func retsNilable1() *int {
-	return nil
+// var dummyBool bool
+// var dummyInt int
+//
+// func retsNilable1() *int {
+// 	return nil
+// }
+//
+// func retsNilable2() *int {
+// 	if dummyBool {
+// 		return &dummyInt
+// 	}
+// 	return nil
+// }
+//
+// func retsNilable3() *int {
+// 	switch dummyInt {
+// 	case dummyInt:
+// 		return retsNilable1()
+// 	case dummyInt:
+// 		return retsNilable2()
+// 	case dummyInt:
+// 		return retsNilable3()
+// 	}
+// 	return &dummyInt
+// }
+//
+// func retsNonnil1() *int {
+// 	return &dummyInt
+// }
+//
+// func retsNonnil2() *int {
+// 	if dummyBool {
+// 		return &dummyInt
+// 	}
+// 	return &dummyInt
+// }
+//
+// func retsNonnil3() *int {
+// 	switch dummyInt {
+// 	case dummyInt:
+// 		return retsNonnil1()
+// 	case dummyInt:
+// 		return retsNonnil2()
+// 	case dummyInt:
+// 		return retsNonnil3()
+// 	}
+// 	return &dummyInt
+// }
+//
+// func retsNilable4() *int {
+// 	if dummyBool {
+// 		return retsNilable3()
+// 	}
+// 	return retsNilable3()
+// }
+//
+// func takesNonnil(x *int) int {
+// 	return *x
+// }
+//
+// func takesNilable(x *int) int {
+// 	if x == nil {
+// 		return 0
+// 	}
+// 	return *x
+// }
+//
+// func retsAndTakes() {
+// 	switch dummyInt {
+// 	case dummyInt:
+// 		takesNonnil(retsNonnil1())
+// 		takesNonnil(retsNonnil2())
+// 		takesNonnil(retsNonnil3())
+//
+// 		takesNilable(retsNonnil1())
+// 		takesNilable(retsNonnil2())
+// 		takesNilable(retsNonnil3())
+//
+// 		takesNilable(retsNilable1())
+// 		takesNilable(retsNilable2())
+// 		takesNilable(retsNilable3())
+// 		takesNilable(retsNilable4())
+// 	}
+// }
+//
+// // Below test checks the working of inference in the presence of annotations
+// // nonnil(x) nilable(result 0)
+// func foo(x *int) *int { //want "NONNIL because it is annotated as so"
+// 	print(*x)
+// 	return nil
+// }
+//
+// func callFoo() {
+// 	ptr := foo(nil)
+// 	print(*ptr) //want "NILABLE because it is annotated as so"
+// }
+
+// type S struct {
+// 	f *int
+// }
+//
+// var dummy bool
+//
+// type myErr2 struct{}
+//
+// func (myErr2) Error() string { return "myErr2 message" }
+//
+// func retPtrErr() (*int, error) {
+// 	if dummy {
+// 		return nil, &myErr2{}
+// 	}
+// 	return new(int), nil
+// }
+//
+// func test(s *S) {
+// 	var err error
+// 	s.f, err = retPtrErr()
+// 	if err != nil {
+// 		return
+// 	}
+// 	print(*s.f)
+// }
+
+type S struct {
+	f *int
 }
 
-func retsNilable2() *int {
-	if dummyBool {
-		return &dummyInt
+type SSuite struct {
+	suite.Suite
+	S *S
+}
+
+func (s *SSuite) SetupTest() {
+	var err error
+	s.S, err = NewS()
+	if err != nil {
+		return
 	}
-	return nil
+	// s.NoError(err)
+	print(s.S.f) // safe
 }
 
-func retsNilable3() *int {
-	switch dummyInt {
-	case dummyInt:
-		return retsNilable1()
-	case dummyInt:
-		return retsNilable2()
-	case dummyInt:
-		return retsNilable3()
+func (s *SSuite) TestField() {
+	print(s.S.f) // FP reported here
+}
+
+var dummy bool
+
+type myErr struct{}
+
+func (myErr) Error() string { return "myErr message" }
+
+func NewS() (*S, error) {
+	if dummy {
+		return &S{}, nil
 	}
-	return &dummyInt
-}
-
-func retsNonnil1() *int {
-	return &dummyInt
-}
-
-func retsNonnil2() *int {
-	if dummyBool {
-		return &dummyInt
-	}
-	return &dummyInt
-}
-
-func retsNonnil3() *int {
-	switch dummyInt {
-	case dummyInt:
-		return retsNonnil1()
-	case dummyInt:
-		return retsNonnil2()
-	case dummyInt:
-		return retsNonnil3()
-	}
-	return &dummyInt
-}
-
-func retsNilable4() *int {
-	if dummyBool {
-		return retsNilable3()
-	}
-	return retsNilable3()
-}
-
-func takesNonnil(x *int) int {
-	return *x
-}
-
-func takesNilable(x *int) int {
-	if x == nil {
-		return 0
-	}
-	return *x
-}
-
-func retsAndTakes() {
-	switch dummyInt {
-	case dummyInt:
-		takesNonnil(retsNonnil1())
-		takesNonnil(retsNonnil2())
-		takesNonnil(retsNonnil3())
-
-		takesNilable(retsNonnil1())
-		takesNilable(retsNonnil2())
-		takesNilable(retsNonnil3())
-
-		takesNilable(retsNilable1())
-		takesNilable(retsNilable2())
-		takesNilable(retsNilable3())
-		takesNilable(retsNilable4())
-	}
-}
-
-// Below test checks the working of inference in the presence of annotations
-// nonnil(x) nilable(result 0)
-func foo(x *int) *int { //want "NONNIL because it is annotated as so"
-	print(*x)
-	return nil
-}
-
-func callFoo() {
-	ptr := foo(nil)
-	print(*ptr) //want "NILABLE because it is annotated as so"
+	return nil, myErr{}
 }

--- a/testdata/src/go.uber.org/receivers/inference/named-types.go
+++ b/testdata/src/go.uber.org/receivers/inference/named-types.go
@@ -81,7 +81,9 @@ func testNamedSlice(i int) {
 		m = append(m, T{})
 		m[0].f = nil
 
-		_ = *m.fetch3(i) //want "dereferenced"
+		// TODO: Error should be reported on the line below. It is currently not reported because of the suppression of
+		//  struct field assignment logic that we added until we add object sensitivity for precise handling (issue #339).
+		_ = *m.fetch3(i) // "dereferenced"
 
 	case 5:
 		var m myTSlice

--- a/testdata/src/go.uber.org/receivers/inference/receivers-with-inference.go
+++ b/testdata/src/go.uber.org/receivers/inference/receivers-with-inference.go
@@ -186,7 +186,9 @@ func testBlankAndNonPointerReceiversForLibraryMethods() {
 	var e E
 	var err2 error
 	e.errField = err2
-	print(e.errField.Error()) //want "unassigned variable"
+	// TODO: Error should be reported on the line below. It is currently not reported because of the suppression of
+	//  struct field assignment logic that we added until we add object sensitivity for precise handling (issue #339).
+	print(e.errField.Error()) // "unassigned variable"
 
 	e.errField = &myErr{}
 	print(e.errField.Error()) // safe

--- a/testdata/src/go.uber.org/structinit/global/global.go
+++ b/testdata/src/go.uber.org/structinit/global/global.go
@@ -57,7 +57,9 @@ func h2() {
 		return
 	}
 
-	print(g2.aptr.ptr) //want "field `aptr` accessed field `ptr`"
+	// TODO: Error should be reported on the line below. It is currently not reported because of the suppression of
+	//  struct field assignment logic that we added until we add object sensitivity for precise handling (issue #339).
+	print(g2.aptr.ptr) // "field `aptr` accessed field `ptr`"
 }
 
 var g3 = &A{}

--- a/testdata/src/go.uber.org/trustedfunc/inference/trustedfuncs-with-inference.go
+++ b/testdata/src/go.uber.org/trustedfunc/inference/trustedfuncs-with-inference.go
@@ -1,0 +1,36 @@
+package inference
+
+import "stubs/github.com/stretchr/testify/suite"
+
+var dummy bool
+
+type myErr struct{}
+
+func (myErr) Error() string { return "myErr message" }
+
+type S struct {
+	f *int
+}
+
+type SSuite struct {
+	suite.Suite
+	S *S
+}
+
+func NewS() (*S, error) {
+	if dummy {
+		return &S{}, nil
+	}
+	return nil, myErr{}
+}
+
+func (s *SSuite) SetupTest() {
+	var err error
+	s.S, err = NewS()
+	s.NoError(err)
+	print(s.S.f) // safe
+}
+
+func (s *SSuite) TestField() {
+	print(s.S.f) // safe since SetupTest is called before this
+}


### PR DESCRIPTION
This PR serves as a stopgap solution to prevent reporting of false positives for struct field errors until we add object sensitivity for precise handling (tracked in #339 ).