### PR TITLE
Add support for built-in conversion functions used as index expr

### DIFF
--- a/assertion/function/assertiontree/parse_expr_producer.go
+++ b/assertion/function/assertiontree/parse_expr_producer.go
@@ -435,7 +435,7 @@ func (r *RootAssertionNode) ParseExprAsProducer(expr ast.Expr, doNotTrack bool) 
 					return false
 				case *ast.CallExpr:
 					if fun, ok := index.Fun.(*ast.Ident); ok {
-						if r.isBuiltIn(fun) {
+						if r.isBuiltIn(fun) || r.builtInConversionFuncBasicType(index) != nil {
 							// iterate over the arguments of the call expression
 							for _, arg := range index.Args {
 								if !isIndexTrackable(arg) {

--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -1143,15 +1143,17 @@ func (r *RootAssertionNode) isBuiltIn(ident *ast.Ident) bool {
 	return ok
 }
 
-// builtInConversionFuncBasicType checks if it is a built-in conversion function call, such as `string(x)`, and if yes returns the basic type object
-func (r *RootAssertionNode) builtInConversionFuncBasicType(call *ast.CallExpr) *types.Basic {
+// builtInConversionFuncBasicType checks if it is a built-in conversion function call, such as `string(x)`.
+// If yes returns the basic type object, otherwise nil.
+func (r *RootAssertionNode) builtInConversionFuncBasicType(call *ast.CallExpr) (b *types.Basic) {
 	if ident := util.FuncIdentFromCallExpr(call); ident != nil {
 		if obj := r.ObjectOf(ident); obj != nil {
-			b, _ := obj.Type().(*types.Basic)
-			return b
+			if tname, ok := obj.(*types.TypeName); ok {
+				b, _ = tname.Type().(*types.Basic)
+			}
 		}
 	}
-	return nil
+	return
 }
 
 // checks if a constant - e.g. "true"

--- a/testdata/src/go.uber.org/maps/maps.go
+++ b/testdata/src/go.uber.org/maps/maps.go
@@ -940,6 +940,22 @@ func testNonLiteralMapAccess(mp map[int]*int, i, j int) {
 			return
 		}
 		print(*vs[0])
+
+	case 15:
+		var v uint8
+		m := make(map[string]*int)
+		if m[string(v)] != nil {
+			_ = *m[string(v)]
+		}
+
+		if v, ok := m[string(v)]; ok {
+			_ = *v
+		}
+
+	case 16:
+		var v uint8
+		m := make(map[string]*int)
+		_ = *m[string(v)] //want "lacking guarding"
 	}
 }
 


### PR DESCRIPTION
This PR adds support for built-in conversion functions, such as `string(x)`, used as index expr. Currently, without this support, NilAway reports a false positive for the example below.
```
func test(v uint8) {
		m := make(map[string]*int)
		if m[string(v)] != nil {
			_ = *m[string(v)]  // false positive was reported here
		}
}
```

Go compiler doesn't treat `string(x)` as a call to a built-in function named “string”, but instead it's considered to be a conversion using the predeclared type string. Therefore, our existing logic of `*types.BuiltIn` did not cover this case. We had to add special support for this case by checking for `pass.TypesInfo.ObjectOf(ident).Type().(*types.Basic)`.

[Closes #357 ]