### PR TITLE
Migrate AST-related helper functions to asthelper

### DIFF
--- a/annotation/map.go
+++ b/annotation/map.go
@@ -25,6 +25,7 @@ import (
 	"go.uber.org/nilaway/config"
 	"go.uber.org/nilaway/util"
 	"go.uber.org/nilaway/util/analysishelper"
+	"go.uber.org/nilaway/util/asthelper"
 )
 
 // Map is an abstraction that concrete annotation maps must implement to be checked against.
@@ -648,7 +649,7 @@ func newObservedMap(pass *analysishelper.EnhancedPass, files []*ast.File) *Obser
 				return true
 			}
 
-			ident := util.FuncIdentFromCallExpr(expr)
+			ident := asthelper.FuncIdentFromCallExpr(expr)
 			// if ident is nil, keep searching for nested CallExpr nodes.
 			if ident == nil {
 				return true

--- a/assertion/affiliation/affiliation.go
+++ b/assertion/affiliation/affiliation.go
@@ -25,6 +25,7 @@ import (
 	"go.uber.org/nilaway/config"
 	"go.uber.org/nilaway/util"
 	"go.uber.org/nilaway/util/analysishelper"
+	"go.uber.org/nilaway/util/asthelper"
 	"go.uber.org/nilaway/util/orderedmap"
 )
 
@@ -130,7 +131,7 @@ func (a *Affiliation) computeTriggersForCastingSites(pass *analysishelper.Enhanc
 					}
 				case *ast.CallExpr:
 					// e.g., func foo(i I), foo(&S{})
-					if ident := util.FuncIdentFromCallExpr(node); ident != nil {
+					if ident := asthelper.FuncIdentFromCallExpr(node); ident != nil {
 						if declObj := pass.TypesInfo.Uses[ident]; declObj != nil {
 							if fdecl, ok := declObj.(*types.Func); ok {
 								fsig := fdecl.Type().(*types.Signature)

--- a/assertion/function/analyzer.go
+++ b/assertion/function/analyzer.go
@@ -32,8 +32,8 @@ import (
 	"go.uber.org/nilaway/assertion/function/functioncontracts"
 	"go.uber.org/nilaway/assertion/structfield"
 	"go.uber.org/nilaway/config"
-	"go.uber.org/nilaway/util"
 	"go.uber.org/nilaway/util/analysishelper"
+	"go.uber.org/nilaway/util/asthelper"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/ctrlflow"
 	"golang.org/x/tools/go/cfg"
@@ -383,7 +383,7 @@ func findCallsToContractedFunctions(
 			return true
 		}
 
-		ident := util.FuncIdentFromCallExpr(callExpr)
+		ident := asthelper.FuncIdentFromCallExpr(callExpr)
 		if ident == nil {
 			return true
 		}

--- a/assertion/function/assertiontree/backprop_util.go
+++ b/assertion/function/assertiontree/backprop_util.go
@@ -99,7 +99,7 @@ func exprCallsKnownNilableErrFunc(expr ast.Expr) bool {
 		return false
 	}
 
-	ident := util.FuncIdentFromCallExpr(callExpr)
+	ident := asthelper.FuncIdentFromCallExpr(callExpr)
 
 	if ident == nil {
 		// no ident - anonymous function
@@ -151,7 +151,7 @@ func computeAndConsumeResults(rootNode *RootAssertionNode, node *ast.ReturnStmt)
 				retKey := annotation.RetKeyFromRetNum(rootNode.ObjectOf(rootNode.FuncNameIdent()).(*types.Func), i)
 
 				// default handling if retVariable is not a blank identifier (e.g., i *int)
-				if !util.IsEmptyExpr(retVariable) {
+				if !asthelper.IsEmptyExpr(retVariable) {
 					addReturnConsumers(rootNode, node, retVariable, retKey, true /* isNamedReturn */)
 
 					if rootNode.functionContext.functionConfig.EnableStructInitCheck {
@@ -230,7 +230,7 @@ func isErrorReturnNil(rootNode *RootAssertionNode, errRet ast.Expr) bool {
 	}
 
 	// check for false cases where error return value may be nil
-	if util.IsEmptyExpr(errRet) {
+	if asthelper.IsEmptyExpr(errRet) {
 		// error result is a blank named return ("_ error"), so it's always nil
 		return true
 	}
@@ -366,7 +366,7 @@ func createConsumerForErrorReturn(rootNode *RootAssertionNode, errRetExpr ast.Ex
 func createGeneralReturnConsumers(rootNode *RootAssertionNode, results []ast.Expr, retStmt *ast.ReturnStmt, isNamedReturn bool) {
 	for i := range results {
 		// don't do anything if the expression is a blank identifier ("_")
-		if util.IsEmptyExpr(results[i]) {
+		if asthelper.IsEmptyExpr(results[i]) {
 			continue
 		}
 		rootNode.AddConsumption(&annotation.ConsumeTrigger{
@@ -386,7 +386,7 @@ func createGeneralReturnConsumers(rootNode *RootAssertionNode, results []ast.Exp
 func createReturnConsumersForAlwaysSafe(rootNode *RootAssertionNode, nonErrResults []ast.Expr, retStmt *ast.ReturnStmt, isNamedReturn bool) {
 	for i := range nonErrResults {
 		// don't do anything if the expression is a blank identifier ("_")
-		if util.IsEmptyExpr(nonErrResults[i]) {
+		if asthelper.IsEmptyExpr(nonErrResults[i]) {
 			continue
 		}
 
@@ -411,7 +411,7 @@ func createReturnConsumersForAlwaysSafe(rootNode *RootAssertionNode, nonErrResul
 func createSpecialConsumersForAllReturns(rootNode *RootAssertionNode, nonErrRetExpr []ast.Expr, errRetExpr ast.Expr, errRetIndex int, retStmt *ast.ReturnStmt, isNamedReturn bool) {
 	for i := range nonErrRetExpr {
 		// don't do anything if the expression is a blank identifier ("_")
-		if util.IsEmptyExpr(nonErrRetExpr[i]) {
+		if asthelper.IsEmptyExpr(nonErrRetExpr[i]) {
 			continue
 		}
 		consumer := &annotation.ConsumeTrigger{
@@ -473,7 +473,7 @@ func exprAsConsumedByAssignment(rootNode *RootAssertionNode, expr ast.Node) *ann
 // not `ast.Expr`, and various "deep" assignments such as to an index of an object
 // nilable(result 0)
 func exprAsAssignmentConsumer(rootNode *RootAssertionNode, expr ast.Node, exprRHS ast.Node) (annotation.ConsumingAnnotationTrigger, error) {
-	if expr, ok := expr.(ast.Expr); ok && util.IsEmptyExpr(expr) {
+	if expr, ok := expr.(ast.Expr); ok && asthelper.IsEmptyExpr(expr) {
 		return nil, nil
 	}
 
@@ -550,7 +550,7 @@ func exprAsAssignmentConsumer(rootNode *RootAssertionNode, expr ast.Node, exprRH
 				}
 			case *ast.CallExpr:
 				// check if this is a call to a function by name
-				if ident := util.FuncIdentFromCallExpr(expr); ident != nil {
+				if ident := asthelper.FuncIdentFromCallExpr(expr); ident != nil {
 					obj := rootNode.ObjectOf(ident).(*types.Func)
 					if obj.Type().(*types.Signature).Results().Len() != 1 {
 						return nil, errors.New("multiply returning function treated as assignment consumer")
@@ -633,7 +633,7 @@ func exprAsAssignmentConsumer(rootNode *RootAssertionNode, expr ast.Node, exprRH
 		}
 
 		if rootNode.functionContext.functionConfig.EnableStructInitCheck {
-			if head := util.GetSelectorExprHeadIdent(expr); head != nil {
+			if head := asthelper.GetSelectorExprHeadIdent(expr); head != nil {
 				if obj, ok := rootNode.ObjectOf(head).(*types.Var); ok {
 					if !annotation.VarIsGlobal(obj) {
 						// If field access for a variable that is not a global var we rely on default field nilability based on

--- a/assertion/function/assertiontree/parse_expr_producer.go
+++ b/assertion/function/assertiontree/parse_expr_producer.go
@@ -23,6 +23,7 @@ import (
 	"go.uber.org/nilaway/assertion/function/producer"
 	"go.uber.org/nilaway/hook"
 	"go.uber.org/nilaway/util"
+	"go.uber.org/nilaway/util/asthelper"
 	"go.uber.org/nilaway/util/typeshelper"
 )
 
@@ -59,7 +60,7 @@ func (r *RootAssertionNode) ParseExprAsProducer(expr ast.Expr, doNotTrack bool) 
 	shallowSeq TrackableExpr, producers []producer.ParsedProducer) {
 
 	parseIdent := func(expr *ast.Ident) (TrackableExpr, []producer.ParsedProducer) {
-		if util.IsEmptyExpr(expr) {
+		if asthelper.IsEmptyExpr(expr) {
 			r.Pass().Panic("the empty identifier is not an expression - don't pass it to ParseExprAsProducer", expr.Pos())
 		}
 		if r.isNil(expr) {
@@ -447,7 +448,7 @@ func (r *RootAssertionNode) ParseExprAsProducer(expr ast.Expr, doNotTrack bool) 
 					}
 					return false
 				case *ast.SelectorExpr:
-					return util.IsFieldSelectorChain(index)
+					return asthelper.IsFieldSelectorChain(index)
 				default:
 					return r.isStable(expr)
 				}
@@ -600,7 +601,7 @@ func (r *RootAssertionNode) parseStructCreateExprAsProducer(expr ast.Expr, field
 			}
 
 			// extract the value assigned to the field in the composite
-			fieldVal := util.GetFieldVal(fieldInitializations, field.Name, numFields, i)
+			fieldVal := asthelper.GetFieldVal(fieldInitializations, field.Name, numFields, i)
 
 			if fieldVal == nil {
 				// this means the field is not assigned any value, thus unassigned field should be produced

--- a/assertion/function/assertiontree/rich_check_effect.go
+++ b/assertion/function/assertiontree/rich_check_effect.go
@@ -227,7 +227,7 @@ func parseExpr(rootNode *RootAssertionNode, expr ast.Expr) TrackableExpr {
 		_ = recover()
 	}()
 	// this handles being passed the empty expression
-	if util.IsEmptyExpr(expr) {
+	if asthelper.IsEmptyExpr(expr) {
 		return nil
 	}
 	parsed, _ := rootNode.ParseExprAsProducer(expr, false)
@@ -337,7 +337,7 @@ func NodeTriggersOkRead(rootNode *RootAssertionNode, nonceGenerator *util.GuardN
 			}
 		}
 	case *ast.CallExpr:
-		callIdent := util.FuncIdentFromCallExpr(rhs)
+		callIdent := asthelper.FuncIdentFromCallExpr(rhs)
 		if callIdent == nil {
 			// this discards the case of an anonymous function
 			// perhaps in the future we could change this

--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -24,6 +24,7 @@ import (
 	"go.uber.org/nilaway/config"
 	"go.uber.org/nilaway/util"
 	"go.uber.org/nilaway/util/analysishelper"
+	"go.uber.org/nilaway/util/asthelper"
 )
 
 // RootAssertionNode is the object that will be directly handled by the propagation algorithm,
@@ -893,7 +894,7 @@ func (r *RootAssertionNode) AddComputation(expr ast.Expr) {
 // is an anonymous function, it will return the fake function declaration created in the
 // function analyzer
 func getFuncIdent(expr *ast.CallExpr, fc *FunctionContext) *ast.Ident {
-	ident := util.FuncIdentFromCallExpr(expr)
+	ident := asthelper.FuncIdentFromCallExpr(expr)
 
 	var funcLit *ast.FuncLit
 	// if ident is nil, check if the expr represents a FuncLit node
@@ -1146,7 +1147,7 @@ func (r *RootAssertionNode) isBuiltIn(ident *ast.Ident) bool {
 // builtInConversionFuncBasicType checks if it is a built-in conversion function call, such as `string(x)`.
 // If yes returns the basic type object, otherwise nil.
 func (r *RootAssertionNode) builtInConversionFuncBasicType(call *ast.CallExpr) (b *types.Basic) {
-	if ident := util.FuncIdentFromCallExpr(call); ident != nil {
+	if ident := asthelper.FuncIdentFromCallExpr(call); ident != nil {
 		if obj := r.ObjectOf(ident); obj != nil {
 			if tname, ok := obj.(*types.TypeName); ok {
 				b, _ = tname.Type().(*types.Basic)

--- a/assertion/function/assertiontree/structinit_util.go
+++ b/assertion/function/assertiontree/structinit_util.go
@@ -22,6 +22,7 @@ import (
 	"go.uber.org/nilaway/assertion/structfield"
 	"go.uber.org/nilaway/util"
 	"go.uber.org/nilaway/util/analysishelper"
+	"go.uber.org/nilaway/util/asthelper"
 )
 
 // addProductionsForAssignmentFields adds production for each produce trigger in fieldProducers.
@@ -67,7 +68,7 @@ func (r *RootAssertionNode) addConsumptionsForFieldsOfReturns(retExpr ast.Expr, 
 		numFields := resType.NumFields()
 
 		// For field selection chains we add the consumptions for fields by creating artificial selector expression
-		if util.IsFieldSelectorChain(retExpr) {
+		if asthelper.IsFieldSelectorChain(retExpr) {
 			for fieldID := 0; fieldID < numFields; fieldID++ {
 				fieldDecl := resType.Field(fieldID)
 
@@ -287,7 +288,7 @@ func (r *RootAssertionNode) addConsumptionsForArgFieldsAtIndex(arg ast.Expr, fun
 		numFields := paramType.NumFields()
 
 		// For field selection chains we add the consumptions for fields by creating artificial selector expression
-		if util.IsFieldSelectorChain(arg) {
+		if asthelper.IsFieldSelectorChain(arg) {
 			for fieldIdx := 0; fieldIdx < numFields; fieldIdx++ {
 				fieldDecl := paramType.Field(fieldIdx)
 
@@ -432,7 +433,7 @@ func (r *RootAssertionNode) addConsumptionsForFieldsOfParams() {
 	for i := 0; i < funcSig.Params().Len(); i++ {
 		param := funcSig.Params().At(i)
 
-		paramNode := util.GetFunctionParamNode(r.FuncDecl(), param)
+		paramNode := asthelper.GetFunctionParamNode(r.FuncDecl(), param)
 		if paramNode != nil {
 			r.addConsumptionsForFieldsOfParam(param, paramNode, i, result.Res)
 		}
@@ -450,7 +451,7 @@ func (r *RootAssertionNode) addConsumptionsForFieldsOfParams() {
 
 		// The length of receivers can only be 0 (unnamed receiver) or 1 (named receiver).
 		// We only need to handle the named case if it is not an empty (`_`) receiver.
-		if len(receivers) != 0 && !util.IsEmptyExpr(receivers[0]) {
+		if len(receivers) != 0 && !asthelper.IsEmptyExpr(receivers[0]) {
 			r.addConsumptionsForFieldsOfParam(funcSig.Recv(), receivers[0], annotation.ReceiverParamIndex, result.Res)
 		}
 	}

--- a/assertion/global/globalvarinit.go
+++ b/assertion/global/globalvarinit.go
@@ -21,6 +21,7 @@ import (
 	"go.uber.org/nilaway/annotation"
 	"go.uber.org/nilaway/util"
 	"go.uber.org/nilaway/util/analysishelper"
+	"go.uber.org/nilaway/util/asthelper"
 )
 
 // analyzeValueSpec returns full triggers corresponding to the declaration
@@ -68,7 +69,7 @@ func getGlobalConsumers(pass *analysishelper.EnhancedPass, valspec *ast.ValueSpe
 
 	for i, name := range valspec.Names {
 		// Types that are not nilable are eliminated here
-		if !util.TypeBarsNilness(pass.TypesInfo.TypeOf(name)) && !util.IsEmptyExpr(name) {
+		if !util.TypeBarsNilness(pass.TypesInfo.TypeOf(name)) && !asthelper.IsEmptyExpr(name) {
 			v := pass.TypesInfo.ObjectOf(name).(*types.Var)
 			consumers[i] = &annotation.ConsumeTrigger{
 				Annotation: &annotation.GlobalVarAssign{

--- a/hook/assume_return.go
+++ b/hook/assume_return.go
@@ -22,6 +22,7 @@ import (
 	"go.uber.org/nilaway/annotation"
 	"go.uber.org/nilaway/util"
 	"go.uber.org/nilaway/util/analysishelper"
+	"go.uber.org/nilaway/util/asthelper"
 	"go.uber.org/nilaway/util/typeshelper"
 )
 
@@ -62,7 +63,7 @@ var _newErrorFuncNameRegex = regexp.MustCompile(`(?i)new[^ ]*error[^ ]*`)
 // - the function must have at least one argument of error-implementing type, and
 // - the function must return an error-implementing type as its last return value.
 func isErrorWrapperFunc(pass *analysishelper.EnhancedPass, call *ast.CallExpr) bool {
-	funcIdent := util.FuncIdentFromCallExpr(call)
+	funcIdent := asthelper.FuncIdentFromCallExpr(call)
 	if funcIdent == nil {
 		return false
 	}

--- a/util/asthelper/asthelper.go
+++ b/util/asthelper/asthelper.go
@@ -19,6 +19,7 @@ import (
 	"go/ast"
 	"go/printer"
 	"go/token"
+	"go/types"
 	"io"
 	"strings"
 )
@@ -142,4 +143,102 @@ func IsLiteral(expr ast.Expr, literals ...string) bool {
 		}
 	}
 	return false
+}
+
+// CallExprFromExpr returns the call expression from the given expression. It recursively
+// traverses the expression tree to find the call expression. If the expression is not a
+// call expression, it returns nil.
+func CallExprFromExpr(expr ast.Expr) *ast.CallExpr {
+	switch e := expr.(type) {
+	case *ast.CallExpr:
+		return e
+	case *ast.ParenExpr:
+		return CallExprFromExpr(e.X)
+	case *ast.UnaryExpr:
+		return CallExprFromExpr(e.X)
+	case *ast.SelectorExpr:
+		return CallExprFromExpr(e.X)
+	}
+	return nil
+}
+
+// GetSelectorExprHeadIdent gets the head of the chained selector expression if it is an ident. Returns nil otherwise
+func GetSelectorExprHeadIdent(selExpr *ast.SelectorExpr) *ast.Ident {
+	if ident, ok := selExpr.X.(*ast.Ident); ok {
+		return ident
+	}
+	if x, ok := selExpr.X.(*ast.SelectorExpr); ok {
+		return GetSelectorExprHeadIdent(x)
+	}
+	return nil
+}
+
+// IsFieldSelectorChain returns true if the expr is chain of idents. e.g, x.y.z
+// It returns for false for expressions such as x.y().z
+func IsFieldSelectorChain(expr ast.Expr) bool {
+	switch expr := expr.(type) {
+	case *ast.Ident:
+		return true
+	case *ast.SelectorExpr:
+		return IsFieldSelectorChain(expr.X)
+	default:
+		return false
+	}
+}
+
+// IsEmptyExpr checks if an expression is the empty identifier
+func IsEmptyExpr(expr ast.Expr) bool {
+	if id, ok := expr.(*ast.Ident); ok {
+		if id.Name == "_" {
+			return true
+		}
+	}
+	return false
+}
+
+// GetFieldVal returns the assigned value for the field at index. compElts holds the  elements of the composite literal expression
+// for struct initialization
+func GetFieldVal(compElts []ast.Expr, fieldName string, numFields int, index int) ast.Expr {
+	for _, elt := range compElts {
+		if kv, ok := elt.(*ast.KeyValueExpr); ok {
+			if key, ok := kv.Key.(*ast.Ident); ok {
+				if key.Name == fieldName {
+					return kv.Value
+				}
+			}
+		}
+	}
+
+	// In this case the initialization is serial e.g. a = &A{p, q}
+	if numFields == len(compElts) {
+		return compElts[index]
+	}
+	return nil
+}
+
+// FuncIdentFromCallExpr return a function identified from a call expression, nil otherwise
+// nilable(result 0)
+func FuncIdentFromCallExpr(expr *ast.CallExpr) *ast.Ident {
+	switch fun := expr.Fun.(type) {
+	case *ast.Ident:
+		return fun
+	case *ast.SelectorExpr:
+		return fun.Sel
+	default:
+		// case of anonymous function
+		return nil
+	}
+}
+
+// GetFunctionParamNode returns the ast param node matching the variable searchParam
+func GetFunctionParamNode(funcDecl *ast.FuncDecl, searchParam *types.Var) ast.Expr {
+	for _, params := range funcDecl.Type.Params.List {
+		for _, param := range params.Names {
+			if searchParam.Name() == param.Name && param.Name != "" && param.Name != "_" {
+				return param
+			}
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
This PR moves all AST-related helper functions to asthelper package for better organization.

As part of the effort we are removing an unused function.