### PR TITLE
Create an `*analysishelper.EnhancedPass` to host helper methods related to `*analysis.Pass`

### DIFF
--- a/accumulation/analyzer.go
+++ b/accumulation/analyzer.go
@@ -74,7 +74,8 @@ var Analyzer = &analysis.Analyzer{
 //
 // Lastly, we export the _incremental_ information we have gathered from the analysis of local
 // package for use by downstream packages.
-func run(pass *analysis.Pass) (result interface{}, _ error) {
+func run(p *analysis.Pass) (result interface{}, _ error) {
+	pass := analysishelper.NewEnhancedPass(p)
 	// As a last resort, we recover from a panic when running the analyzer, convert the panic to
 	// a diagnostic and return.
 	defer func() {

--- a/annotation/analyzer.go
+++ b/annotation/analyzer.go
@@ -36,7 +36,8 @@ var Analyzer = &analysis.Analyzer{
 	Requires:   []*analysis.Analyzer{config.Analyzer},
 }
 
-func run(pass *analysis.Pass) (*ObservedMap, error) {
+func run(p *analysis.Pass) (*ObservedMap, error) {
+	pass := analysishelper.NewEnhancedPass(p)
 	conf := pass.ResultOf[config.Analyzer].(*config.Config)
 
 	if !conf.IsPkgInScope(pass.Pkg) {

--- a/annotation/full_trigger.go
+++ b/annotation/full_trigger.go
@@ -19,7 +19,7 @@ import (
 	"go/token"
 
 	"go.uber.org/nilaway/util"
-	"golang.org/x/tools/go/analysis"
+	"go.uber.org/nilaway/util/analysishelper"
 )
 
 // A FullTrigger is a completed assertion. It contains both a ProduceTrigger Producer and a
@@ -59,11 +59,11 @@ func (t *FullTrigger) Check(annMap Map) bool {
 		t.Consumer.Annotation.CheckConsume(annMap)
 }
 
-func (t *FullTrigger) truncatedConsumerPos(pass *analysis.Pass) token.Position {
+func (t *FullTrigger) truncatedConsumerPos(pass *analysishelper.EnhancedPass) token.Position {
 	return util.PosToLocation(t.Consumer.Pos(), pass)
 }
 
-func (t *FullTrigger) truncatedProducerPos(pass *analysis.Pass) token.Position {
+func (t *FullTrigger) truncatedProducerPos(pass *analysishelper.EnhancedPass) token.Position {
 	// Our struct init analysis only tracks fields for depth 1 and relies on escape analysis for
 	// escaped fields (t.Producer.Expr here). Since there are functions that return nil producers
 	// (although they were never assigned to [FullTrigger.Producer]), NilAway concluded that
@@ -112,7 +112,7 @@ func (l LocatedPrestring) String() string {
 // with artifical expression generated from the position of that consumer in the assertion tree,
 // and producers that arise from non-trackable expressions correspond to those real non-trackable
 // expressions.
-func (t *FullTrigger) Prestrings(pass *analysis.Pass) (Prestring, Prestring) {
+func (t *FullTrigger) Prestrings(pass *analysishelper.EnhancedPass) (Prestring, Prestring) {
 	producerPrestring := t.Producer.Annotation.Prestring()
 	if util.ExprIsAuthentic(pass, t.Producer.Expr) {
 		producerPrestring = LocatedPrestring{

--- a/annotation/map.go
+++ b/annotation/map.go
@@ -24,7 +24,7 @@ import (
 
 	"go.uber.org/nilaway/config"
 	"go.uber.org/nilaway/util"
-	"golang.org/x/tools/go/analysis"
+	"go.uber.org/nilaway/util/analysishelper"
 )
 
 // Map is an abstraction that concrete annotation maps must implement to be checked against.
@@ -416,7 +416,7 @@ func (set nilabilitySet) checkNilability(name string, t types.Type) Val {
 	return val
 }
 
-func newObservedMap(pass *analysis.Pass, files []*ast.File) *ObservedMap {
+func newObservedMap(pass *analysishelper.EnhancedPass, files []*ast.File) *ObservedMap {
 	conf := pass.ResultOf[config.Analyzer].(*config.Config)
 	// TODO - only store annotations for fields/vars/parameters of types that do not bar nilness
 
@@ -693,6 +693,6 @@ func newObservedMap(pass *analysis.Pass, files []*ast.File) *ObservedMap {
 	}
 }
 
-func getLineFromPos(pos token.Pos, pass *analysis.Pass) int {
+func getLineFromPos(pos token.Pos, pass *analysishelper.EnhancedPass) int {
 	return pass.Fset.Position(pos).Line
 }

--- a/assertion/affiliation/affiliation.go
+++ b/assertion/affiliation/affiliation.go
@@ -24,7 +24,7 @@ import (
 	"go.uber.org/nilaway/annotation"
 	"go.uber.org/nilaway/config"
 	"go.uber.org/nilaway/util"
-	"golang.org/x/tools/go/analysis"
+	"go.uber.org/nilaway/util/analysishelper"
 )
 
 // Affiliation is used to track the association between an interface and its concrete implementations in the form of a map,
@@ -56,7 +56,7 @@ func (*AffliliationCache) AFact() {}
 
 // extractAffiliations processes all affiliations (e.g., interface and its implementing struct) and returns map documenting
 // the affiliations
-func (a *Affiliation) extractAffiliations(pass *analysis.Pass) {
+func (a *Affiliation) extractAffiliations(pass *analysishelper.EnhancedPass) {
 	// initialize
 	upstreamCache := make(ImplementedDeclaredTypesCache, 0) // store entries passed from upstream packages
 	currentCache := make(ImplementedDeclaredTypesCache, 0)  // store new entries witnessed in this current package
@@ -86,7 +86,7 @@ func (a *Affiliation) extractAffiliations(pass *analysis.Pass) {
 
 // computeTriggersForCastingSites analyzes all explicit and implicit sites of casts in the AST. For example, explicit casts,
 // variable assignments, variable declaration and initialization, method returns, and method parameters.
-func (a *Affiliation) computeTriggersForCastingSites(pass *analysis.Pass, upstreamCache ImplementedDeclaredTypesCache, currentCache ImplementedDeclaredTypesCache) {
+func (a *Affiliation) computeTriggersForCastingSites(pass *analysishelper.EnhancedPass, upstreamCache ImplementedDeclaredTypesCache, currentCache ImplementedDeclaredTypesCache) {
 	appendTypeToTypeTriggers := func(lhsType, rhsType types.Type) {
 		a.triggers = append(a.triggers, a.computeTriggersForTypes(lhsType, rhsType, upstreamCache, currentCache)...)
 	}

--- a/assertion/affiliation/analyzer.go
+++ b/assertion/affiliation/analyzer.go
@@ -39,7 +39,8 @@ var Analyzer = &analysis.Analyzer{
 	Requires:   []*analysis.Analyzer{config.Analyzer},
 }
 
-func run(pass *analysis.Pass) ([]annotation.FullTrigger, error) {
+func run(p *analysis.Pass) ([]annotation.FullTrigger, error) {
+	pass := analysishelper.NewEnhancedPass(p)
 	conf := pass.ResultOf[config.Analyzer].(*config.Config)
 
 	if !conf.IsPkgInScope(pass.Pkg) {

--- a/assertion/analyzer.go
+++ b/assertion/analyzer.go
@@ -43,7 +43,8 @@ var Analyzer = &analysis.Analyzer{
 	Requires:   []*analysis.Analyzer{config.Analyzer, function.Analyzer, affiliation.Analyzer, global.Analyzer},
 }
 
-func run(pass *analysis.Pass) ([]annotation.FullTrigger, error) {
+func run(p *analysis.Pass) ([]annotation.FullTrigger, error) {
+	pass := analysishelper.NewEnhancedPass(p)
 	conf := pass.ResultOf[config.Analyzer].(*config.Config)
 
 	if !conf.IsPkgInScope(pass.Pkg) {

--- a/assertion/anonymousfunc/analyzer.go
+++ b/assertion/anonymousfunc/analyzer.go
@@ -68,7 +68,8 @@ type VarInfo struct {
 // It contains an illegal character to avoid collisions with other variables.
 const _fakeFuncDeclPrefix = "__anonymousFunction$"
 
-func run(pass *analysis.Pass) (map[*ast.FuncLit]*FuncLitInfo, error) {
+func run(p *analysis.Pass) (map[*ast.FuncLit]*FuncLitInfo, error) {
+	pass := analysishelper.NewEnhancedPass(p)
 	conf := pass.ResultOf[config.Analyzer].(*config.Config)
 
 	if !conf.IsPkgInScope(pass.Pkg) {
@@ -110,7 +111,7 @@ func run(pass *analysis.Pass) (map[*ast.FuncLit]*FuncLitInfo, error) {
 // createFakeFuncDecl creates a fake function declaration (AST node and a type object) for the
 // given func lit node, where the parameter list is extended to include fake parameters that
 // represent the closure variables.
-func createFakeFuncDecl(pass *analysis.Pass, funcLit *ast.FuncLit, fakeParams []*VarInfo) (*ast.FuncDecl, *types.Func) {
+func createFakeFuncDecl(pass *analysishelper.EnhancedPass, funcLit *ast.FuncLit, fakeParams []*VarInfo) (*ast.FuncDecl, *types.Func) {
 	// The name for the node is named "<prefix>Line:Column" for easier identification.
 	pos := pass.Fset.Position(funcLit.Pos())
 	name := _fakeFuncDeclPrefix + strconv.Itoa(pos.Line) + ":" + strconv.Itoa(pos.Column)

--- a/assertion/anonymousfunc/closure.go
+++ b/assertion/anonymousfunc/closure.go
@@ -20,7 +20,7 @@ import (
 	"go/types"
 
 	"go.uber.org/nilaway/annotation"
-	"golang.org/x/tools/go/analysis"
+	"go.uber.org/nilaway/util/analysishelper"
 )
 
 // collectClosure collects a set of variables in closure for the given function literal and updates
@@ -32,7 +32,7 @@ import (
 // modulo the ones defined in the scope of the enclosing function literals.
 // (2) If the node is an ident node that represents a variable which is not global, it updates the
 // closure set if the node doesn't exist in the current scope.
-func collectClosure(funcLit *ast.FuncLit, pass *analysis.Pass, closureMap map[*ast.FuncLit][]*VarInfo) {
+func collectClosure(funcLit *ast.FuncLit, pass *analysishelper.EnhancedPass, closureMap map[*ast.FuncLit][]*VarInfo) {
 	// Retrieve the scope of the given function literal
 	scope := pass.TypesInfo.Scopes[funcLit.Type]
 

--- a/assertion/function/analyzer.go
+++ b/assertion/function/analyzer.go
@@ -82,7 +82,8 @@ type functionResult struct {
 	funcDecl *ast.FuncDecl
 }
 
-func run(pass *analysis.Pass) ([]annotation.FullTrigger, error) {
+func run(p *analysis.Pass) ([]annotation.FullTrigger, error) {
+	pass := analysishelper.NewEnhancedPass(p)
 	conf := pass.ResultOf[config.Analyzer].(*config.Config)
 	if !conf.IsPkgInScope(pass.Pkg) {
 		return nil, nil
@@ -244,7 +245,7 @@ func run(pass *analysis.Pass) ([]annotation.FullTrigger, error) {
 // create new full triggers that duplicates the original full triggers of the contracted functions
 // but uses the new producers/consumers instead.
 func duplicateFullTriggersFromContractedFunctionsToCallers(
-	pass *analysis.Pass,
+	pass *analysishelper.EnhancedPass,
 	funcContracts functioncontracts.Map,
 	funcTriggers [][]annotation.FullTrigger,
 	funcResults map[*types.Func]*functionResult,
@@ -327,7 +328,7 @@ func duplicateFullTrigger(
 	trigger annotation.FullTrigger,
 	callee *types.Func,
 	callExpr *ast.CallExpr,
-	pass *analysis.Pass,
+	pass *analysishelper.EnhancedPass,
 	isParamProducer bool,
 	isReturnConsumer bool,
 ) annotation.FullTrigger {
@@ -370,7 +371,7 @@ func duplicateFullTrigger(
 // call it.
 func findCallsToContractedFunctions(
 	funcNode *ast.FuncDecl,
-	pass *analysis.Pass,
+	pass *analysishelper.EnhancedPass,
 	functionContracts functioncontracts.Map,
 ) map[*types.Func][]*ast.CallExpr {
 	calls := map[*types.Func][]*ast.CallExpr{}
@@ -421,7 +422,7 @@ func hasOnlyNonNilToNonNilContract(funcContracts functioncontracts.Map, funcObj 
 // The actual result will be sent via the channel.
 func analyzeFunc(
 	ctx context.Context,
-	pass *analysis.Pass,
+	pass *analysishelper.EnhancedPass,
 	funcDecl *ast.FuncDecl,
 	funcContext assertiontree.FunctionContext,
 	graph *cfg.CFG,

--- a/assertion/function/analyzer_test.go
+++ b/assertion/function/analyzer_test.go
@@ -58,7 +58,7 @@ func TestCancelledContext(t *testing.T) {
 
 	// First do an analysis test run just to get the pass variable.
 	r := analysistest.Run(t, testdata, Analyzer, "go.uber.org/pkg")
-	pass := r[0].Pass
+	pass := analysishelper.NewEnhancedPass(r[0].Pass)
 
 	// Select the first function declaration node to run test.
 	var funcDecl *ast.FuncDecl
@@ -125,7 +125,7 @@ func TestAnalyzeFuncPanic(t *testing.T) {
 	// Intentionally give bad input data to cause a panic. We should convert the panic to an error
 	// and send it back to the original channel.
 	go analyzeFunc(ctx,
-		&analysis.Pass{},                /* pass */
+		analysishelper.NewEnhancedPass(&analysis.Pass{}), /* pass */
 		&ast.FuncDecl{},                 /* funcDecl */
 		assertiontree.FunctionContext{}, /* funcContext */
 		&cfg.CFG{},                      /* graph */
@@ -151,7 +151,7 @@ func TestBackpropFixpointConvergence(t *testing.T) {
 
 	// First do an analysis test run just to get the pass variable.
 	r := analysistest.Run(t, testdata, Analyzer, "go.uber.org/backprop")
-	pass := r[0].Pass
+	pass := analysishelper.NewEnhancedPass(r[0].Pass)
 
 	// Gather function declaration nodes from test.
 	var funcs []*ast.FuncDecl
@@ -184,7 +184,7 @@ func TestBackpropFixpointConvergence(t *testing.T) {
 		funcTriggers, roundCount, stableRoundCount, err := assertiontree.BackpropAcrossFunc(ctx, pass, funcDecl, funcContext, ctrlflowResult.FuncDecl(funcDecl))
 		require.NoError(t, err, "Backpropagation algorithm should not return an error")
 
-		expectedValues := nilawaytest.FindExpectedValues(pass, _wantFixpointPrefix)
+		expectedValues := nilawaytest.FindExpectedValues(pass.Pass, _wantFixpointPrefix)
 		expectedVals, ok := expectedValues[funcDecl]
 		if !ok {
 			// No expected values written in the test file, so we skip the comparison.

--- a/assertion/function/assertiontree/backprop.go
+++ b/assertion/function/assertiontree/backprop.go
@@ -29,8 +29,8 @@ import (
 	"go.uber.org/nilaway/assertion/function/preprocess"
 	"go.uber.org/nilaway/config"
 	"go.uber.org/nilaway/util"
+	"go.uber.org/nilaway/util/analysishelper"
 	"go.uber.org/nilaway/util/typeshelper"
-	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/cfg"
 )
 
@@ -884,7 +884,7 @@ func computePostOrder(blocks []*cfg.Block) []int {
 // to the function, the set of assertions that must hold to avoid possible nil flow errors.
 func BackpropAcrossFunc(
 	ctx context.Context,
-	pass *analysis.Pass,
+	pass *analysishelper.EnhancedPass,
 	decl *ast.FuncDecl,
 	functionContext FunctionContext,
 	graph *cfg.CFG,

--- a/assertion/function/assertiontree/backprop_util.go
+++ b/assertion/function/assertiontree/backprop_util.go
@@ -25,8 +25,8 @@ import (
 	"go.uber.org/nilaway/annotation"
 	"go.uber.org/nilaway/hook"
 	"go.uber.org/nilaway/util"
+	"go.uber.org/nilaway/util/analysishelper"
 	"go.uber.org/nilaway/util/asthelper"
-	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/cfg"
 )
 
@@ -686,10 +686,7 @@ func composeRootFuncs(f1, f2 RootFunc) RootFunc {
 // the end of that block
 //
 // postcondition - length of two return slices is equal
-//
-// nonnil(result 0, result 1)
-func blocksAndPreprocessingFromCFG(
-	pass *analysis.Pass, graph *cfg.CFG, richCheckBlocks [][]RichCheckEffect) (
+func blocksAndPreprocessingFromCFG(pass *analysishelper.EnhancedPass, graph *cfg.CFG, richCheckBlocks [][]RichCheckEffect) (
 	[]*cfg.Block, []*preprocessPair) {
 
 	numBlocks := len(graph.Blocks)
@@ -825,7 +822,7 @@ func CheckGuardOnFullTrigger(trigger annotation.FullTrigger) annotation.FullTrig
 }
 
 // addAssignmentToConsumer updates the consumer with assignment entries for informative printing of errors
-func addAssignmentToConsumer(lhs, rhs ast.Expr, pass *analysis.Pass, consumer annotation.ConsumingAnnotationTrigger) error {
+func addAssignmentToConsumer(lhs, rhs ast.Expr, pass *analysishelper.EnhancedPass, consumer annotation.ConsumingAnnotationTrigger) error {
 	var lhsExprStr, rhsExprStr string
 	var err error
 

--- a/assertion/function/assertiontree/function_context.go
+++ b/assertion/function/assertiontree/function_context.go
@@ -20,7 +20,7 @@ import (
 
 	"go.uber.org/nilaway/assertion/anonymousfunc"
 	"go.uber.org/nilaway/assertion/function/functioncontracts"
-	"golang.org/x/tools/go/analysis"
+	"go.uber.org/nilaway/util/analysishelper"
 )
 
 // SelectorExprMap is used to cache artificially created ast selector expressions
@@ -37,7 +37,7 @@ type FunctionContext struct {
 	funcLit *ast.FuncLit
 
 	// pass records the overarching analysis pass - needed for identifier resolution.
-	pass *analysis.Pass
+	pass *analysishelper.EnhancedPass
 
 	// selectorExpressionCache we cache artificially created selector expressions nodes to avoid
 	// duplication. Duplication is dangerous as it will result in duplicate triggers and the
@@ -75,7 +75,7 @@ type FunctionConfig struct {
 
 // NewFunctionContext returns a new FunctionContext and initializes all the maps
 func NewFunctionContext(
-	pass *analysis.Pass,
+	pass *analysishelper.EnhancedPass,
 	decl *ast.FuncDecl,
 	funcLit *ast.FuncLit,
 	functionConfig FunctionConfig,

--- a/assertion/function/assertiontree/parse_expr_producer.go
+++ b/assertion/function/assertiontree/parse_expr_producer.go
@@ -470,7 +470,7 @@ func (r *RootAssertionNode) ParseExprAsProducer(expr ast.Expr, doNotTrack bool) 
 		switch {
 		// For slice expressions `b[_:0:_]`, the result is always an empty (nilable in
 		// NilAway's eyes) slice. (`_` can be anything including empty.)
-		case r.isIntZero(expr.High):
+		case r.Pass().IsZero(expr.High):
 			// We should create a nilable producer.
 			return nil, []producer.ParsedProducer{producer.ShallowParsedProducer{
 				Producer: &annotation.ProduceTrigger{
@@ -480,7 +480,7 @@ func (r *RootAssertionNode) ParseExprAsProducer(expr ast.Expr, doNotTrack bool) 
 		// For slice expressions `b[0:]` and `b[:]`, the result's nilability depends on the
 		// nilability of the original slice. Note that you cannot give empty High in 3-index
 		// slices.
-		case expr.High == nil && (expr.Low == nil || r.isIntZero(expr.Low)):
+		case expr.High == nil && (expr.Low == nil || r.Pass().IsZero(expr.Low)):
 			// TODO: for now we directly return the trackable expression of the original slice. We
 			// should instead properly create a trackable expression for the slice expression. See
 			//  for more details.

--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -24,7 +24,7 @@ import (
 	"go.uber.org/nilaway/annotation"
 	"go.uber.org/nilaway/config"
 	"go.uber.org/nilaway/util"
-	"golang.org/x/tools/go/analysis"
+	"go.uber.org/nilaway/util/analysishelper"
 )
 
 // RootAssertionNode is the object that will be directly handled by the propagation algorithm,
@@ -76,7 +76,7 @@ func (r *RootAssertionNode) FuncDecl() *ast.FuncDecl {
 }
 
 // Pass the overarching analysis pass
-func (r *RootAssertionNode) Pass() *analysis.Pass {
+func (r *RootAssertionNode) Pass() *analysishelper.EnhancedPass {
 	return r.functionContext.pass
 }
 

--- a/assertion/function/assertiontree/util.go
+++ b/assertion/function/assertiontree/util.go
@@ -22,7 +22,7 @@ import (
 
 	"go.uber.org/nilaway/annotation"
 	"go.uber.org/nilaway/util"
-	"golang.org/x/tools/go/analysis"
+	"go.uber.org/nilaway/util/analysishelper"
 	"golang.org/x/tools/go/ast/astutil"
 )
 
@@ -38,7 +38,7 @@ func checkCFGFixedPointRuntime(passName string, currRound, numBlocks int) {
 }
 
 // GetDeclaringPath finds the path of nested AST nodes beginning with the passed interval `[start, end]`
-func GetDeclaringPath(pass *analysis.Pass, start, end token.Pos) ([]ast.Node, bool) {
+func GetDeclaringPath(pass *analysishelper.EnhancedPass, start, end token.Pos) ([]ast.Node, bool) {
 	astFile := lookupAstFromFile(pass, pass.Fset.File(start))
 	if astFile == nil {
 		astFile = lookupAstFromFilename(pass, pass.Fset.Position(start).Filename)
@@ -176,7 +176,7 @@ func inverseToken(t token.Token) token.Token {
 //
 // For better performance by the caller, it also returns a boolean flag `isNoop` indicating whether
 // the returned function is a no-op
-func AddNilCheck(pass *analysis.Pass, expr ast.Expr) (trueCheck, falseCheck RootFunc, isNoop bool) {
+func AddNilCheck(pass *analysishelper.EnhancedPass, expr ast.Expr) (trueCheck, falseCheck RootFunc, isNoop bool) {
 	noop := func(_ *RootAssertionNode) {}
 
 	expr = ast.Unparen(expr)
@@ -424,7 +424,7 @@ func CopyNode(node AssertionNode) AssertionNode {
 
 // lookupAstFromFile attempts to find the file ast for a given file (token.File)
 // nilable(result 0)
-func lookupAstFromFile(pass *analysis.Pass, file *token.File) *ast.File {
+func lookupAstFromFile(pass *analysishelper.EnhancedPass, file *token.File) *ast.File {
 	for _, astFile := range pass.Files {
 		if file != nil && int(astFile.Pos()) >= file.Base() && int(astFile.Pos()) <= file.Base()+file.Size() {
 			return astFile
@@ -435,7 +435,7 @@ func lookupAstFromFile(pass *analysis.Pass, file *token.File) *ast.File {
 
 // lookupAstFromFilename attempts to find the file ast for a given file (token.File)
 // nilable(result 0)
-func lookupAstFromFilename(pass *analysis.Pass, filename string) *ast.File {
+func lookupAstFromFilename(pass *analysishelper.EnhancedPass, filename string) *ast.File {
 	for _, astFile := range pass.Files {
 		if astFile.Name.Name == filename {
 			return astFile

--- a/assertion/function/functioncontracts/analyzer.go
+++ b/assertion/function/functioncontracts/analyzer.go
@@ -56,7 +56,8 @@ func (*Contracts) AFact() {}
 // Map stores the mappings from *types.Func to associated function contracts.
 type Map map[*types.Func]Contracts
 
-func run(pass *analysis.Pass) (Map, error) {
+func run(p *analysis.Pass) (Map, error) {
+	pass := analysishelper.NewEnhancedPass(p)
 	conf := pass.ResultOf[config.Analyzer].(*config.Config)
 	if !conf.IsPkgInScope(pass.Pkg) {
 		return make(Map), nil
@@ -122,7 +123,7 @@ type functionResult struct {
 // every function with its contracts if it has any. We prefer to parse handwritten contracts from
 // the comments at the top of each function. Only when there are no handwritten contracts there,
 // do we try to automatically infer contracts.
-func collectFunctionContracts(pass *analysis.Pass) (Map, error) {
+func collectFunctionContracts(pass *analysishelper.EnhancedPass) (Map, error) {
 	conf := pass.ResultOf[config.Analyzer].(*config.Config)
 
 	// Collect ssa for every function.

--- a/assertion/function/functioncontracts/analyzer_test.go
+++ b/assertion/function/functioncontracts/analyzer_test.go
@@ -17,6 +17,7 @@ package functioncontracts
 import (
 	"fmt"
 	"go/types"
+	"golang.org/x/tools/go/analysis"
 	"strings"
 	"testing"
 
@@ -24,7 +25,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 	"go.uber.org/nilaway/util/analysishelper"
-	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/analysistest"
 )
 

--- a/assertion/function/preprocess/preprocessor.go
+++ b/assertion/function/preprocess/preprocessor.go
@@ -16,14 +16,16 @@
 // amenable to analysis.
 package preprocess
 
-import "golang.org/x/tools/go/analysis"
+import (
+	"go.uber.org/nilaway/util/analysishelper"
+)
 
 // Preprocessor handles different preprocessing logic for different types of input.
 type Preprocessor struct {
-	pass *analysis.Pass
+	pass *analysishelper.EnhancedPass
 }
 
 // New returns a new Preprocessor.
-func New(pass *analysis.Pass) *Preprocessor {
+func New(pass *analysishelper.EnhancedPass) *Preprocessor {
 	return &Preprocessor{pass: pass}
 }

--- a/assertion/global/analyzer.go
+++ b/assertion/global/analyzer.go
@@ -37,7 +37,8 @@ var Analyzer = &analysis.Analyzer{
 	Requires:   []*analysis.Analyzer{config.Analyzer},
 }
 
-func run(pass *analysis.Pass) ([]annotation.FullTrigger, error) {
+func run(p *analysis.Pass) ([]annotation.FullTrigger, error) {
+	pass := analysishelper.NewEnhancedPass(p)
 	conf := pass.ResultOf[config.Analyzer].(*config.Config)
 
 	if !conf.IsPkgInScope(pass.Pkg) {

--- a/assertion/structfield/analyzer.go
+++ b/assertion/structfield/analyzer.go
@@ -36,7 +36,8 @@ var Analyzer = &analysis.Analyzer{
 	Requires:   []*analysis.Analyzer{config.Analyzer},
 }
 
-func run(pass *analysis.Pass) (*FieldContext, error) {
+func run(p *analysis.Pass) (*FieldContext, error) {
+	pass := analysishelper.NewEnhancedPass(p)
 	conf := pass.ResultOf[config.Analyzer].(*config.Config)
 
 	fieldContext := &FieldContext{fieldMap: make(relevantFieldsMap)}

--- a/assertion/structfield/field_context.go
+++ b/assertion/structfield/field_context.go
@@ -19,7 +19,7 @@ import (
 	"go/types"
 
 	"go.uber.org/nilaway/annotation"
-	"golang.org/x/tools/go/analysis"
+	"go.uber.org/nilaway/util/analysishelper"
 )
 
 // fieldUse is an int type to indicate how a field is used in the function
@@ -69,7 +69,7 @@ func (f *FieldContext) addEntry(funcDecl *types.Func, param int, fieldName strin
 }
 
 // processFunc parses the function body for collecting field uses (i.e., assignments and accesses) of a given struct passed as a parameter to the function
-func (f *FieldContext) processFunc(funcDecl *ast.FuncDecl, pass *analysis.Pass) {
+func (f *FieldContext) processFunc(funcDecl *ast.FuncDecl, pass *analysishelper.EnhancedPass) {
 	// get all assigned and accessed selector expressions from `funcDecl` of the form `s.f`
 	fieldRefUseList := collectIdentSelExpr(funcDecl)
 

--- a/cmd/nilaway/main.go
+++ b/cmd/nilaway/main.go
@@ -26,6 +26,7 @@ import (
 
 	"go.uber.org/nilaway"
 	"go.uber.org/nilaway/config"
+	"go.uber.org/nilaway/util/analysishelper"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/singlechecker"
 )
@@ -49,7 +50,8 @@ var (
 	_excludeErrorsInFiles string
 )
 
-func run(pass *analysis.Pass) (interface{}, error) {
+func run(p *analysis.Pass) (interface{}, error) {
+	pass := analysishelper.NewEnhancedPass(p)
 	// NilAway by default analyzes all packages, including dependencies. Even if specified to
 	// exclude packages from analysis via configurations, NilAway can still report errors on
 	// packages that are not analyzed if the nilness flow happens within the analyzed package, but
@@ -86,7 +88,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	}
 
 	// Delegate the real analysis run to the original nilaway analyzer.
-	return nilaway.Analyzer.Run(pass)
+	return nilaway.Analyzer.Run(p)
 }
 
 // parseFilePrefixes parses the comma-separated list of file prefixes, converts them to absolute

--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,7 @@ package config
 
 import (
 	"flag"
+	"go.uber.org/nilaway/util/analysishelper"
 	"go/ast"
 	"go/types"
 	"reflect"
@@ -151,7 +152,8 @@ func newFlagSet() flag.FlagSet {
 	return *fs
 }
 
-func run(pass *analysis.Pass) (any, error) {
+func run(p *analysis.Pass) (any, error) {
+	pass := analysishelper.NewEnhancedPass(p)
 	// Set up default values for the config.
 	conf := &Config{
 		PrettyPrint:        true,

--- a/diagnostic/conflict.go
+++ b/diagnostic/conflict.go
@@ -21,8 +21,8 @@ import (
 	"strings"
 
 	"go.uber.org/nilaway/config"
+	"go.uber.org/nilaway/util/analysishelper"
 	"go.uber.org/nilaway/util/tokenhelper"
-	"golang.org/x/tools/go/analysis"
 )
 
 type conflict struct {
@@ -62,7 +62,7 @@ func (c *conflict) addSimilarConflict(conflict conflict) {
 }
 
 // groupConflicts groups conflicts with the same nil path together and update conflicts list.
-func groupConflicts(allConflicts []conflict, pass *analysis.Pass) []conflict {
+func groupConflicts(allConflicts []conflict, pass *analysishelper.EnhancedPass) []conflict {
 	conflictsMap := make(map[string]int)  // key: nil path string, value: index in `allConflicts`
 	indicesToIgnore := make(map[int]bool) // indices of conflicts to be ignored from `allConflicts`, since they are grouped with other conflicts
 

--- a/diagnostic/engine.go
+++ b/diagnostic/engine.go
@@ -40,7 +40,7 @@ type fileInfo struct {
 
 // Engine is the main engine for generating diagnostics from conflicts.
 type Engine struct {
-	pass      *analysis.Pass
+	pass      *analysishelper.EnhancedPass
 	conflicts []conflict
 	// files maps the file name (modulo the possible build-system prefix) to the token.File object
 	// for faster lookup when converting correct upstream position back to local token.Pos for
@@ -49,7 +49,7 @@ type Engine struct {
 }
 
 // NewEngine creates a new diagnostic engine.
-func NewEngine(pass *analysis.Pass) *Engine {
+func NewEngine(pass *analysishelper.EnhancedPass) *Engine {
 	// Iterate all files within the Fset (which includes upstream and current-package files), and
 	// store the mapping between its file name (modulo the possible build-system prefix) and the
 	// token.File object. This is needed for converting correct upstream position back to local

--- a/diagnostic/nolint.go
+++ b/diagnostic/nolint.go
@@ -57,7 +57,8 @@ type Range struct {
 	From, To int
 }
 
-func run(pass *analysis.Pass) ([]Range, error) {
+func run(p *analysis.Pass) ([]Range, error) {
+	pass := analysishelper.NewEnhancedPass(p)
 	var ranges []Range
 	for _, f := range pass.Files {
 		// CommentMap will correctly associate comments to the largest node group

--- a/hook/assume_return.go
+++ b/hook/assume_return.go
@@ -21,14 +21,14 @@ import (
 
 	"go.uber.org/nilaway/annotation"
 	"go.uber.org/nilaway/util"
-	"golang.org/x/tools/go/analysis"
+	"go.uber.org/nilaway/util/analysishelper"
 )
 
 // AssumeReturn returns the producer for the return value of the given call expression, which would
 // have the assumed nilability. This is useful for modeling the return value of stdlib and 3rd party
 // functions that are not analyzed by NilAway. For example, "errors.New" is assumed to return a
 // nonnil value. If the given call expression does not match any known function, nil is returned.
-func AssumeReturn(pass *analysis.Pass, call *ast.CallExpr) *annotation.ProduceTrigger {
+func AssumeReturn(pass *analysishelper.EnhancedPass, call *ast.CallExpr) *annotation.ProduceTrigger {
 	for sig, act := range _assumeReturns {
 		if sig.match(pass, call) {
 			return act(call)
@@ -41,7 +41,7 @@ func AssumeReturn(pass *analysis.Pass, call *ast.CallExpr) *annotation.ProduceTr
 // AssumeReturnForErrorWrapperFunc returns the producer for the return value of the given call expression which is
 // an error wrapper function. This is useful for modeling the return value of error wrapper functions like
 // `errors.Wrapf(err, "message")` to return a non-nil error. If the given call expression is not an error wrapper, nil is returned.
-func AssumeReturnForErrorWrapperFunc(pass *analysis.Pass, call *ast.CallExpr) *annotation.ProduceTrigger {
+func AssumeReturnForErrorWrapperFunc(pass *analysishelper.EnhancedPass, call *ast.CallExpr) *annotation.ProduceTrigger {
 	if isErrorWrapperFunc(pass, call) {
 		return nonnilProducer(call)
 	}
@@ -52,7 +52,7 @@ func AssumeReturnForErrorWrapperFunc(pass *analysis.Pass, call *ast.CallExpr) *a
 // It does this by applying the following criteria:
 // - the function must have at least one argument of error-implementing type, and
 // - the function must return an error-implementing type as its last return value.
-func isErrorWrapperFunc(pass *analysis.Pass, call *ast.CallExpr) bool {
+func isErrorWrapperFunc(pass *analysishelper.EnhancedPass, call *ast.CallExpr) bool {
 	funcIdent := util.FuncIdentFromCallExpr(call)
 	if funcIdent == nil {
 		return false

--- a/hook/hook.go
+++ b/hook/hook.go
@@ -25,7 +25,7 @@ import (
 	"regexp"
 
 	"go.uber.org/nilaway/util"
-	"golang.org/x/tools/go/analysis"
+	"go.uber.org/nilaway/util/analysishelper"
 )
 
 // funcKind indicates the kind of the trusted function:
@@ -48,7 +48,7 @@ type trustedFuncSig struct {
 // match checks if a given call expression matches with a trusted function's signature. Namely,
 // it performs a strict matching for the function / method name and a user-defined regex match for
 // the enclosing package or struct path.
-func (t *trustedFuncSig) match(pass *analysis.Pass, call *ast.CallExpr) bool {
+func (t *trustedFuncSig) match(pass *analysishelper.EnhancedPass, call *ast.CallExpr) bool {
 	sel, ok := call.Fun.(*ast.SelectorExpr)
 	if !ok || !t.funcNameRegex.MatchString(sel.Sel.Name) {
 		return false

--- a/hook/no_return_call.go
+++ b/hook/no_return_call.go
@@ -19,7 +19,7 @@ import (
 	"regexp"
 	"slices"
 
-	"golang.org/x/tools/go/analysis"
+	"go.uber.org/nilaway/util/analysishelper"
 )
 
 // IsNoReturnCall returns whether the specific call expression terminates the program unconditionally.
@@ -30,7 +30,7 @@ import (
 // configured to just panic (but we cannot infer that purely from code).
 //
 // `testing.TB.Fatal`-related: they are interface methods without implementations.
-func IsNoReturnCall(pass *analysis.Pass, call *ast.CallExpr) bool {
+func IsNoReturnCall(pass *analysishelper.EnhancedPass, call *ast.CallExpr) bool {
 	return slices.ContainsFunc(_terminatingCalls, func(sig trustedFuncSig) bool { return sig.match(pass, call) })
 }
 

--- a/hook/replace_conditional.go
+++ b/hook/replace_conditional.go
@@ -19,7 +19,7 @@ import (
 	"go/token"
 	"regexp"
 
-	"golang.org/x/tools/go/analysis"
+	"go.uber.org/nilaway/util/analysishelper"
 )
 
 // ReplaceConditional replaces a call to a matched function with the returned expression. This is
@@ -28,7 +28,7 @@ import (
 // `target != nil`, so it can be replaced with `target != nil`.
 //
 // If the call does not match any known function, nil is returned.
-func ReplaceConditional(pass *analysis.Pass, call *ast.CallExpr) ast.Expr {
+func ReplaceConditional(pass *analysishelper.EnhancedPass, call *ast.CallExpr) ast.Expr {
 	for sig, act := range _replaceConditionals {
 		if sig.match(pass, call) {
 			return act(pass, call)
@@ -37,7 +37,7 @@ func ReplaceConditional(pass *analysis.Pass, call *ast.CallExpr) ast.Expr {
 	return nil
 }
 
-type replaceConditionalAction func(pass *analysis.Pass, call *ast.CallExpr) ast.Expr
+type replaceConditionalAction func(pass *analysishelper.EnhancedPass, call *ast.CallExpr) ast.Expr
 
 // _errorAsAction replaces a call to `errors.As(err, &target)` with an equivalent expression
 // `errors.As(err, &target) && target != nil`. Keeping the `errors.As(err, &target)` is important
@@ -50,7 +50,7 @@ type replaceConditionalAction func(pass *analysis.Pass, call *ast.CallExpr) ast.
 // assumes the target is non-nil after such check [1]. So here we make this assumption as well.
 //
 // [1] https://pkg.go.dev/errors#As
-var _errorAsAction replaceConditionalAction = func(_ *analysis.Pass, call *ast.CallExpr) ast.Expr {
+var _errorAsAction replaceConditionalAction = func(_ *analysishelper.EnhancedPass, call *ast.CallExpr) ast.Expr {
 	if len(call.Args) != 2 {
 		return nil
 	}

--- a/inference/engine.go
+++ b/inference/engine.go
@@ -24,6 +24,7 @@ import (
 
 	"go.uber.org/nilaway/annotation"
 	"go.uber.org/nilaway/assertion/function/assertiontree"
+	"go.uber.org/nilaway/util/analysishelper"
 	"golang.org/x/tools/go/analysis"
 )
 
@@ -38,7 +39,7 @@ type conflictHandler interface {
 // various tasks for the inference and stores an internal map that can be obtained by calling
 // Engine.InferredMap.
 type Engine struct {
-	pass *analysis.Pass
+	pass *analysishelper.EnhancedPass
 	// inferredMap is the internal inferred map that the engine writes to, it is initialized on the
 	// construction of the engine and populated by the "Observe*" methods of the engine. Users
 	// should use the Engine.InferredMap() method to obtain the current inferred map.
@@ -56,7 +57,7 @@ type Engine struct {
 }
 
 // NewEngine constructs an inference engine that is ready to run inference.
-func NewEngine(pass *analysis.Pass, diagnosticEngine conflictHandler) *Engine {
+func NewEngine(pass *analysishelper.EnhancedPass, diagnosticEngine conflictHandler) *Engine {
 	primitive := newPrimitivizer(pass)
 	return &Engine{
 		pass:             pass,

--- a/inference/inferred_map.go
+++ b/inference/inferred_map.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/klauspost/compress/s2"
 	"go.uber.org/nilaway/annotation"
+	"go.uber.org/nilaway/util/analysishelper"
 	"go.uber.org/nilaway/util/orderedmap"
-	"golang.org/x/tools/go/analysis"
 )
 
 // An InferredMap is the state accumulated by multi-package inference. It's
@@ -105,7 +105,7 @@ func (i *InferredMap) OrderedRange(f func(primitiveSite, InferredVal) bool) {
 // encode all (in the go sense; i.e. capitalized) annotation sites (See chooseSitesToExport).
 // This ensures that only _incremental_ information is exported by this package and plays a _vital_
 // role in minimizing build output.
-func (i *InferredMap) Export(pass *analysis.Pass) {
+func (i *InferredMap) Export(pass *analysishelper.EnhancedPass) {
 	if len(i.mapping.Pairs) == 0 {
 		return
 	}

--- a/inference/mode.go
+++ b/inference/mode.go
@@ -16,8 +16,8 @@ package inference
 
 import (
 	"go.uber.org/nilaway/config"
+	"go.uber.org/nilaway/util/analysishelper"
 	"go.uber.org/nilaway/util/asthelper"
-	"golang.org/x/tools/go/analysis"
 )
 
 // ModeOfInference is effectively an enum indicating the possible ways that we may conduct inference
@@ -38,7 +38,7 @@ const (
 // DetermineMode searches the files in this package for docstrings that indicate
 // inference should be entirely suppressed (returns NoInfer). By default, if no such
 // docstring is found, multi-package inference is used (returns FullInfer).
-func DetermineMode(pass *analysis.Pass) ModeOfInference {
+func DetermineMode(pass *analysishelper.EnhancedPass) ModeOfInference {
 	for _, file := range pass.Files {
 		if asthelper.DocContains(file, config.NilAwayNoInferString) {
 			return NoInfer

--- a/inference/primitive.go
+++ b/inference/primitive.go
@@ -19,8 +19,8 @@ import (
 	"go/token"
 
 	"go.uber.org/nilaway/annotation"
+	"go.uber.org/nilaway/util/analysishelper"
 	"go.uber.org/nilaway/util/tokenhelper"
-	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/types/objectpath"
 )
 
@@ -118,7 +118,7 @@ func (s *primitiveSite) String() string {
 //
 // [archive importer]: https://github.com/golang/tools/blob/fa12f34b4218307705bf0365ab7df7c119b3653a/internal/gcimporter/bimport.go#L59-L69
 type primitivizer struct {
-	pass *analysis.Pass
+	pass *analysishelper.EnhancedPass
 	// upstreamObjPositions maps "<pkg path>.<object path>" to the correct position.
 	upstreamObjPositions map[string]token.Position
 	// objPathEncoder is used to encode object paths, which amortizes the cost of encoding the
@@ -127,7 +127,7 @@ type primitivizer struct {
 }
 
 // newPrimitivizer returns a new and properly-initialized primitivizer.
-func newPrimitivizer(pass *analysis.Pass) *primitivizer {
+func newPrimitivizer(pass *analysishelper.EnhancedPass) *primitivizer {
 	// To tackle the position discrepancies for upstream sites, we have added an ObjectPath field
 	// to primitiveSite, which can be used to uniquely identify an exported object relative to the
 	// package. Then, we simply cache the correct position information when importing

--- a/nilaway.go
+++ b/nilaway.go
@@ -20,6 +20,7 @@ import (
 	"go.uber.org/nilaway/accumulation"
 	"go.uber.org/nilaway/config"
 	"go.uber.org/nilaway/util"
+	"go.uber.org/nilaway/util/analysishelper"
 	"golang.org/x/tools/go/analysis"
 )
 
@@ -36,7 +37,8 @@ var Analyzer = &analysis.Analyzer{
 	Requires:  []*analysis.Analyzer{config.Analyzer, accumulation.Analyzer},
 }
 
-func run(pass *analysis.Pass) (interface{}, error) {
+func run(p *analysis.Pass) (interface{}, error) {
+	pass := analysishelper.NewEnhancedPass(p)
 	conf := pass.ResultOf[config.Analyzer].(*config.Config)
 	deferredErrors := pass.ResultOf[accumulation.Analyzer].([]analysis.Diagnostic)
 	for _, e := range deferredErrors {

--- a/util/analysishelper/pass.go
+++ b/util/analysishelper/pass.go
@@ -1,0 +1,31 @@
+package analysishelper
+
+import (
+	"go/ast"
+	"go/constant"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+// EnhancedPass is a drop-in replacement for `*analysis.Pass` that provides additional helper methods
+// to make it easier to work with the analysis pass.
+type EnhancedPass struct {
+	*analysis.Pass
+}
+
+// NewEnhancedPass creates a new EnhancedPass from the given *analysis.Pass.
+func NewEnhancedPass(pass *analysis.Pass) *EnhancedPass {
+	return &EnhancedPass{Pass: pass}
+}
+
+// IsZero returns if the given expression is evaluated to integer zero at compile time. For
+// example, zero literal, zero const or binary expression that evaluates to zero, e.g., 1 - 1
+// should all return true. Note the function will return false for zero string `"0"`.
+func (p *EnhancedPass) IsZero(expr ast.Expr) bool {
+	tv, ok := p.TypesInfo.Types[expr]
+	if !ok {
+		return false
+	}
+	intValue, ok := constant.Val(tv.Value).(int64)
+	return ok && intValue == 0
+}

--- a/util/analysishelper/pass_test.go
+++ b/util/analysishelper/pass_test.go
@@ -1,0 +1,90 @@
+//  Copyright (c) 2024 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analysishelper
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/analysis"
+)
+
+func TestEnhancedPass_IsZero(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		code     string
+		expected bool
+	}{
+		{"zero literal", "0", true},
+		{"non-zero literal", "1", false},
+		{"negative zero", "-0", true},
+		{"negative non-zero", "-1", false},
+		{"binary expression evaluating to zero", "1 - 1", true},
+		{"binary expression evaluating to non-zero", "1 + 1", false},
+		{"complex binary expression evaluating to zero", "5 - 3 - 2", true},
+		{"multiplication by zero", "42 * 0", true},
+		{"zero string literal", `"0"`, false},
+		{"zero float literal (IsZero only handles integers)", "0.0", false},
+		{"parenthesized zero", "(0)", true},
+		{"parenthesized expression evaluating to zero", "(2 - 2)", true},
+		{"non-literal expression", "x", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Create a minimal Go program with the expression
+			src := "package main\nfunc main() { var x int; print(x); _ = " + tt.code + " }"
+			pass, file := newTestEnhancedPass(t, src)
+
+			// Find the expression in the AST
+			var expr ast.Expr
+			ast.Inspect(file, func(n ast.Node) bool {
+				if assign, ok := n.(*ast.AssignStmt); ok && len(assign.Rhs) > 0 {
+					expr = assign.Rhs[0]
+					return false
+				}
+				return true
+			})
+			require.NotNil(t, expr, "expression not found in AST")
+
+			require.Equal(t, tt.expected, pass.IsZero(expr))
+		})
+	}
+}
+
+// newTestEnhancedPass creates an *analysishelper.EnhancedPass from the given Go source code for testing purposes.
+func newTestEnhancedPass(t *testing.T, src string) (*EnhancedPass, *ast.File) {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "test.go", src, parser.ParseComments)
+	require.NoError(t, err)
+
+	conf := types.Config{}
+	info := &types.Info{Types: make(map[ast.Expr]types.TypeAndValue)}
+	_, err = conf.Check("test", fset, []*ast.File{file}, info)
+	require.NoError(t, err)
+
+	pass := &analysis.Pass{TypesInfo: info}
+	return NewEnhancedPass(pass), file
+}

--- a/util/asthelper/asthelper.go
+++ b/util/asthelper/asthelper.go
@@ -22,7 +22,7 @@ import (
 	"io"
 	"strings"
 
-	"golang.org/x/tools/go/analysis"
+	"go.uber.org/nilaway/util/analysishelper"
 )
 
 // DocContains returns true if the comment group contains the given string.
@@ -43,7 +43,7 @@ func DocContains(file *ast.File, s string) bool {
 }
 
 // PrintExpr converts AST expression to string, and shortens long expressions if isShortenExpr is true
-func PrintExpr(e ast.Expr, pass *analysis.Pass, isShortenExpr bool) (string, error) {
+func PrintExpr(e ast.Expr, pass *analysishelper.EnhancedPass, isShortenExpr bool) (string, error) {
 	builder := &strings.Builder{}
 	var err error
 

--- a/util/util.go
+++ b/util/util.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 
 	"go.uber.org/nilaway/config"
-	"golang.org/x/tools/go/analysis"
+	"go.uber.org/nilaway/util/analysishelper"
 )
 
 // ErrorType is the type of the builtin "error" interface.
@@ -236,7 +236,7 @@ func PortionAfterSep(input, sep string, occ int) string {
 // map is a good approximation.
 // Right now, this is used only to decide whether to print the location of the producer expression
 // in a full trigger.
-func ExprIsAuthentic(pass *analysis.Pass, expr ast.Expr) bool {
+func ExprIsAuthentic(pass *analysishelper.EnhancedPass, expr ast.Expr) bool {
 	t := pass.TypesInfo.TypeOf(expr)
 	return t != nil
 }
@@ -246,7 +246,7 @@ func ExprIsAuthentic(pass *analysis.Pass, expr ast.Expr) bool {
 // The function checks 2 things,
 // 1) Name of the called function is "builtin append"
 // 2) The first argument to the function is a slice
-func IsSliceAppendCall(node *ast.CallExpr, pass *analysis.Pass) (*types.Slice, bool) {
+func IsSliceAppendCall(node *ast.CallExpr, pass *analysishelper.EnhancedPass) (*types.Slice, bool) {
 	if funcName, ok := node.Fun.(*ast.Ident); ok {
 		if declObj := pass.TypesInfo.Uses[funcName]; declObj != nil {
 			if declObj.String() == "builtin append" {
@@ -290,7 +290,7 @@ func TypeBarsNilness(t types.Type) bool {
 
 // ExprBarsNilness returns if the expression can never be nil for the simple reason that nil does
 // not inhabit its type.
-func ExprBarsNilness(pass *analysis.Pass, expr ast.Expr) bool {
+func ExprBarsNilness(pass *analysishelper.EnhancedPass, expr ast.Expr) bool {
 	t := pass.TypesInfo.TypeOf(expr)
 	// `pass.TypesInfo.TypeOf` only checks Types, Uses, and Defs maps in TypesInfo. However, we may
 	// miss types for some expressions. For example, `f` in `s.f` can only be found in
@@ -513,7 +513,7 @@ func truncatePosition(position token.Position) token.Position {
 }
 
 // PosToLocation converts a token.Pos as a real code location, of token.Position.
-func PosToLocation(pos token.Pos, pass *analysis.Pass) token.Position {
+func PosToLocation(pos token.Pos, pass *analysishelper.EnhancedPass) token.Position {
 	return truncatePosition(pass.Fset.Position(pos))
 }
 


### PR DESCRIPTION
This PR introduces a drop-in replacement for `*analysis.Pass` that provides more helper methods that are directly attached to `*analysis.Pass`. These helper methods usually provide logic that spans different areas (e.g., a combination of types and ast, like `IsZero` that takes an `ast.Expr` as input but checks if it is a compile-time constant via `types`).

This is different than pure helper functions in `asthelper` / `typeshelper` etc. that are only related to the particular package (i.e., no cross-area functionality).

As part of this, we are lifting `isIntZero` helper that is directly attached to `RootAssertionNode` to this `EnhancedPass`. Moreover, since it is a drop-in replacement for `*analysis.Pass`, we replace most sites within the NilAway codebase with `*analysishelper.EnhancedPass` such that we can enjoy the new helper methods in the future without refactors at all.

This is meant to be the initial PR that does the refactor, more helper methods will be refactored / added to this in the future.