### PR TITLE
Cleanup dead code in enabling experimental features when linting NilAway itself

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,8 @@ tidy-lint:
 
 .PHONY: nilaway-lint
 nilaway-lint: build
+	# Enable -experimental-struct-init for linting nilaway (tracked in #23).
 	@$(foreach mod,$(MODULE_DIRS), \
 		(cd $(mod) && \
 		echo "[lint] nilaway linting itself: $(mod)" && \
-		$(GOBIN)/nilaway -include-pkgs="go.uber.org/nilaway" ./...) &&) true
+		$(GOBIN)/nilaway -include-pkgs="go.uber.org/nilaway" -experimental-anonymous-function ./...) &&) true

--- a/assertion/function/analyzer.go
+++ b/assertion/function/analyzer.go
@@ -90,7 +90,10 @@ func run(p *analysis.Pass) ([]annotation.FullTrigger, error) {
 	}
 
 	// Construct experimental features. By default, enable all features on NilAway itself.
-	functionConfig := assertiontree.FunctionConfig{}
+	functionConfig := assertiontree.FunctionConfig{
+		EnableStructInitCheck: conf.ExperimentalStructInitEnable,
+		EnableAnonymousFunc:   conf.ExperimentalAnonymousFuncEnable,
+	}
 	if strings.HasPrefix(pass.Pkg.Path(), config.NilAwayPkgPathPrefix) { //nolint:revive
 		// TODO: enable struct initialization flag (tracked in Issue #23).
 		// TODO: enable anonymous function flag.


### PR DESCRIPTION
Now that we have exposed these experimental feature flags as proper flags, we can simply pass the flags when running NilAway linting task on itself, rather than hardcoding it directly in NilAway.