### PR TITLE
Use newer language features from Go 1.24

### DIFF
--- a/annotation/map.go
+++ b/annotation/map.go
@@ -319,7 +319,7 @@ func nilabilityFromCommentGroup(group *ast.CommentGroup) nilabilitySet {
 					deepFunc, shallowFunc = markDeepNilable, markNilable
 				}
 
-				for _, match := range strings.Split(seqMatch[2], sep) {
+				for match := range strings.SplitSeq(seqMatch[2], sep) {
 					match = strings.TrimSpace(match)
 					n := len(match)
 

--- a/assertion/function/analyzer_test.go
+++ b/assertion/function/analyzer_test.go
@@ -94,7 +94,7 @@ func TestCancelledContext(t *testing.T) {
 	wg.Add(1)
 
 	// Give a cancelled context, so back propagation should immediately return with an error.
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
 	ctrlflowResult := pass.ResultOf[ctrlflow.Analyzer].(*ctrlflow.CFGs)
@@ -116,7 +116,7 @@ func TestCancelledContext(t *testing.T) {
 func TestAnalyzeFuncPanic(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	resultChan := make(chan functionResult)
 	var wg sync.WaitGroup
@@ -177,7 +177,7 @@ func TestBackpropFixpointConvergence(t *testing.T) {
 			funcConfig, emptyFuncLitMap, emptyPkgFakeIdentMap, emptyFuncContracts)
 		ctrlflowResult := pass.ResultOf[ctrlflow.Analyzer].(*ctrlflow.CFGs)
 
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		defer cancel()
 
 		// Run the backpropagation algorithm and collect the results.

--- a/diagnostic/nolint.go
+++ b/diagnostic/nolint.go
@@ -114,7 +114,7 @@ func nolintContainsNilAway(text string) bool {
 	if len(parts) == 1 {
 		return true
 	}
-	for _, linter := range strings.Split(strings.TrimSpace(parts[1]), ",") {
+	for linter := range strings.SplitSeq(strings.TrimSpace(parts[1]), ",") {
 		if strings.EqualFold(linter, "all") || strings.EqualFold(linter, "nilaway") {
 			return true
 		}

--- a/inference/inferred_map_test.go
+++ b/inference/inferred_map_test.go
@@ -30,7 +30,7 @@ func BenchmarkGobEncoding(b *testing.B) {
 	m := newBigInferredMap()
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		var buf bytes.Buffer
 		err := gob.NewEncoder(&buf).Encode(m)
 		require.NoError(b, err)


### PR DESCRIPTION
We have recently bumped the minimum Go version to 1.24, this PR contains some refactors with newer language features from Go 1.24.