### PR TITLE
Suppress direct passing of rich check effect func

### DIFF
--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -612,6 +612,13 @@ func (r *RootAssertionNode) AddComputation(expr ast.Expr) {
 					handleArgFuncIdent := func(argFuncIdent *ast.Ident) bool {
 						if r.isFunc(argFuncIdent) {
 							funcObj := r.ObjectOf(argFuncIdent).(*types.Func)
+
+							// Check if it is a rich check effect function call. If yes, this needs special handling.
+							if util.FuncIsErrReturning(funcObj.Signature()) || util.FuncIsOkReturning(funcObj.Signature()) {
+								// TODO: this is a temporary suppression which will be removed once we add support for
+								//  handling such cases precisely.
+								return true
+							}
 							if n := util.FuncNumResults(funcObj); n > 1 {
 								// is a pass of a multiply returning function to another function
 								_, producers := r.ParseExprAsProducer(argFunc, true)

--- a/testdata/src/go.uber.org/errorreturn/inference/errorreturn-with-inference.go
+++ b/testdata/src/go.uber.org/errorreturn/inference/errorreturn-with-inference.go
@@ -908,3 +908,19 @@ func testFunctionValue(i int) {
 		})
 	}
 }
+
+// checkError is a function that follows the same pattern as foo.
+func checkError(ptr *int, err error) (*int, error) {
+	if err != nil {
+		return nil, err
+	}
+	return ptr, nil
+}
+
+func TestDirectPassingOfErrorReturningFunc() {
+	ptr, err := checkError(retPtrAndErr2(0))
+	if err != nil {
+		return
+	}
+	print(*ptr) // safe
+}


### PR DESCRIPTION
This PR adds suppression for false positives caused by direct passing of rich check effect function. This is only meant to be a temporary solution until we add systematic support for this case as tracked in #101 .