### PR TITLE
Use `ast.Unparen` instead of `astutil.Unparen`

### DIFF
--- a/assertion/function/assertiontree/backprop.go
+++ b/assertion/function/assertiontree/backprop.go
@@ -297,7 +297,7 @@ func backpropAcrossAssignment(rootNode *RootAssertionNode, lhs, rhs []ast.Expr) 
 	// and some cases for "ok" contracts, all of which will have a rhs with length 1.
 	if len(rhs) == 1 {
 		// Here we first strip the parentheses of the rhs to reveal the underlying nodes.
-		rhsNode := astutil.Unparen(rhs[0])
+		rhsNode := ast.Unparen(rhs[0])
 
 		// Type switch `x := y.(type)`, which needs special handling because TypesInfo.Defs
 		// can't find an object for the lhs.
@@ -771,7 +771,7 @@ func backpropAcrossManyToOneAssignment(rootNode *RootAssertionNode, lhs, rhs []a
 			"rhsVal count, but rhsVal count is also not 1")
 	}
 
-	rhsVal, ok := astutil.Unparen(rhs[0]).(*ast.CallExpr)
+	rhsVal, ok := ast.Unparen(rhs[0]).(*ast.CallExpr)
 	if !ok {
 		return errors.New("assumptions about assignment shape violated: lhs count does not equal " +
 			"rhsVal count, but rhsVal is not a call expression")

--- a/assertion/function/assertiontree/backprop.go
+++ b/assertion/function/assertiontree/backprop.go
@@ -31,7 +31,6 @@ import (
 	"go.uber.org/nilaway/util"
 	"go.uber.org/nilaway/util/typeshelper"
 	"golang.org/x/tools/go/analysis"
-	"golang.org/x/tools/go/ast/astutil"
 	"golang.org/x/tools/go/cfg"
 )
 

--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -25,7 +25,6 @@ import (
 	"go.uber.org/nilaway/config"
 	"go.uber.org/nilaway/util"
 	"golang.org/x/tools/go/analysis"
-	"golang.org/x/tools/go/ast/astutil"
 )
 
 // RootAssertionNode is the object that will be directly handled by the propagation algorithm,

--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -1264,8 +1264,8 @@ func (r *RootAssertionNode) isStable(expr ast.Expr) bool {
 // Between two stable expressions, check if we expect them to produce the same value
 // precondition: isStable(left) && isStable(right), then checks if left and right are equal
 func (r *RootAssertionNode) eqStable(left, right ast.Expr) bool {
-	left = astutil.Unparen(left)
-	right = astutil.Unparen(right)
+	left = ast.Unparen(left)
+	right = ast.Unparen(right)
 
 	switch left := left.(type) {
 	case *ast.BasicLit:

--- a/assertion/function/assertiontree/util.go
+++ b/assertion/function/assertiontree/util.go
@@ -179,7 +179,7 @@ func inverseToken(t token.Token) token.Token {
 func AddNilCheck(pass *analysis.Pass, expr ast.Expr) (trueCheck, falseCheck RootFunc, isNoop bool) {
 	noop := func(_ *RootAssertionNode) {}
 
-	expr = astutil.Unparen(expr)
+	expr = ast.Unparen(expr)
 
 	if e, ok := expr.(*ast.UnaryExpr); ok && e.Op == token.NOT {
 		// Check if the unary expression is a negation of a binary expression.


### PR DESCRIPTION
`astutil.Unparen` is now deprecated and `ast.Unparen` was introduced since Go 1.22 (our minimal supported Go version is now 1.23), so this PR replaces all such usages.