### PR TITLE
Move helper functions to analysishelper.EnhancedPass properly

### DIFF
--- a/annotation/full_trigger.go
+++ b/annotation/full_trigger.go
@@ -114,7 +114,7 @@ func (l LocatedPrestring) String() string {
 // expressions.
 func (t *FullTrigger) Prestrings(pass *analysishelper.EnhancedPass) (Prestring, Prestring) {
 	producerPrestring := t.Producer.Annotation.Prestring()
-	if util.ExprIsAuthentic(pass, t.Producer.Expr) {
+	if pass.ExprIsAuthentic(t.Producer.Expr) {
 		producerPrestring = LocatedPrestring{
 			Contained: producerPrestring,
 			Location:  t.truncatedProducerPos(pass),

--- a/annotation/map.go
+++ b/annotation/map.go
@@ -26,6 +26,7 @@ import (
 	"go.uber.org/nilaway/util"
 	"go.uber.org/nilaway/util/analysishelper"
 	"go.uber.org/nilaway/util/asthelper"
+	"go.uber.org/nilaway/util/typeshelper"
 )
 
 // Map is an abstraction that concrete annotation maps must implement to be checked against.
@@ -383,7 +384,7 @@ func TypeIsDeepDefaultNilable(t types.Type) bool {
 			return TypeIsDeepDefaultNilable(e)
 		}
 		// assign deep nilability based on the element type
-		return !util.TypeBarsNilness(t.Elem())
+		return !typeshelper.TypeBarsNilness(t.Elem())
 	case *types.Slice:
 		return TypeIsDefaultNilable(t.Elem())
 	case *types.Map:

--- a/assertion/affiliation/affiliation.go
+++ b/assertion/affiliation/affiliation.go
@@ -145,7 +145,7 @@ func (a *Affiliation) computeTriggersForCastingSites(pass *analysishelper.Enhanc
 					}
 
 					// slice is declared to be of interface type, and append function is used to add struct
-					if sliceType, ok := util.IsSliceAppendCall(node, pass); ok {
+					if sliceType, ok := pass.IsSliceAppendCall(node); ok {
 						for i := 1; i < len(node.Args); i++ {
 							lhsType := sliceType.Elem()
 							rhsType := pass.TypesInfo.TypeOf(node.Args[i])

--- a/assertion/function/assertiontree/backprop.go
+++ b/assertion/function/assertiontree/backprop.go
@@ -204,7 +204,7 @@ func backpropAcrossReturn(rootNode *RootAssertionNode, node *ast.ReturnStmt) err
 					}
 					// since we don't individually track the returns of a multiply returning function,
 					// we form full triggers for each return whose type doesn't bar nilness
-					if !util.TypeBarsNilness(funcObj.Type().(*types.Signature).Results().At(i).Type()) {
+					if !typeshelper.TypeBarsNilness(funcObj.Type().(*types.Signature).Results().At(i).Type()) {
 						isErrReturning := util.FuncIsErrReturning(funcObj.Signature())
 						isOkReturning := util.FuncIsOkReturning(funcObj.Signature())
 
@@ -323,7 +323,7 @@ func backpropAcrossAssignment(rootNode *RootAssertionNode, lhs, rhs []ast.Expr) 
 					// This is the case of creating a pointer and assigning it to a variable, e.g., `x := &y`,
 					// where y is a non-pointer type (e.g., y := S{}).
 					// Here, the pointer is always nonnil, so we can just add a ProduceTriggerNever.
-					if util.ExprBarsNilness(rootNode.Pass(), r.X) {
+					if rootNode.Pass().ExprBarsNilness(r.X) {
 						if len(lhs) == 1 && !asthelper.IsEmptyExpr(lhs[0]) {
 							rootNode.AddProduction(&annotation.ProduceTrigger{
 								Annotation: &annotation.ProduceTriggerNever{},
@@ -840,7 +840,7 @@ func backpropAcrossManyToOneAssignment(rootNode *RootAssertionNode, lhs, rhs []a
 			// lhsVal is a field read, so this is a field assignment
 			// since multiple return functions aren't trackable, this is a completed trigger
 			// as long as the type of the expression being assigned doesn't bar nilness
-			if !util.ExprBarsNilness(rootNode.Pass(), lhsVal) {
+			if !rootNode.Pass().ExprBarsNilness(lhsVal) {
 				rootNode.AddNewTriggers(annotation.FullTrigger{
 					Producer: &annotation.ProduceTrigger{
 						// We are assigning directly into the field, so we only care about shallow,

--- a/assertion/function/assertiontree/backprop_util.go
+++ b/assertion/function/assertiontree/backprop_util.go
@@ -159,7 +159,7 @@ func computeAndConsumeResults(rootNode *RootAssertionNode, node *ast.ReturnStmt)
 					}
 				} else {
 					// special handling if retVariable is a blank identifier (e.g., _ *int)
-					if !util.ExprBarsNilness(rootNode.Pass(), retVariable) {
+					if !rootNode.Pass().ExprBarsNilness(retVariable) {
 						producer := &annotation.ProduceTrigger{
 							Annotation: &annotation.BlankVarReturn{ProduceTriggerTautology: &annotation.ProduceTriggerTautology{}},
 							Expr:       retVariable,

--- a/assertion/function/assertiontree/parse_expr_producer.go
+++ b/assertion/function/assertiontree/parse_expr_producer.go
@@ -595,7 +595,7 @@ func (r *RootAssertionNode) parseStructCreateExprAsProducer(expr ast.Expr, field
 			fieldDecl := structType.Field(i)
 			field := r.GetDeclaringIdent(fieldDecl)
 
-			if util.TypeBarsNilness(fieldDecl.Type()) {
+			if typeshelper.TypeBarsNilness(fieldDecl.Type()) {
 				// we do not create producers for fields that are not nilable
 				continue
 			}

--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -256,7 +256,7 @@ func (r *RootAssertionNode) linkPath(path TrackableExpr) *RootAssertionNode {
 func (r *RootAssertionNode) AddConsumption(consumer *annotation.ConsumeTrigger) {
 
 	// we check if the type of the expression `expr` prevents it from ever being nil in the first place
-	if util.ExprBarsNilness(r.Pass(), consumer.Expr) {
+	if r.Pass().ExprBarsNilness(consumer.Expr) {
 		return // expr cannot be nil, so do nothing
 	}
 

--- a/assertion/function/assertiontree/structinit_util.go
+++ b/assertion/function/assertiontree/structinit_util.go
@@ -23,6 +23,7 @@ import (
 	"go.uber.org/nilaway/util"
 	"go.uber.org/nilaway/util/analysishelper"
 	"go.uber.org/nilaway/util/asthelper"
+	"go.uber.org/nilaway/util/typeshelper"
 )
 
 // addProductionsForAssignmentFields adds production for each produce trigger in fieldProducers.
@@ -72,7 +73,7 @@ func (r *RootAssertionNode) addConsumptionsForFieldsOfReturns(retExpr ast.Expr, 
 			for fieldID := 0; fieldID < numFields; fieldID++ {
 				fieldDecl := resType.Field(fieldID)
 
-				if util.TypeBarsNilness(fieldDecl.Type()) {
+				if typeshelper.TypeBarsNilness(fieldDecl.Type()) {
 					// We do not create field triggers for types that are not nilable
 					continue
 				}
@@ -135,7 +136,7 @@ func (r *RootAssertionNode) getFieldProducersForFuncReturns(calledFuncDecl *type
 		for fieldID := 0; fieldID < numFields; fieldID++ {
 			fieldDecl := resType.Field(fieldID)
 
-			if util.TypeBarsNilness(fieldDecl.Type()) {
+			if typeshelper.TypeBarsNilness(fieldDecl.Type()) {
 				// We do not create field triggers for types that are not nilable
 				return nil
 			}
@@ -168,7 +169,7 @@ func (r *RootAssertionNode) addProductionsForParamFields(node AssertionNode, bui
 
 	for _, node := range nodes {
 		if fldNode, ok := node.(*fldAssertionNode); ok {
-			if util.TypeBarsNilness(fldNode.decl.Type()) {
+			if typeshelper.TypeBarsNilness(fldNode.decl.Type()) {
 				// We do not add production for types that are not nilable
 				continue
 			}
@@ -183,7 +184,7 @@ func (r *RootAssertionNode) addProductionsForParamFields(node AssertionNode, bui
 func (r *RootAssertionNode) addProductionForVarFieldNode(varNode *varAssertionNode, varAstExpr ast.Expr) {
 	for _, child := range varNode.Children() {
 		if fldNode, ok := child.(*fldAssertionNode); ok {
-			if util.TypeBarsNilness(fldNode.decl.Type()) {
+			if typeshelper.TypeBarsNilness(fldNode.decl.Type()) {
 				continue
 			}
 			selExpr := r.getSelectorExpr(fldNode.decl, varAstExpr)
@@ -292,7 +293,7 @@ func (r *RootAssertionNode) addConsumptionsForArgFieldsAtIndex(arg ast.Expr, fun
 			for fieldIdx := 0; fieldIdx < numFields; fieldIdx++ {
 				fieldDecl := paramType.Field(fieldIdx)
 
-				if util.TypeBarsNilness(fieldDecl.Type()) {
+				if typeshelper.TypeBarsNilness(fieldDecl.Type()) {
 					continue
 				}
 
@@ -488,7 +489,7 @@ func (r *RootAssertionNode) addConsumptionsForFieldsOfParam(param *types.Var, pa
 func (r *RootAssertionNode) getParamFieldKey(arg ast.Expr, methodType *types.Func, argIdx int, structType *types.Struct, fieldID int) (annotation.Key, *ast.SelectorExpr) {
 	fieldDecl := structType.Field(fieldID)
 
-	if util.TypeBarsNilness(fieldDecl.Type()) {
+	if typeshelper.TypeBarsNilness(fieldDecl.Type()) {
 		return nil, nil
 	}
 	selExpr := r.getSelectorExpr(fieldDecl, arg)

--- a/assertion/function/functioncontracts/analyzer.go
+++ b/assertion/function/functioncontracts/analyzer.go
@@ -27,8 +27,8 @@ import (
 	"sync"
 
 	"go.uber.org/nilaway/config"
-	"go.uber.org/nilaway/util"
 	"go.uber.org/nilaway/util/analysishelper"
+	"go.uber.org/nilaway/util/typeshelper"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/buildssa"
 	"golang.org/x/tools/go/ssa"
@@ -170,8 +170,8 @@ func collectFunctionContracts(pass *analysishelper.EnhancedPass) (Map, error) {
 			// function. We need to infer contracts for this function.
 			if funcDecl.Type.Params.NumFields() != 1 ||
 				funcDecl.Type.Results.NumFields() != 1 ||
-				util.TypeBarsNilness(funcObj.Type().(*types.Signature).Params().At(0).Type()) ||
-				util.TypeBarsNilness(funcObj.Type().(*types.Signature).Results().At(0).Type()) ||
+				typeshelper.TypeBarsNilness(funcObj.Type().(*types.Signature).Params().At(0).Type()) ||
+				typeshelper.TypeBarsNilness(funcObj.Type().(*types.Signature).Results().At(0).Type()) ||
 				funcObj.Type().(*types.Signature).Variadic() {
 				// We definitely want to ignore any function without any parameters or return
 				// values since they cannot have any contracts.

--- a/assertion/function/functioncontracts/infer.go
+++ b/assertion/function/functioncontracts/infer.go
@@ -18,7 +18,7 @@ import (
 	"go/token"
 	"go/types"
 
-	"go.uber.org/nilaway/util"
+	"go.uber.org/nilaway/util/typeshelper"
 	"golang.org/x/tools/go/ssa"
 )
 
@@ -316,7 +316,7 @@ func branch(b *ssa.BasicBlock) (*ssa.BasicBlock, *ssa.BasicBlock, *ssa.BinOp) {
 	}
 	binOp, ok := ifInstr.Cond.(*ssa.BinOp)
 	// Check only one operand is sufficient since the two operands must have the same type.
-	if !ok || util.TypeBarsNilness(binOp.X.Type()) {
+	if !ok || typeshelper.TypeBarsNilness(binOp.X.Type()) {
 		// not a binary comparison or the type cannot have nil as a value.
 		return nil, nil, nil
 	}

--- a/assertion/global/globalvarinit.go
+++ b/assertion/global/globalvarinit.go
@@ -22,6 +22,7 @@ import (
 	"go.uber.org/nilaway/util"
 	"go.uber.org/nilaway/util/analysishelper"
 	"go.uber.org/nilaway/util/asthelper"
+	"go.uber.org/nilaway/util/typeshelper"
 )
 
 // analyzeValueSpec returns full triggers corresponding to the declaration
@@ -69,7 +70,7 @@ func getGlobalConsumers(pass *analysishelper.EnhancedPass, valspec *ast.ValueSpe
 
 	for i, name := range valspec.Names {
 		// Types that are not nilable are eliminated here
-		if !util.TypeBarsNilness(pass.TypesInfo.TypeOf(name)) && !asthelper.IsEmptyExpr(name) {
+		if !asthelper.IsEmptyExpr(name) && !typeshelper.TypeBarsNilness(pass.TypesInfo.TypeOf(name)) {
 			v := pass.TypesInfo.ObjectOf(name).(*types.Var)
 			consumers[i] = &annotation.ConsumeTrigger{
 				Annotation: &annotation.GlobalVarAssign{

--- a/util/typeshelper/typeshelper.go
+++ b/util/typeshelper/typeshelper.go
@@ -71,3 +71,32 @@ func GetFuncSignature(t types.Type) *types.Signature {
 	}
 	return sig
 }
+
+// TypeBarsNilness returns false iff the type `t` is inhabited by nil.
+func TypeBarsNilness(t types.Type) bool {
+	switch t := t.(type) {
+	case *types.Array:
+		return true
+	case *types.Slice:
+		return false
+	case *types.Pointer:
+		return false
+	case *types.Tuple:
+		return false
+	case *types.Signature:
+		return true // function-types are not inhabited by nil
+	case *types.Map:
+		return false
+	case *types.Chan:
+		return false
+	case *types.Alias, *types.Named:
+		return TypeBarsNilness(t.Underlying())
+	case *types.Interface:
+		return false
+	case *types.Basic:
+		// all basic types except UntypedNil are not inhabited by nil
+		return t.Kind() != types.UntypedNil
+	default:
+		return true
+	}
+}


### PR DESCRIPTION
This PR moves the helper functions that should've been methods of `analysishelper.EnhancedPass` to its package properly. All call sites have been updated too.
