### PR TITLE
Fix for handling assignment from non-pointer to pointer type in rich check effect context

### DIFF
--- a/assertion/function/assertiontree/rich_check_effect.go
+++ b/assertion/function/assertiontree/rich_check_effect.go
@@ -354,8 +354,7 @@ func NodeTriggersOkRead(rootNode *RootAssertionNode, nonceGenerator *util.GuardN
 		for i := 0; i < len(lhs)-1; i++ {
 			lhsExpr := lhs[i]
 			lhsValueParsed := parseExpr(rootNode, lhsExpr)
-			if lhsValueParsed == nil || util.ExprBarsNilness(rootNode.Pass(), lhsExpr) {
-				// ignore assignments to any variables whose type bars nilness, such as 'int'
+			if lhsValueParsed == nil {
 				continue
 			}
 			// here, the lhs `value` operand is trackable
@@ -421,9 +420,7 @@ func NodeTriggersFuncErrRet(rootNode *RootAssertionNode, nonceGenerator *util.Gu
 		lhsExpr := lhs[i]
 		lhsExprParsed := parseExpr(rootNode, lhsExpr)
 
-		if lhsExprParsed == nil || util.ExprBarsNilness(rootNode.Pass(), lhsExpr) {
-			// for now, we ignore assignments into anything but local variables
-			// we also ignore assignments to any variables whose type bars nilness, such as 'int'
+		if lhsExprParsed == nil {
 			continue
 		}
 

--- a/testdata/src/go.uber.org/contracts/inference/userdefinedfunctions-with-inference.go
+++ b/testdata/src/go.uber.org/contracts/inference/userdefinedfunctions-with-inference.go
@@ -165,3 +165,97 @@ func testAlwaysSafeMultipleHops() {
 	v2, _ := f1(0)
 	print(*v2) //want "dereferenced"
 }
+
+type Value[T any] struct {
+	value T
+	valid bool
+}
+
+func (v Value[T]) Get() (T, bool) {
+	return v.value, v.valid
+}
+
+type V struct{}
+
+func retV() (V, bool) {
+	return V{}, true
+}
+
+func retInt() (int, bool) {
+	return 42, true
+}
+
+func TestAssignmentToNonPointerTypes(i int, v Value[V]) {
+	switch i {
+	case 1:
+		var sum *V
+		if a, ok := v.Get(); ok {
+			sum = &a
+			_ = *sum
+		}
+
+	case 2:
+		var sum *V
+		if a, ok := v.Get(); ok {
+			_ = &a
+			_ = *sum //want "dereferenced"
+		}
+
+	case 3:
+		var sum1, sum2 *V
+		if a, ok := v.Get(); ok {
+			sum1 = &a
+			_ = *sum1
+			_ = *sum2 //want "dereferenced"
+		}
+
+	case 4:
+		var sum *V
+		if a, ok := retV(); ok {
+			sum = &a
+			_ = *sum
+		}
+
+	case 5:
+		var sum *V
+		if a, ok := retV(); ok {
+			_ = &a
+			_ = *sum //want "dereferenced"
+		}
+
+	case 6:
+		var sum1, sum2 *V
+		if a, ok := retV(); ok {
+			sum1 = &a
+			_ = *sum1
+			_ = *sum2 //want "dereferenced"
+		}
+
+	case 7:
+		var sum *int
+		if a, ok := retInt(); ok {
+			sum = &a
+			_ = *sum
+		}
+
+	case 8:
+		var sum *int
+		if a, ok := retInt(); ok {
+			_ = &a
+			_ = *sum //want "dereferenced"
+		}
+
+	case 9:
+		var sum *V
+		a, _ := retV()
+		sum = &a
+		_ = *sum
+
+	case 10:
+		var sum *V
+		if a, ok := retV(); !ok {
+			sum = &a
+			_ = *sum
+		}
+	}
+}

--- a/testdata/src/go.uber.org/errorreturn/inference/errorreturn-with-inference.go
+++ b/testdata/src/go.uber.org/errorreturn/inference/errorreturn-with-inference.go
@@ -924,3 +924,97 @@ func TestDirectPassingOfErrorReturningFunc() {
 	}
 	print(*ptr) // safe
 }
+
+type Value[T any] struct {
+	value T
+	err   error
+}
+
+func (v Value[T]) Get() (T, error) {
+	return v.value, v.err
+}
+
+type V struct{}
+
+func retV() (V, error) {
+	return V{}, &myErr2{}
+}
+
+func retInt() (int, error) {
+	return 42, &myErr2{}
+}
+
+func TestAssignmentToNonPointerTypes(i int, v Value[V]) {
+	switch i {
+	case 1:
+		var sum *V
+		if a, err := v.Get(); err == nil {
+			sum = &a
+			_ = *sum
+		}
+
+	case 2:
+		var sum *V
+		if a, err := v.Get(); err == nil {
+			_ = &a
+			_ = *sum //want "dereferenced"
+		}
+
+	case 3:
+		var sum1, sum2 *V
+		if a, err := v.Get(); err == nil {
+			sum1 = &a
+			_ = *sum1
+			_ = *sum2 //want "dereferenced"
+		}
+
+	case 4:
+		var sum *V
+		if a, err := retV(); err == nil {
+			sum = &a
+			_ = *sum
+		}
+
+	case 5:
+		var sum *V
+		if a, err := retV(); err == nil {
+			_ = &a
+			_ = *sum //want "dereferenced"
+		}
+
+	case 6:
+		var sum1, sum2 *V
+		if a, err := retV(); err == nil {
+			sum1 = &a
+			_ = *sum1
+			_ = *sum2 //want "dereferenced"
+		}
+
+	case 7:
+		var sum *int
+		if a, err := retInt(); err == nil {
+			sum = &a
+			_ = *sum
+		}
+
+	case 8:
+		var sum *int
+		if a, err := retInt(); err == nil {
+			_ = &a
+			_ = *sum //want "dereferenced"
+		}
+
+	case 9:
+		var sum *V
+		a, _ := retV()
+		sum = &a
+		_ = *sum
+
+	case 10:
+		var sum *V
+		if a, err := retV(); err != nil {
+			sum = &a
+			_ = *sum
+		}
+	}
+}


### PR DESCRIPTION
This PR addresses false positive due to lack of support for non-pointer to pointer types in rich check effect functions. Example:
```
type V struct{}

func retV() (V, error) {
   return V{}, errors.New("some error")
}

func test() {
   var v *V
   if a, err := retV(); err == nil {
        v = &a
        _ = *v  // False positive was reported here
   }
}
```