### PR TITLE
Add test exclusion flag

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -38,6 +38,8 @@ type Config struct {
 	ExperimentalAnonymousFuncEnable bool
 	// PrintFullFilePath incidates whether to print full filenames in the output.
 	PrintFullFilePath bool
+	// ExcludeTestFiles indicates whether to exclude diagnostics that involve test files.
+	ExcludeTestFiles bool
 
 	// includePkgs is the list of packages to analyze.
 	includePkgs []string
@@ -136,6 +138,8 @@ const (
 	ExperimentalAnonymousFunctionFlag = "experimental-anonymous-function"
 	// PrintFullFilePathFlag is the flag name for printing full filenames in output.
 	PrintFullFilePathFlag = "print-full-file-path"
+	// ExcludeTestFilesFlag is the flag name for excluding diagnostics involving test files.
+	ExcludeTestFilesFlag = "exclude-test-files"
 )
 
 // newFlagSet returns a flag set to be used in the nilaway config analyzer.
@@ -152,6 +156,7 @@ func newFlagSet() flag.FlagSet {
 	_ = fs.Bool(ExperimentalStructInitEnableFlag, false, "Whether to enable experimental struct initialization support")
 	_ = fs.Bool(ExperimentalAnonymousFunctionFlag, false, "Whether to enable experimental anonymous function support")
 	_ = fs.Bool(PrintFullFilePathFlag, false, "Whether to show full filenames in output")
+	_ = fs.Bool(ExcludeTestFilesFlag, false, "Whether to exclude diagnostics involving test files")
 
 	return *fs
 }
@@ -181,6 +186,9 @@ func run(pass *analysis.Pass) (any, error) {
 	}
 	if printFullFilePath, ok := pass.Analyzer.Flags.Lookup(PrintFullFilePathFlag).Value.(flag.Getter).Get().(bool); ok {
 		conf.PrintFullFilePath = printFullFilePath
+	}
+	if excludeTestFiles, ok := pass.Analyzer.Flags.Lookup(ExcludeTestFilesFlag).Value.(flag.Getter).Get().(bool); ok {
+		conf.ExcludeTestFiles = excludeTestFiles
 	}
 	if include, ok := pass.Analyzer.Flags.Lookup(IncludePkgsFlag).Value.(flag.Getter).Get().(string); ok && include != "" {
 		conf.includePkgs = strings.Split(include, ",")

--- a/config/config.go
+++ b/config/config.go
@@ -156,7 +156,7 @@ func newFlagSet() flag.FlagSet {
 	_ = fs.Bool(ExperimentalStructInitEnableFlag, false, "Whether to enable experimental struct initialization support")
 	_ = fs.Bool(ExperimentalAnonymousFunctionFlag, false, "Whether to enable experimental anonymous function support")
 	_ = fs.Bool(PrintFullFilePathFlag, false, "Whether to show full filenames in output")
-	_ = fs.Bool(ExcludeTestFilesFlag, true, "Whether to exclude diagnostics involving test files")
+	_ = fs.Bool(ExcludeTestFilesFlag, false, "Whether to exclude diagnostics involving test files")
 
 	return *fs
 }

--- a/config/config.go
+++ b/config/config.go
@@ -156,7 +156,7 @@ func newFlagSet() flag.FlagSet {
 	_ = fs.Bool(ExperimentalStructInitEnableFlag, false, "Whether to enable experimental struct initialization support")
 	_ = fs.Bool(ExperimentalAnonymousFunctionFlag, false, "Whether to enable experimental anonymous function support")
 	_ = fs.Bool(PrintFullFilePathFlag, false, "Whether to show full filenames in output")
-	_ = fs.Bool(ExcludeTestFilesFlag, false, "Whether to exclude diagnostics involving test files")
+	_ = fs.Bool(ExcludeTestFilesFlag, true, "Whether to exclude diagnostics involving test files")
 
 	return *fs
 }

--- a/diagnostic/engine.go
+++ b/diagnostic/engine.go
@@ -255,8 +255,5 @@ func (e *Engine) toPos(position token.Position) token.Pos {
 // involvesTestFile returns true if the conflict's report position or any node position in the
 // nil flow originates from a test file (i.e., a file ending with "_test.go").
 func involvesTestFile(c conflict) bool {
-	if strings.HasSuffix(c.position.Filename, "_test.go") {
-		return true
-	}
-	return c.flow.involvesTestFile()
+	return strings.HasSuffix(c.position.Filename, "_test.go") || c.flow.involvesTestFile()
 }

--- a/diagnostic/engine.go
+++ b/diagnostic/engine.go
@@ -22,8 +22,10 @@ import (
 	"fmt"
 	"go/token"
 	"slices"
+	"strings"
 
 	"go.uber.org/nilaway/annotation"
+	"go.uber.org/nilaway/config"
 	"go.uber.org/nilaway/inference"
 	"go.uber.org/nilaway/util/analysishelper"
 	"go.uber.org/nilaway/util/tokenhelper"
@@ -109,11 +111,16 @@ func (e *Engine) Diagnostics(grouping bool) []analysis.Diagnostic {
 	}
 	nolintRanges := nolintResult.Res
 
+	conf := e.pass.ResultOf[config.Analyzer].(*config.Config)
+
 	diagnostics := make([]analysis.Diagnostic, 0, len(conflicts))
 	for _, c := range conflicts {
 		if slices.ContainsFunc(nolintRanges, func(r Range) bool {
 			return c.position.Filename == r.Filename && c.position.Line >= r.From && c.position.Line <= r.To
 		}) {
+			continue
+		}
+		if conf.ExcludeTestFiles && involvesTestFile(c) {
 			continue
 		}
 		diagnostics = append(diagnostics, analysis.Diagnostic{
@@ -243,4 +250,13 @@ func (e *Engine) toPos(position token.Position) token.Pos {
 
 	// For non-fake files, the position is accurate.
 	return info.file.Pos(position.Offset)
+}
+
+// involvesTestFile returns true if the conflict's report position or any node position in the
+// nil flow originates from a test file (i.e., a file ending with "_test.go").
+func involvesTestFile(c conflict) bool {
+	if strings.HasSuffix(c.position.Filename, "_test.go") {
+		return true
+	}
+	return c.flow.involvesTestFile()
 }

--- a/diagnostic/nilflow.go
+++ b/diagnostic/nilflow.go
@@ -57,6 +57,20 @@ func (n *nilFlow) String() string {
 	return "\n" + strings.Join(flow, "\n")
 }
 
+// involvesTestFile returns true if any node position in the nil or non-nil path originates from
+// a test file (i.e., a file ending with "_test.go").
+func (n *nilFlow) involvesTestFile() bool {
+	for _, nodes := range [2][]node{n.nilPath, n.nonnilPath} {
+		for _, nd := range nodes {
+			if strings.HasSuffix(nd.producerPosition.Filename, "_test.go") ||
+				strings.HasSuffix(nd.consumerPosition.Filename, "_test.go") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 type node struct {
 	producerPosition token.Position
 	consumerPosition token.Position

--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -63,6 +63,12 @@ A boolean flag enabling experimental support for anonymous functions in NilAway.
 
 Added in v0.1.0
 
+#### `exclude-test-files`
+
+> Default `false`
+
+A boolean flag that, when enabled, excludes diagnostics that involve test files (`*_test.go`). A diagnostic is excluded if its report position or any position in its nil flow (both nil path and non-nil path) is in a test file. This is useful when users want to focus on production code and skip nil flow errors in test code.
+
 #### `print-full-file-path`
 
 > Default `false`

--- a/nilaway_test.go
+++ b/nilaway_test.go
@@ -155,6 +155,37 @@ func TestGroupErrorMessages(t *testing.T) { //nolint:paralleltest
 	}()
 }
 
+func TestExcludeTestFiles(t *testing.T) { //nolint:paralleltest
+	// We specifically do not set this test to be parallel such that this test is run separately
+	// from the parallel tests. This makes it possible to test the exclude-test-files flag independently
+	// without affecting the other tests.
+	testdata := analysistest.TestData()
+
+	// Restrict analysis to the test package only, since the _test.go file pulls in the testing
+	// infrastructure and its transitive dependencies, which would otherwise produce unrelated
+	// diagnostics from stdlib.
+	err := config.Analyzer.Flags.Set(config.IncludePkgsFlag, "go.uber.org/excludetestfiles")
+	require.NoError(t, err)
+
+	// First, verify that diagnostics ARE produced for test files when flag is disabled.
+	err = config.Analyzer.Flags.Set(config.ExcludeTestFilesFlag, "false")
+	require.NoError(t, err)
+	analysistest.Run(t, testdata, Analyzer, "go.uber.org/excludetestfilesbaseline")
+
+	// Then verify diagnostics are filtered when flag is enabled.
+	err = config.Analyzer.Flags.Set(config.ExcludeTestFilesFlag, "true")
+	require.NoError(t, err)
+	analysistest.Run(t, testdata, Analyzer, "go.uber.org/excludetestfiles")
+
+	// Reset flags to their default values.
+	defer func() {
+		err := config.Analyzer.Flags.Set(config.ExcludeTestFilesFlag, "false")
+		require.NoError(t, err)
+		err = config.Analyzer.Flags.Set(config.IncludePkgsFlag, "")
+		require.NoError(t, err)
+	}()
+}
+
 func TestPrintFullFilePath(t *testing.T) { //nolint:paralleltest
 	// We specifically do not set this test to be parallel such that this test is run separately
 	// from the parallel tests. This makes it possible to set the print-full-file-path flag to true for

--- a/testdata/src/go.uber.org/excludetestfiles/excludetestfiles.go
+++ b/testdata/src/go.uber.org/excludetestfiles/excludetestfiles.go
@@ -1,0 +1,14 @@
+// Package excludetestfiles is meant to check if the exclude-test-files flag has effect.
+package excludetestfiles
+
+// Deref dereferences the given pointer. When called with nil from a test file,
+// the resulting diagnostic should be excluded since the nil flow involves a test file.
+func Deref(p *int) {
+	print(*p)
+}
+
+func main() {
+	var a *int
+	// Error in non-test file should still be reported even when exclude-test-files is enabled.
+	print(*a) // want "unassigned variable `a`"
+}

--- a/testdata/src/go.uber.org/excludetestfiles/excludetestfiles_test.go
+++ b/testdata/src/go.uber.org/excludetestfiles/excludetestfiles_test.go
@@ -1,0 +1,13 @@
+package excludetestfiles
+
+func testHelper() {
+	var b *int
+	// This nil dereference should NOT be reported when exclude-test-files is enabled,
+	// since the report position is in a test file.
+	print(*b)
+
+	// Calling Deref with nil: the dereference happens in the non-test file, but
+	// the nil originates from this test file, so the diagnostic should be excluded
+	// because the nil flow involves a test file.
+	Deref(nil)
+}

--- a/testdata/src/go.uber.org/excludetestfilesbaseline/excludetestfilesbaseline.go
+++ b/testdata/src/go.uber.org/excludetestfilesbaseline/excludetestfilesbaseline.go
@@ -1,0 +1,8 @@
+// Package excludetestfilesbaseline is the baseline for the exclude-test-files test.
+// It verifies that diagnostics ARE produced for test file flows when the flag is disabled.
+package excludetestfilesbaseline
+
+func main() {
+	var a *int
+	print(*a) // want "dereferenced"
+}

--- a/testdata/src/go.uber.org/excludetestfilesbaseline/excludetestfilesbaseline_test.go
+++ b/testdata/src/go.uber.org/excludetestfilesbaseline/excludetestfilesbaseline_test.go
@@ -1,0 +1,6 @@
+package excludetestfilesbaseline
+
+func testHelper() {
+	var b *int
+	print(*b) // want "unassigned variable `b` dereferenced"
+}


### PR DESCRIPTION
This PR adds a top-level flag for excluding reporting of nil flows that involve test files.