### PR TITLE
Handle explicit type conversions as potential nil producers (#166)

### DIFF
--- a/testdata/src/go.uber.org/trustedfunc/type_conversion.go
+++ b/testdata/src/go.uber.org/trustedfunc/type_conversion.go
@@ -1,0 +1,56 @@
+//  Copyright (c) 2024 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trustedfunc
+
+type Struct struct {
+	Field int
+}
+
+type StructPtr *Struct
+
+func typeConversionBasic() {
+	var explicit *Struct
+	explicit = (*Struct)(nil)
+	_ = explicit.Field // want "deref"
+
+	explicitShort := (*Struct)(nil)
+	_ = explicitShort.Field // want "deref"
+
+	explicitWithoutParens := StructPtr(nil)
+	_ = explicitWithoutParens.Field // want "deref"
+
+	var implicit *Struct
+	implicit = nil
+	_ = implicit.Field // want "deref"
+}
+
+func typeConversionWithNonNil() {
+	var s *Struct = &Struct{Field: 42}
+	explicit := (*Struct)(s)
+	_ = explicit.Field
+
+	var implicit *Struct
+	implicit = s
+	_ = implicit.Field
+}
+
+func typeConversionToNonNilable() {
+	var i int = 42
+	converted := int(i)
+	_ = converted // Should not report nil dereference
+
+	f := float64(i)
+	_ = f // Should not report nil dereference
+}


### PR DESCRIPTION
Fixes #166

## Problem

NilAway did not handle explicit type conversions (like (*Struct)(nil) or StructPtr(nil)), resulting in false negatives. These type conversions can produce nil values and should be treated as potential nil producers.

Example:
```go
var explicit *Struct
explicit = (*Struct)(nil)
_ = explicit.Field // PANICS but NilAway missed this

explicitWithoutParens := StructPtr(nil)
_ = explicitWithoutParens.Field // PANICS but NilAway missed this
```

## Solution

Added a check in ParseExprAsProducer to detect when a *ast.CallExpr represents an explicit type conversion (using TypesInfo.Types[expr.Fun].IsType()). When detected:

1. If the target type bars nilness (e.g., int, functions), treat the result as non-nil
2. Otherwise, pass-through the nilability of the converted expression since the conversion can be nil if and only if the argument is nil and the type allows nil

## Testing

[x] All linting checks pass
[x] Full test suite passes
[x] New test cases added for:
   - Explicit type conversions with parens ((*Struct)(nil))
   - Named type conversions without parens (StructPtr(nil))
   - Conversions with non-nil values (no false positive)
   - Conversions to non-nilable types (no false positive)