### PR TITLE
Check in documentations into `docs` directory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,6 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+@docs/index.md
+@docs/Developing.md

--- a/README.md
+++ b/README.md
@@ -3,29 +3,29 @@
 [![GoDoc][doc-img]][doc] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov]
 
 > [!WARNING]  
-> NilAway is currently under active development: false positives and breaking changes can happen. 
+> NilAway is currently under active development: false positives and breaking changes can happen.
 > We highly appreciate any feedback and contributions!
 
-NilAway is a static analysis tool that seeks to help developers avoid nil panics in production by catching them at 
+NilAway is a static analysis tool that seeks to help developers avoid nil panics in production by catching them at
 compile time rather than runtime. NilAway is similar to the standard
-[nilness analyzer](https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/nilness), however, it employs much more 
+[nilness analyzer](https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/nilness), however, it employs much more
 sophisticated and powerful static analysis techniques to track nil flows within a package as well _across_ packages, and
 report errors providing users with the nilness flows for easier debugging.
 
 NilAway enjoys three key properties that make it stand out:
 
-* It is **fully-automated**: NilAway is equipped with an inference engine, making it require _no_ any additional 
-information from the developers (e.g., annotations) besides standard Go code.
+- It is **fully-automated**: NilAway is equipped with an inference engine, making it require _no_ any additional
+  information from the developers (e.g., annotations) besides standard Go code.
 
-* It is **fast**: we have designed NilAway to be fast and scalable, making it suitable for large codebases. In our
-measurements, we have observed less than 5% build-time overhead when NilAway is enabled. We are also constantly applying
-optimizations to further reduce its footprint.
+- It is **fast**: we have designed NilAway to be fast and scalable, making it suitable for large codebases. In our
+  measurements, we have observed less than 5% build-time overhead when NilAway is enabled. We are also constantly applying
+  optimizations to further reduce its footprint.
 
-* It is **practical**: it does not prevent _all_ possible nil panics in your code, but it catches most of the potential
-nil panics we have observed in production, allowing NilAway to maintain a good balance between usefulness and build-time 
-overhead.
+- It is **practical**: it does not prevent _all_ possible nil panics in your code, but it catches most of the potential
+  nil panics we have observed in production, allowing NilAway to maintain a good balance between usefulness and build-time
+  overhead.
 
-:star2: For more detailed technical discussion, please check our [Wiki][wiki], [Engineering Blog][blog], and paper (WIP).
+:star2: For more detailed technical discussion, please check our [docs][docs], [Engineering Blog][blog], and paper (WIP).
 
 ## Running NilAway
 
@@ -33,49 +33,51 @@ NilAway is implemented using the standard [go/analysis][go-analysis], making it 
 drivers (i.e., [golangci-lint][golangci-lint], [nogo][nogo], or [running as a standalone checker][singlechecker]).
 
 > [!IMPORTANT]  
-> By default, NilAway analyzes _all_ Go code, including the standard libraries and dependencies. This helps NilAway 
-> better understand the code form dependencies and reduce its false negatives. However, this would also incur a 
-> significant performance cost (only once for drivers with modular support) and increase the number of non-actionable 
+> By default, NilAway analyzes _all_ Go code, including the standard libraries and dependencies. This helps NilAway
+> better understand the code form dependencies and reduce its false negatives. However, this would also incur a
+> significant performance cost (only once for drivers with modular support) and increase the number of non-actionable
 > errors in dependencies, for large Go projects with a lot of dependencies.
-> 
-> We highly recommend using the [include-pkgs][include-pkgs-flag] flag to narrow down the analysis to your project's 
-> code exclusively. This directs NilAway to skip analyzing dependencies (e.g., third-party libraries), allowing you to 
+>
+> We highly recommend using the [include-pkgs][include-pkgs-flag] flag to narrow down the analysis to your project's
+> code exclusively. This directs NilAway to skip analyzing dependencies (e.g., third-party libraries), allowing you to
 > focus solely on potential nil panics reported by NilAway in your first-party code!
 
 ### Standalone Checker
 
 > [!IMPORTANT]  
-> Due to the sophistication of the analyses that NilAway does, NilAway caches its findings about a 
-> particular package via the [Fact Mechanism][fact-mechanism] from the [go/analysis][go-analysis] 
-> framework. Therefore, it is _highly_ recommended to leverage a driver that supports modular 
-> analysis (i.e., bazel/nogo or golangci-lint, but _not_ the standalone checker since it stores all 
+> Due to the sophistication of the analyses that NilAway does, NilAway caches its findings about a
+> particular package via the [Fact Mechanism][fact-mechanism] from the [go/analysis][go-analysis]
+> framework. Therefore, it is _highly_ recommended to leverage a driver that supports modular
+> analysis (i.e., bazel/nogo or golangci-lint, but _not_ the standalone checker since it stores all
 > facts in memory) for better performance on large projects. The standalone checker is provided
 > more for evaluation purposes since it is easy to get started.
 
-Install the binary from source by running: 
+Install the binary from source by running:
+
 ```shell
 go install go.uber.org/nilaway/cmd/nilaway@latest
 ```
 
 Then, run the linter by:
+
 ```shell
 nilaway -include-pkgs="<YOUR_PKG_PREFIX>,<YOUR_PKG_PREFIX_2>" ./...
 ```
 
 > [!TIP]  
 > Disable the `pretty-print` flag when output as JSON:
+>
 > ```shell
 > nilaway -json -pretty-print=false -include-pkgs="<YOUR_PKG_PREFIX>,<YOUR_PKG_PREFIX_2>" ./...
 > ```
 
-
 ### golangci-lint (>= v1.57.0)
 
-NilAway, in its current form, can report false positives. This unfortunately hinders its immediate 
-merging in [golangci-lint][golangci-lint] and be offered as a linter (see [PR#4045][pr-4045]). 
-Therefore, you need to build NilAway as a plugin to golangci-lint to be executed as a private 
-linter. There are two plugin systems in golangci-lint, and it is much easier to use the 
-[Module Plugin System][golangci-lint-module-plugin] (introduced since v1.57.0), and it is the only 
+NilAway, in its current form, can report false positives. This unfortunately hinders its immediate
+merging in [golangci-lint][golangci-lint] and be offered as a linter (see [PR#4045][pr-4045]).
+Therefore, you need to build NilAway as a plugin to golangci-lint to be executed as a private
+linter. There are two plugin systems in golangci-lint, and it is much easier to use the
+[Module Plugin System][golangci-lint-module-plugin] (introduced since v1.57.0), and it is the only
 supported approach to run NilAway in golangci-lint.
 
 (1) Create a `.custom-gcl.yml` file at the root of the repository if you have not done so, add the
@@ -110,7 +112,6 @@ linters:
           include-pkgs: "<YOUR_PACKAGE_PREFIXES>"
 ```
 
-
 <details>
 
 <summary>For golangci-lint v1:</summary>
@@ -125,7 +126,7 @@ linters-settings:
         # Settings must be a "map from string to string" to mimic command line flags: the keys are
         # flag names and the values are the values to the particular flags.
         include-pkgs: "<YOUR_PACKAGE_PREFIXES>"
-# NilAway can be referred to as `nilaway` just like any other golangci-lint analyzers in other 
+# NilAway can be referred to as `nilaway` just like any other golangci-lint analyzers in other
 # parts of the configuration file.
 ```
 
@@ -145,7 +146,7 @@ instructions).
 > [!TIP]  
 > Cache the custom binary to avoid having to build it again to save resources, you can use the
 > hash of the `.custom-gcl.yml` file as the cache key if you are using a fixed version of NilAway.
-> If you are using `latest` as NilAway version, you can append the date of build to the cache key 
+> If you are using `latest` as NilAway version, you can append the date of build to the cache key
 > to force cache expiration after certain time period.
 
 (4) Run the custom binary instead of `golangci-lint`:
@@ -157,15 +158,16 @@ $ ./custom-gcl run ./...
 
 ### Bazel/nogo
 
-Running with bazel/nogo requires slightly more efforts. First follow the instructions from [rules_go][rules-go], 
-[gazelle][gazelle], and [nogo][nogo] to set up your Go project such that it can be built with bazel/nogo with no or 
+Running with bazel/nogo requires slightly more efforts. First follow the instructions from [rules_go][rules-go],
+[gazelle][gazelle], and [nogo][nogo] to set up your Go project such that it can be built with bazel/nogo with no or
 default set of linters configured. Then,
 
-(1) Add `import _ "go.uber.org/nilaway"` to your `tools.go` file (or other file that you use for configuring tool 
-dependencies, see [How can I track tool dependencies for a module?][track-tool-dependencies] from Go Modules 
+(1) Add `import _ "go.uber.org/nilaway"` to your `tools.go` file (or other file that you use for configuring tool
+dependencies, see [How can I track tool dependencies for a module?][track-tool-dependencies] from Go Modules
 documentation) to avoid `go mod tidy` from removing NilAway as a tool dependency.
 
 (2) Run the following commands to add NilAway as a tool dependency to your project:
+
 ```bash
 # Get NilAway as a dependency, as well as getting its transitive dependencies in go.mod file.
 $ go get go.uber.org/nilaway@latest
@@ -188,14 +190,14 @@ nogo(
 )
 ```
 
-(4) Run bazel build to see NilAway working (any nogo error will stop the bazel build, you can use the `--keep_going` 
+(4) Run bazel build to see NilAway working (any nogo error will stop the bazel build, you can use the `--keep_going`
 flag to request bazel to build as much as possible):
 
 ```bash
 $ bazel build --keep_going //...
 ```
 
-(5) See [nogo documentation][nogo-configure-analyzers] on how to pass a configuration JSON to the nogo driver, and see 
+(5) See [nogo documentation][nogo-configure-analyzers] on how to pass a configuration JSON to the nogo driver, and see
 our [wiki page][nogo-configure-nilaway] on how to pass configurations to NilAway.
 
 ## Code Examples
@@ -236,7 +238,7 @@ func bar() {
 
 In this example, the function `foo` returns a nil pointer, which is directly dereferenced in `bar`, resulting in a panic
 whenever `bar` is called. NilAway is able to catch this potential nil flow and reports the following error, describing
-the nilness flow across function boundaries: 
+the nilness flow across function boundaries:
 
 ```
 go.uber.org/example.go:23:13: error: Potential nil panic detected. Observed nil flow from source to dereference point:
@@ -254,17 +256,17 @@ We expose a set of flags via the standard flag passing mechanism in [go/analysis
 Please check [wiki/Configuration](https://github.com/uber-go/nilaway/wiki/Configuration) to see the available flags and
 how to pass them using different linter drivers.
 
-## Support 
+## Support
 
-We follow the same [version support policy](https://go.dev/doc/devel/release#policy) as the [Go](https://golang.org/) 
+We follow the same [version support policy](https://go.dev/doc/devel/release#policy) as the [Go](https://golang.org/)
 project: we support and test the last two major versions of Go.
 
-Please feel free to [open a GitHub issue](https://github.com/uber-go/nilaway/issues) if you have any questions, bug 
+Please feel free to [open a GitHub issue](https://github.com/uber-go/nilaway/issues) if you have any questions, bug
 reports, and feature requests.
 
 ## Contributions
 
-We'd love for you to contribute to NilAway! Please note that once you create a pull request, you will be asked to sign 
+We'd love for you to contribute to NilAway! Please note that once you create a pull request, you will be asked to sign
 our [Uber Contributor License Agreement](https://cla-assistant.io/uber-go/nilaway).
 
 ## License
@@ -282,15 +284,15 @@ This project is copyright 2023 Uber Technologies, Inc., and licensed under Apach
 [ci]: https://github.com/uber-go/nilaway/actions/workflows/ci.yml
 [cov-img]: https://codecov.io/gh/uber-go/nilaway/branch/main/graph/badge.svg
 [cov]: https://codecov.io/gh/uber-go/nilaway
-[wiki]: https://github.com/uber-go/nilaway/wiki
+[docs]: https://github.com/uber-go/nilaway/tree/main/docs
 [blog]: https://www.uber.com/blog/nilaway-practical-nil-panic-detection-for-go/
 [fact-mechanism]: https://pkg.go.dev/golang.org/x/tools/go/analysis#hdr-Modular_analysis_with_Facts
-[include-pkgs-flag]: https://github.com/uber-go/nilaway/wiki/Configuration#include-pkgs
+[include-pkgs-flag]: https://github.com/uber-go/nilaway/tree/main/docs/Configuration.md#include-pkgs
 [pr-4045]: https://github.com/golangci/golangci-lint/issues/4045
 [nilaway-as-a-plugin]: https://golangci-lint.run/contributing/new-linters/#how-to-add-a-private-linter-to-golangci-lint
 [rules-go]: https://github.com/bazelbuild/rules_go
 [gazelle]: https://github.com/bazelbuild/bazel-gazelle
 [track-tool-dependencies]: https://go.dev/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
 [nogo-configure-analyzers]: https://github.com/bazelbuild/rules_go/blob/master/go/nogo.rst#id14
-[nogo-configure-nilaway]: https://github.com/uber-go/nilaway/wiki/Configuration#nogo
+[nogo-configure-nilaway]: https://github.com/uber-go/nilaway/tree/main/docs/Configuration.md#nogo
 [nogo-instructions]: https://github.com/uber-go/nilaway?tab=readme-ov-file#bazelnogo

--- a/docs/Community-Maintained-Projects.md
+++ b/docs/Community-Maintained-Projects.md
@@ -1,0 +1,3 @@
+We always welcome and love community contributions! Here we share a list of community-maintained projects related to NilAway which may be useful to you. Please direct issues to the corresponding repositories, as we cannot provide any support for them.
+
+- [nilaway-action](https://github.com/qbaware/nilaway-action): GitHub Action that uses NilAway to check potential nil panics in your repository.

--- a/docs/Configurations.md
+++ b/docs/Configurations.md
@@ -1,0 +1,162 @@
+# Configurations
+
+## General Flags
+
+#### `include-pkgs`
+
+> Default `""` (all packages are included)
+
+A comma-separated list of package prefixes to include for analysis.
+
+By default all packages (including standard and 3rd party libraries) will be loaded by the driver and passed to the linters for analysis. This may not be desirable in practice: the errors reported on them cannot be fixed locally, and the overhead for analyzing them is pointless. Hence this flag can be set to include packages that have certain prefixes (e.g., `go.uber.org`), such that only first-party code is analyzed. If a package is excluded from analysis, default nilabilities will be assumed (e.g., functions will be assumed to always return nonnil pointers).
+
+> [!WARNING]  
+> Please note that even if a package is excluded from analysis, errors might still be reported on them if the nilness flows happens within the analyzed package, but it includes using a struct from the excluded package. For example, if the analyzed package constructs a struct from the excluded package, assigns a `nil` to a field, and then immediately dereferences the field. In this case, NilAway will report an error for this flow, but the location will be on the field (that resides in the excluded package). To only report errors on the desired packages, please use the error suppression mechanisms specified in the driver ([golangci-lint](https://golangci-lint.run/usage/false-positives/), [nogo](https://github.com/bazelbuild/rules_go/blob/master/go/nogo.rst)).
+
+Added in v0.1.0
+
+#### `exclude-pkgs`
+
+> Default `""` (no packages are excluded)
+
+A comma-separated list of package prefixes to exclude for analysis. This takes precedence over `include-pkgs`.
+
+Added in v0.1.0
+
+#### `exclude-file-docstrings`
+
+> Default `""` (no files are excluded)
+
+A comma-separated list of strings to search for in a file's docstrings to exclude a file from analysis.
+
+Added in v0.1.0
+
+#### `pretty-print`
+
+> Default `false`
+
+A boolean flag indicating if NilAway should pretty print the errors (with ANSI color codes to highlight different components in the errors).
+
+Added in v0.1.0
+
+#### `group-error-messages`
+
+> Default `true`
+
+A boolean flag indicating if NilAway should group similar error messages together.
+
+Added in v0.1.0
+
+#### `experimental-struct-init`
+
+> Default `false`
+
+A boolean flag enabling experimental support in NilAway for more sophisticated tracking / analysis around struct fields and struct initializations (e.g., initializing an empty struct and then calling a function to populate the fields, such that the fields should be considered nonnil). Note that this feature brings performance penalties and false positives. We plan to further improve this feature and merge it in main NilAway, so this flag could be removed in the future.
+
+Added in v0.1.0
+
+#### `experimental-anonymous-function`
+
+> Default `false`
+
+A boolean flag enabling experimental support for anonymous functions in NilAway. Note that this feature brings a fair number of false positives. We plan to further improve this feature and merge it in main NilAway, so this flag could be removed in the future.
+
+Added in v0.1.0
+
+## Driver-Specific Flags
+
+#### Standalone Checker
+
+Since the standalone linter driver does not support error suppression, which may be required for some deployments (see [Include Package](https://github.com/uber-go/nilaway/wiki/Configuration/#include-packages-include-pkgs) for a detailed discussion), we add two more flags to this specific checker for such functionality:
+
+#### `include-errors-in-files`
+
+> Default is the current working directory, meaning we only report errors for files within the current working directory.
+
+A comma-separated list of file prefixes to report errors.
+
+Added in v0.1.0
+
+#### `exclude-errors-in-files`
+
+> Default "", meaning no errors are suppressed.
+
+A comma-separated list of file prefixes to exclude from error reporting. This takes precedence over include-errors-in-files.
+
+Added in v0.1.0
+
+#### `json`
+
+> Default `false`
+
+A boolean flag indicating if the NilAway errors should be printed in JSON format for further post-processing.
+
+Added in v0.1.0
+
+## Passing Configurations
+
+### Standalone Checker
+
+Flags can be specified directly on the command line:
+
+```
+nilaway -flag1 <VALUE> -flag2 <VALUE> ./...
+```
+
+### golangci-lint
+
+Flags can be specified in `.golangci.yaml` configuration file:
+
+```yaml
+linters-settings:
+  custom:
+    nilaway:
+      type: "module"
+      description: Static analysis tool to detect potential nil panics in Go code.
+      settings:
+        # Settings must be a "map from string to string" to mimic command line flags: the keys are
+        # flag names and the values are the values to the particular flags.
+        include-pkgs: "<YOUR_PACKAGE_PREFIXES>"
+# NilAway can be referred to as `nilaway` just like any other golangci-lint analyzers in other
+# parts of the configuration file.
+```
+
+### Bazel/nogo
+
+Configurations of NilAway is slightly confusing: the flags should be passed to a specific `nilaway_config` analyzer, and error suppressions should be passed to the top-level `nilaway` analyzer instead.
+
+<details>
+
+<summary> Here is the technical explanation </summary>
+
+> NilAway adopts the standard flag passing mechanism in the [`go/analysis`](https://pkg.go.dev/golang.org/x/tools/go/analysis) framework. However, the multi-analyzer architecture of NilAway (see [wiki/Architecture](https://github.com/uber-go/nilaway/wiki/Architecture)) makes it slightly difficult to pass flags to NilAway. If we simply set the `Flags` fields to the top-level `nilaway.Analyzer`, by the time it is executed, the sub-analyzers have already done the work, making the flags meaningless (i.e., it can no long alter their behaviors).
+>
+> To address this problem, we have defined a separate `nilaway_config` analyzer which is only responsible for defining the `Flags` field and expose the configs through its return value. All other sub-analyzers will depend on the `config.Analyzer` and use the values there to execute different logic.
+>
+> This inevitably makes the configurations for NilAway slightly confusing: you will have to pass flags to the separate `nilaway_config` analyzer, while any error suppressions must be set for the top-level `nilaway` analyzer (since it is the one that eventually reports the errors).
+>
+> For drivers other than Bazel/nogo, we usually have a chance to run extra logic (e.g., during standalone driver initialiation, or during NilAway registration to golangci-lint) before the execution, where we can pass the top-level flags to the specific `nilaway_config` analyzer. However, unfortunately Bazel/nogo does not allow us to do so.
+
+</details>
+
+In your nogo's `config.json` file (see [nogo's documentation on configurations](https://github.com/bazelbuild/rules_go/blob/master/go/nogo.rst#configuring-analyzers) on how to pass this file to the nogo driver), you have to specify configurations for two analyzers. For example:
+
+```json
+{
+  "nilaway_config": {
+    "analyzer_flags": {
+      "include-pkgs": "go.uber.org",
+      "exclude-pkgs": "vendor/",
+      "exclude-file-docstrings": "@generated,Code generated by,Autogenerated by"
+    }
+  },
+  "nilaway": {
+    "exclude_files": {
+      "bazel-out": "this prevents nilaway from outputting diagnostics on intermediate test files"
+    },
+    "only_files": {
+      "my/code/path": "This is the comment for why we want to enable NilAway on this code path"
+    }
+  }
+}
+```

--- a/docs/Developing.md
+++ b/docs/Developing.md
@@ -1,0 +1,96 @@
+# Developing
+
+## Building
+
+```bash
+make build                    # Build the nilaway binary to ./bin/
+```
+
+## Testing
+
+```bash
+make test                     # Run unit tests for all modules
+make cover                    # Run tests with coverage reports
+make golden-test              # Run golden tests on stdlib (Use $ARGS env var to pass arguments)
+make integration-test         # Run integration tests
+```
+
+## Linting
+
+```bash
+make lint                    # Run all linting (golangci-lint, nilaway self-check, mod tidy)
+make golangci-lint           # Run golangci-lint only
+make nilaway-lint            # Run nilaway on itself
+make tidy-lint               # Check go.mod tidiness
+```
+
+### Running NilAway
+
+```bash
+# Build nilaway in current codebase.
+make build
+
+# Standalone usage
+bin/nilaway -include-pkgs="<YOUR_PKG_PREFIX>" ./...
+
+# With JSON output (disable pretty-print)
+bin/nilaway -json -pretty-print=false -include-pkgs="<YOUR_PKG_PREFIX>" ./...
+
+# Using custom golangci-lint build
+golangci-lint custom         # Build custom binary with NilAway plugin
+./custom-gcl run ./...       # Run custom golangci-lint with NilAway
+```
+
+## Architecture
+
+For best performance and easier maintenance, NilAway consists of multiple levels of sub-analyzers that are all
+`analysis.Analyzer`s, and they are connected by specifying dependencies (via `Requires` field) between them. Currently, the organization is as follows:
+
+- **nilaway.Analyzer** (nilaway.go) - Top-level analyzer that reports errors
+  - **accumulation.Analyzer** - Collects triggers, runs inference, returns errors
+    - **annotation.Analyzer** - Reads annotations from structs/interfaces/functions
+    - **function.Analyzer** - Analyzes functions and creates triggers
+      - **anonymousfunc.Analyzer** - Handles function literals
+      - **structfield.Analyzer** - Handles struct field accesses
+    - **affiliation.Analyzer** - Creates interface-struct affiliation triggers
+    - **global.Analyzer** - Creates global variable triggers
+
+All the analyzers depend on `config.Analyzer` (`config/config.go`) to retrieve configurations.
+
+The decoupling of error generation and error reporting logic makes it possible to apply custom error reporting to fit other needs. For example, it is possible to create another top-level analyzer `nilaway-log` that depends on the accumulation analyzer, which simply retrieves the NilAway errors and logs them to a local file or database for later auditing.
+
+### Key Components
+
+- **Triggers**: Flow conditions that may cause nil panics
+- **Annotations**: Metadata about nilability of types and functions
+- **Inference Engine**: Matches triggers with annotations to detect nil flows
+- **Facts Mechanism**: Caches analysis results across packages for performance
+
+### Important Files
+
+- `nilaway.go` - Main analyzer entry point
+- `cmd/nilaway/main.go` - Standalone checker with additional flags
+- `cmd/gclplugin/gclplugin.go` - golangci-lint plugin integration
+- `accumulation/analyzer.go` - Core inference coordination
+- `config/config.go` - Configuration management
+
+## Key Configuration Flags
+
+- `-include-pkgs`: Comma-separated package prefixes to analyze (recommended)
+- `-exclude-pkgs`: Package prefixes to exclude from analysis
+- `-pretty-print`: Enable/disable pretty error messages (default: true)
+- `-group-error-messages`: Group similar error messages
+- `-experimental-struct-init-enable`: Enable experimental struct initialization
+- `-experimental-anonymous-func-enable`: Enable experimental anonymous function support
+
+## Performance Notes
+
+- Uses `go/analysis` Facts mechanism for cross-package caching
+- For large projects, use modular drivers (bazel/nogo or golangci-lint) over standalone checker
+- Recommend using `-include-pkgs` to focus analysis on first-party code only
+
+## Module Structure
+
+- Root module: Core NilAway implementation
+- `tools/` module: Development tools (golden-test, integration-test)
+- `testdata/` directory: Comprehensive test cases organized by feature

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,9 @@
+# Project Overview
+
+NilAway is a static analysis tool that detects potential nil panics in Go code. It uses
+sophisticated analysis techniques to track nil flows within and across packages, reporting errors
+with nilness flows for easier debugging.
+
+- [Configurations](Configurations.md)
+- [Developing](Developing.md)
+- [Community-Maintained Projects](Community-Maintained-Projects.md)


### PR DESCRIPTION
This PR checks in the existing wiki documentations into the source repository to allow source controls (we will be using it as single source of truth going forward).

Not only does this allow source controls (PRs can now be made against docs), but it also enables AI agents to work more effectively when working in NilAway repository. As part of this effort, we are checking in `CLAUDE.md` that simply references the `docs/Developing.md` file.