### PR TITLE
Allow complex length check conditions to determine the slice being nonnil

### DIFF
--- a/assertion/function/assertiontree/util.go
+++ b/assertion/function/assertiontree/util.go
@@ -22,6 +22,7 @@ import (
 
 	"go.uber.org/nilaway/annotation"
 	"go.uber.org/nilaway/util"
+	"go.uber.org/nilaway/util/asthelper"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/ast/astutil"
 )
@@ -198,17 +199,6 @@ func AddNilCheck(pass *analysis.Pass, expr ast.Expr) (trueCheck, falseCheck Root
 		return noop, noop, true
 	}
 
-	asLenCall := func(expr ast.Expr) (ast.Expr, bool) {
-		if call, ok := expr.(*ast.CallExpr); ok {
-			if fun, ok := call.Fun.(*ast.Ident); ok {
-				if fun.Name == "len" && len(call.Args) == 1 {
-					return call.Args[0], true
-				}
-			}
-		}
-		return nil, false
-	}
-
 	isLiteralZeroInt := func(expr ast.Expr) bool {
 		if lit, ok := expr.(*ast.BasicLit); ok {
 			if lit.Kind == token.INT && lit.Value == "0" {
@@ -285,7 +275,7 @@ func AddNilCheck(pass *analysis.Pass, expr ast.Expr) (trueCheck, falseCheck Root
 		{ // this exprCheck matches on expressions like `len(a) == 0`
 			op: token.EQL,
 			matcher: func(x, y ast.Expr) (RootFunc, RootFunc, bool) {
-				if lenArg, isLen := asLenCall(x); isLen && isLiteralZeroInt(y) {
+				if lenArg := asthelper.AsLenCall(x, false /* allowNested */); lenArg != nil && isLiteralZeroInt(y) {
 					return noop, produceNegativeNilCheck(lenArg), false
 				}
 				return noop, noop, true
@@ -299,10 +289,10 @@ func AddNilCheck(pass *analysis.Pass, expr ast.Expr) (trueCheck, falseCheck Root
 			// it as a contract that only generates non-nil for one side when the other is checked
 			op: token.EQL,
 			matcher: func(x, y ast.Expr) (RootFunc, RootFunc, bool) {
-				xLenArg, xIsLen := asLenCall(x)
-				yLenArg, yIsLen := asLenCall(y)
+				xLenArg := asthelper.AsLenCall(x, true /* allowNested */)
+				yLenArg := asthelper.AsLenCall(y, true /* allowNested */)
 
-				if xIsLen && yIsLen {
+				if xLenArg != nil && yLenArg != nil {
 					return composeRootFuncs(
 						produceNegativeNilCheck(xLenArg),
 						produceNegativeNilCheck(yLenArg),
@@ -314,7 +304,7 @@ func AddNilCheck(pass *analysis.Pass, expr ast.Expr) (trueCheck, falseCheck Root
 		{ // this exprCheck matches on expressions like `len(a) == 37` or `len(a) == b`
 			op: token.EQL,
 			matcher: func(x, y ast.Expr) (RootFunc, RootFunc, bool) {
-				if lenArg, isLen := asLenCall(x); isLen && (isLiteralPositiveInt(y) || isNonLiteralInt(y)) {
+				if lenArg := asthelper.AsLenCall(x, true /* allowNested */); lenArg != nil && (isLiteralPositiveInt(y) || isNonLiteralInt(y)) {
 					return produceNegativeNilCheck(lenArg), noop, false
 				}
 				return noop, noop, true
@@ -323,7 +313,7 @@ func AddNilCheck(pass *analysis.Pass, expr ast.Expr) (trueCheck, falseCheck Root
 		{ // this exprCheck matches on expressions like `len(a) > 0` or `len(a) > 9`
 			op: token.GTR,
 			matcher: func(x, y ast.Expr) (RootFunc, RootFunc, bool) {
-				if lenArg, isLen := asLenCall(x); isLen && (isLiteralZeroInt(y) || isLiteralPositiveInt(y) || isNonLiteralInt(y)) {
+				if lenArg := asthelper.AsLenCall(x, true /* allowNested */); lenArg != nil && (isLiteralZeroInt(y) || isLiteralPositiveInt(y) || isNonLiteralInt(y)) {
 					return produceNegativeNilCheck(lenArg), noop, false
 				}
 				return noop, noop, true
@@ -332,7 +322,7 @@ func AddNilCheck(pass *analysis.Pass, expr ast.Expr) (trueCheck, falseCheck Root
 		{ // this exprCheck matches on expressions like `len(a) >= 19`
 			op: token.GEQ,
 			matcher: func(x, y ast.Expr) (RootFunc, RootFunc, bool) {
-				if lenArg, isLen := asLenCall(x); isLen && (isLiteralPositiveInt(y) || isNonLiteralInt(y)) {
+				if lenArg := asthelper.AsLenCall(x, true /* allowNested */); lenArg != nil && (isLiteralPositiveInt(y) || isNonLiteralInt(y)) {
 					return produceNegativeNilCheck(lenArg), noop, false
 				}
 				return noop, noop, true

--- a/testdata/src/go.uber.org/slices/slices.go
+++ b/testdata/src/go.uber.org/slices/slices.go
@@ -242,6 +242,14 @@ func lengthCheckAsNilCheckTest(a []int) int {
 		if 1 > len(a) {
 			return a[0] //want "sliced into"
 		}
+	case 30:
+		for i := 0; i < len(a); i++ {
+			_ = a[i]
+		}
+	case 31:
+		for i := 0; i < len(a)-1; i++ {
+			_ = a[i]
+		}
 	}
 	return 0
 }

--- a/util/asthelper/asthelper.go
+++ b/util/asthelper/asthelper.go
@@ -133,3 +133,46 @@ func ExtractLHSRHS(node ast.Node) (lhs, rhs []ast.Expr) {
 	}
 	return
 }
+
+// AsLenCall checks if the given expression is a call to the `len` function and returns the
+// argument if it is. If `allowNested` is true, it allows nested calls to `len` and returns
+// the innermost argument.
+func AsLenCall(expr ast.Expr, allowNested bool) ast.Expr {
+	if !allowNested {
+		return asLenCall(expr)
+	}
+
+	var lenExpr ast.Expr
+	ast.Inspect(expr, func(n ast.Node) bool {
+		expr, ok := n.(ast.Expr)
+		if !ok {
+			return true
+		}
+		if e := asLenCall(expr); e != nil {
+			// If we found a len call, we return it immediately.
+			lenExpr = e
+			return false // stop the inspection
+		}
+		return true
+	})
+
+	return lenExpr
+}
+
+func asLenCall(expr ast.Expr) ast.Expr {
+	callExpr, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := callExpr.Fun.(*ast.Ident)
+	if !ok || ident.Name != "len" {
+		return nil
+	}
+
+	if len(callExpr.Args) != 1 {
+		return nil
+	}
+
+	return callExpr.Args[0]
+}


### PR DESCRIPTION
We can have different length checks in Go code i.e., `0 < len(a) - 1` instead of simply `0 < len(a)` which would imply that `a` is nonnil. However, NilAway currently only reasons about simple cases like `0 < len(a)`. This PR adds the ability to reason about complex length check conditions by traversing the AST node and extracting the `len(a)` node.

Note that we maintain an unsound assumption that the length check yields nonnil `a` (unless explicitly checking for `len(a) == 0`) to reduce false positives. 