### PR TITLE
Suppress generic rich-check-effect functions error reporting

### DIFF
--- a/assertion/function/assertiontree/backprop.go
+++ b/assertion/function/assertiontree/backprop.go
@@ -382,6 +382,19 @@ func backpropAcrossAssignment(rootNode *RootAssertionNode, lhs, rhs []ast.Expr) 
 				// TODO: properly handle type assertions' "OK" contract
 				return backpropAcrossOneToOneAssignment(rootNode, lhs[0:1], rhs)
 			}
+
+			// Generic function call
+			// TODO: currently we do not handle generic rich-check-effect function calls, so as a temporary solution,
+			//  we suppress reporting of errors. Note that this helps suppress false positives, but it also means that
+			//  we don't report true positives either. We should fix this in the future when we add support for generics.
+			if c := util.CallExprFromExpr(rhsNode); c != nil {
+				if _, ok := c.Fun.(*ast.IndexExpr); ok {
+					rootNode.AddProduction(&annotation.ProduceTrigger{
+						Annotation: &annotation.ProduceTriggerNever{},
+						Expr:       lhs[0],
+					})
+				}
+			}
 		}
 	}
 

--- a/testdata/src/go.uber.org/contracts/inference/userdefinedfunctions-with-inference.go
+++ b/testdata/src/go.uber.org/contracts/inference/userdefinedfunctions-with-inference.go
@@ -259,3 +259,54 @@ func TestAssignmentToNonPointerTypes(i int, v Value[V]) {
 		}
 	}
 }
+
+// Test generic functions with "ok" form
+// TODO: Note that currently we do not support generics in NilAway. Hence, the below cases are expected to not report
+//  errors since we have put a suppresion in place for generic rich-check-effect functions' error reporting.
+
+func GenericFunc[T any]() (*T, bool) {
+	var resp T
+	if dummy {
+		return nil, false
+	}
+	return &resp, true
+}
+
+func GenericFuncAlwaysSafe[T any]() (*T, bool) {
+	var resp T
+	return &resp, true
+}
+
+func GenericFuncAlwaysUnsafe[T any]() (*T, bool) {
+	return nil, false
+}
+
+func TestGenericFunc(s string) {
+	switch s {
+	case "conditionally safe":
+		v, ok := GenericFunc[int]()
+		if !ok {
+			return
+		}
+		print(*v)
+
+	case "conditionally unsafe":
+		if v, ok := GenericFunc[int](); !ok {
+			// TODO: This is a false negative since we do not support generics yet.
+			print(*v) // "dereferenced"
+		}
+
+	case "always safe":
+		v, ok := GenericFuncAlwaysSafe[int]()
+		if !ok {
+			return
+		}
+		print(*v)
+
+	case "always unsafe":
+		if v, ok := GenericFuncAlwaysUnsafe[int](); ok {
+			// TODO: This is a false negative since we do not support generics yet.
+			print(*v) // "dereferenced"
+		}
+	}
+}

--- a/testdata/src/go.uber.org/errorreturn/inference/errorreturn-with-inference.go
+++ b/testdata/src/go.uber.org/errorreturn/inference/errorreturn-with-inference.go
@@ -1018,3 +1018,54 @@ func TestAssignmentToNonPointerTypes(i int, v Value[V]) {
 		}
 	}
 }
+
+// Test generic error returning functions
+// TODO: Note that currently we do not support generics in NilAway. Hence, the below cases are expected to not report
+//  errors since we have put a suppresion in place for generic rich-check-effect functions' error reporting.
+
+func GenericFunc[T any]() (*T, error) {
+	var resp T
+	if dummy2 {
+		return nil, &myErr2{}
+	}
+	return &resp, nil
+}
+
+func GenericFuncAlwaysSafe[T any]() (*T, error) {
+	var resp T
+	return &resp, &myErr2{}
+}
+
+func GenericFuncAlwaysUnsafe[T any]() (*T, error) {
+	return nil, nil
+}
+
+func TestGenericFunc(s string) {
+	switch s {
+	case "conditionally safe":
+		v, err := GenericFunc[int]()
+		if err != nil {
+			return
+		}
+		print(*v)
+
+	case "conditionally unsafe":
+		if v, err := GenericFunc[int](); err != nil {
+			// TODO: This is a false negative since we do not support generics yet.
+			print(*v) // "dereferenced"
+		}
+
+	case "always safe":
+		v, err := GenericFuncAlwaysSafe[int]()
+		if err != nil {
+			return
+		}
+		print(*v)
+
+	case "always unsafe":
+		if v, err := GenericFuncAlwaysUnsafe[int](); err == nil {
+			// TODO: This is a false negative since we do not support generics yet.
+			print(*v) // "dereferenced"
+		}
+	}
+}


### PR DESCRIPTION
This PR addresses the false positives that were reported for generic rich-check-effect functions. Example:
```
func GenericFunc[T any]() (*T, error) {
	var resp T
	if someCond {
		return nil, errors.New("some error")
	}
	return &resp, nil
}

func CallGenericFunc() {
        v, err := GenericFunc[int]()
	if err != nil {
		return
	}
	print(*v)  // FP reported here: unassigned variable `v` dereferenced
}
```

Currently we do not handle generic rich-check-effect function calls in NilAway. So as a temporary solution, we suppress reporting of errors related to generic rich-check-effect functions. Note that this does help suppress false positives, but it also means that we don't report true positives either. We should fix this in the future when we add support for generics in NilAway.