### PR TITLE
Add `make lint-fix` subcommand to automatically apply lint/format fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,9 +60,9 @@ install-golangci-lint:
 .PHONY: format-lint
 format-lint: install-golangci-lint
 	@$(foreach mod,$(MODULE_DIRS), \
-    		(cd $(mod) && \
-    		echo "[lint] golangci-lint fmt: $(mod)" && \
-    		$(GOBIN)/golangci-lint fmt $(if $(FIX),,--diff)) &&) true
+    	(cd $(mod) && \
+    	echo "[lint] golangci-lint fmt: $(mod)" && \
+    	$(GOBIN)/golangci-lint fmt $(if $(FIX),,--diff)) &&) true
 
 .PHONY: golangci-lint
 golangci-lint: install-golangci-lint

--- a/docs/Developing.md
+++ b/docs/Developing.md
@@ -3,7 +3,7 @@
 ## Building
 
 ```bash
-make build                    # Build the nilaway binary to ./bin/
+make build                    # Build the nilaway binary to <project root>/bin/
 ```
 
 ## Testing
@@ -11,17 +11,35 @@ make build                    # Build the nilaway binary to ./bin/
 ```bash
 make test                     # Run unit tests for all modules
 make cover                    # Run tests with coverage reports
-make golden-test              # Run golden tests on stdlib (Use $ARGS env var to pass arguments)
-make integration-test         # Run integration tests
+make integration-test         # Run integration tests (using real drivers)
+```
+
+The following golden tests are available, which run NilAway on a base (usually `main`) and test (usually `HEAD`) branches
+on stdlib and compare the differences of NilAway violations. This is mostly run in CI to catch unexpected breakages.
+
+```bash
+# The arguments are passed as an environment variable `ARGS`.
+# Use `make golden-test ARGS="-h" to see the available arguments.
+make golden-test ARGS="-base-branch main -test-branch HEAD -result-file /tmp/result.txt"
 ```
 
 ## Linting
 
 ```bash
-make lint                    # Run all linting (golangci-lint, nilaway self-check, mod tidy)
+make lint                    # Run all linting (format check, mod tidy, golangci-lint, nilaway self-check)
+make lint-fix                # Run all linting with autofix (and auto-formats) applied
+```
+
+The following subcommands are available if you need to run individual linting components. Pass in `FIX=true` environment
+variable to apply auto-fixes _if available_. 
+
+In most cases you only need to ever run `make lint` or `make lint-fix` instead of these.
+
+```bash
+make format-lint             # Check if Go files are correctly formatted
+make tidy-lint               # Check go.mod tidiness
 make golangci-lint           # Run golangci-lint only
 make nilaway-lint            # Run nilaway on itself
-make tidy-lint               # Check go.mod tidiness
 ```
 
 ### Running NilAway


### PR DESCRIPTION
We add a `make lint-fix` to automatically apply lint fixes if available. Additionally, we introduce Go format check into the linting suite (by leveraging `golangci-lint`, which we already use) and also add auto-format to the newly-introduced `lint-fix` sub commands.

Moreover, we are adding such description to `docs/Developing.md` file to help contributors and coding agents.