### PR TITLE
Migrate more helper methods to analysishelper

### DIFF
--- a/annotation/full_trigger.go
+++ b/annotation/full_trigger.go
@@ -60,7 +60,7 @@ func (t *FullTrigger) Check(annMap Map) bool {
 }
 
 func (t *FullTrigger) truncatedConsumerPos(pass *analysishelper.EnhancedPass) token.Position {
-	return util.PosToLocation(t.Consumer.Pos(), pass)
+	return pass.PosToLocation(t.Consumer.Pos())
 }
 
 func (t *FullTrigger) truncatedProducerPos(pass *analysishelper.EnhancedPass) token.Position {
@@ -73,7 +73,7 @@ func (t *FullTrigger) truncatedProducerPos(pass *analysishelper.EnhancedPass) to
 	if t.Producer.Expr == nil {
 		panic(fmt.Sprintf("nil Expr for producer %q", t.Producer))
 	}
-	return util.PosToLocation(t.Producer.Expr.Pos(), pass)
+	return pass.PosToLocation(t.Producer.Expr.Pos())
 }
 
 // equals returns true if the two passed FullTriggers are equal, and false otherwise.

--- a/annotation/map.go
+++ b/annotation/map.go
@@ -670,9 +670,9 @@ func newObservedMap(pass *analysishelper.EnhancedPass, files []*ast.File) *Obser
 					"have parsed annotations once for every function declaration and the " +
 					"mappings should have been set up.")
 			}
-			callSite := CallSite{Fun: funcObj, Location: util.PosToLocation(expr.Pos(), pass)}
+			callSite := CallSite{Fun: funcObj, Location: pass.PosToLocation(expr.Pos())}
 			for i, val := range accFromFieldList(set, funcDecl.Type.Params, true, true) {
-				argLoc := util.PosToLocation(expr.Args[i].Pos(), pass)
+				argLoc := pass.PosToLocation(expr.Args[i].Pos())
 				funcCallSiteParamAnnMap[callSite] = append(funcCallSiteParamAnnMap[callSite],
 					ArgLocAndVal{Location: argLoc, Val: val})
 			}

--- a/assertion/function/analyzer.go
+++ b/assertion/function/analyzer.go
@@ -336,7 +336,7 @@ func duplicateFullTrigger(
 ) annotation.FullTrigger {
 	// TODO: what if we have more than one parameter, planned in future revisions
 	argExpr := callExpr.Args[0]
-	argLoc := util.PosToLocation(argExpr.Pos(), pass)
+	argLoc := pass.PosToLocation(argExpr.Pos())
 
 	// Create the duplicated full trigger
 	// TODO: we just copy the pointer for producer and consumer because I don't see a problem when
@@ -358,7 +358,7 @@ func duplicateFullTrigger(
 		dupTrigger.Producer = annotation.DuplicateParamProducer(trigger.Producer, argLoc)
 	}
 	if isReturnConsumer {
-		retLoc := util.PosToLocation(callExpr.Pos(), pass)
+		retLoc := pass.PosToLocation(callExpr.Pos())
 		dupTrigger.Consumer = annotation.DuplicateReturnConsumer(trigger.Consumer, retLoc)
 		// Set up the site that controls the controlled full trigger to be created
 		c := annotation.NewCallSiteParamKey(callee, 0, argLoc)

--- a/assertion/function/assertiontree/backprop_util.go
+++ b/assertion/function/assertiontree/backprop_util.go
@@ -836,7 +836,7 @@ func addAssignmentToConsumer(lhs, rhs ast.Expr, pass *analysishelper.EnhancedPas
 	consumer.AddAssignment(annotation.Assignment{
 		LHSExprStr: lhsExprStr,
 		RHSExprStr: rhsExprStr,
-		Position:   util.PosToLocation(lhs.Pos(), pass),
+		Position:   pass.PosToLocation(lhs.Pos()),
 	})
 
 	return nil

--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -50,7 +50,7 @@ type RootAssertionNode struct {
 
 // LocationOf returns the location of the given expression.
 func (r *RootAssertionNode) LocationOf(expr ast.Expr) token.Position {
-	return util.PosToLocation(expr.Pos(), r.Pass())
+	return r.Pass().PosToLocation(expr.Pos())
 }
 
 // HasContract returns if the given function has any contracts.

--- a/config/config.go
+++ b/config/config.go
@@ -22,7 +22,6 @@ import (
 	"reflect"
 	"strings"
 
-	"go.uber.org/nilaway/util/analysishelper"
 	"go.uber.org/nilaway/util/asthelper"
 	"golang.org/x/tools/go/analysis"
 )
@@ -157,8 +156,7 @@ func newFlagSet() flag.FlagSet {
 	return *fs
 }
 
-func run(p *analysis.Pass) (any, error) {
-	pass := analysishelper.NewEnhancedPass(p)
+func run(pass *analysis.Pass) (any, error) {
 	// Set up default values for the config.
 	conf := &Config{
 		PrettyPrint:        true,

--- a/diagnostic/engine.go
+++ b/diagnostic/engine.go
@@ -25,7 +25,6 @@ import (
 
 	"go.uber.org/nilaway/annotation"
 	"go.uber.org/nilaway/inference"
-	"go.uber.org/nilaway/util"
 	"go.uber.org/nilaway/util/analysishelper"
 	"go.uber.org/nilaway/util/tokenhelper"
 	"golang.org/x/tools/go/analysis"
@@ -157,7 +156,7 @@ func (e *Engine) AddOverconstraintConflict(nilReason, nonnilReason inference.Exp
 		} else {
 			flow.addNilPathNode(annotation.LocatedPrestring{
 				Contained: r,
-				Location:  util.HumanReadablePosition(e.pass, r.Position()),
+				Location:  e.pass.HumanReadablePosition(r.Position()),
 			}, nil)
 		}
 	}
@@ -181,7 +180,7 @@ func (e *Engine) AddOverconstraintConflict(nilReason, nonnilReason inference.Exp
 		} else {
 			flow.addNonNilPathNode(annotation.LocatedPrestring{
 				Contained: r,
-				Location:  util.HumanReadablePosition(e.pass, r.Position()),
+				Location:  e.pass.HumanReadablePosition(r.Position()),
 			}, nil)
 			reportPosition = position
 		}

--- a/util/tokenhelper/tokenhelper.go
+++ b/util/tokenhelper/tokenhelper.go
@@ -21,6 +21,7 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 var _cwd, _cwdErr = os.Getwd()
@@ -77,4 +78,22 @@ func Inverse(t token.Token) token.Token {
 	default:
 		panic(fmt.Sprintf("unrecognized token %q has no known inverse", t.String()))
 	}
+}
+
+// PortionAfterSep returns the suffix of the passed string `input` containing at most `occ` occurrences
+// of the separator `sep`
+func PortionAfterSep(input, sep string, occ int) string {
+	splits := strings.Split(input, sep)
+	n := len(splits)
+	if n <= occ+1 {
+		return input // input contains at most `occ` occurrences of `sep`
+	}
+	out := ""
+	for i := n - (1 + occ); i < n; i++ {
+		if len(out) > 0 {
+			out += sep
+		}
+		out += splits[i]
+	}
+	return out
 }


### PR DESCRIPTION
This PR migrates `HumanReadablePosition` and `PosToLocation` from `util/util.go` to methods in `analysishelper.EnhancedPass` for better ergonomics and organizations.

As part of this effort, we are also moving `PortionAfterSep` to `tokenhelper` to avoid cyclic dependencies (and also better organizations).