### PR TITLE
Add `github.com/cockroachdb/errors` to hooks as alternative `errors` package

### DIFF
--- a/hook/assume_return.go
+++ b/hook/assume_return.go
@@ -161,12 +161,7 @@ var _assumeReturns = map[trustedFuncSig]assumeReturnAction{
 	{
 		kind:           _func,
 		enclosingRegex: regexp.MustCompile(`^(stubs/)?github\.com/cockroachdb/errors$`),
-		funcNameRegex:  regexp.MustCompile(`^New$`),
-	}: nonnilProducer,
-	{
-		kind:           _func,
-		enclosingRegex: regexp.MustCompile(`^(stubs/)?github\.com/cockroachdb/errors$`),
-		funcNameRegex:  regexp.MustCompile(`^Newf$`),
+		funcNameRegex:  regexp.MustCompile(`^New(f)?$`),
 	}: nonnilProducer,
 
 	// `errors.Join`

--- a/hook/assume_return.go
+++ b/hook/assume_return.go
@@ -157,6 +157,18 @@ var _assumeReturns = map[trustedFuncSig]assumeReturnAction{
 		funcNameRegex:  regexp.MustCompile(`^New$`),
 	}: nonnilProducer,
 
+	// `github.com/cockroachdb/errors`
+	{
+		kind:           _func,
+		enclosingRegex: regexp.MustCompile(`^(stubs/)?github\.com/cockroachdb/errors$`),
+		funcNameRegex:  regexp.MustCompile(`^New$`),
+	}: nonnilProducer,
+	{
+		kind:           _func,
+		enclosingRegex: regexp.MustCompile(`^(stubs/)?github\.com/cockroachdb/errors$`),
+		funcNameRegex:  regexp.MustCompile(`^Newf$`),
+	}: nonnilProducer,
+
 	// `errors.Join`
 	// Note that `errors.Join` can return nil if all arguments are nil [1]. However, in practice this should rarely
 	// happen such that we assume it returns a non-nil error for simplicity. Here we are making a conscious trade-off
@@ -166,6 +178,13 @@ var _assumeReturns = map[trustedFuncSig]assumeReturnAction{
 	{
 		kind:           _func,
 		enclosingRegex: regexp.MustCompile(`^errors$`),
+		funcNameRegex:  regexp.MustCompile(`^Join$`),
+	}: nonnilProducer,
+
+	// `github.com/cockroachdb/errors.Join`
+	{
+		kind:           _func,
+		enclosingRegex: regexp.MustCompile(`^(stubs/)?github\.com/cockroachdb/errors$`),
 		funcNameRegex:  regexp.MustCompile(`^Join$`),
 	}: nonnilProducer,
 

--- a/hook/replace_conditional.go
+++ b/hook/replace_conditional.go
@@ -75,4 +75,9 @@ var _replaceConditionals = map[trustedFuncSig]replaceConditionalAction{
 		enclosingRegex: regexp.MustCompile(`^errors$`),
 		funcNameRegex:  regexp.MustCompile(`^As$`),
 	}: _errorAsAction,
+	{
+		kind:           _func,
+		enclosingRegex: regexp.MustCompile(`^(stubs/)?github\.com/cockroachdb/errors$`),
+		funcNameRegex:  regexp.MustCompile(`^As$`),
+	}: _errorAsAction,
 }

--- a/testdata/src/go.uber.org/trustedfunc/inference/cockroach_errors.go
+++ b/testdata/src/go.uber.org/trustedfunc/inference/cockroach_errors.go
@@ -9,6 +9,13 @@ func cockroachdbErrorsNewIsNonNil() {
 	print(err.Error())
 }
 
+// cockroachdbErrorsNewfIsNonNil checks that `cockroachdb/errors.Newf` is
+// modeled as returning a non-nil error.
+func cockroachdbErrorsNewfIsNonNil() {
+	err := cockroachdbErrors.Newf("some error %s", "some arg")
+	print(err.Error())
+}
+
 // cockroachdbErrorsJoinIsNonNil checks that `cockroachdb/errors.Join` is
 // modeled as returning a non-nil error.
 // `Join` can return nil if all arguments are nil, but we model it as non-nil

--- a/testdata/src/go.uber.org/trustedfunc/inference/cockroach_errors.go
+++ b/testdata/src/go.uber.org/trustedfunc/inference/cockroach_errors.go
@@ -1,0 +1,19 @@
+package inference
+
+import cockroachdbErrors "stubs/github.com/cockroachdb/errors"
+
+// cockroachdbErrorsNewIsNonNil checks that `cockroachdb/errors.New` is
+// modeled as returning a non-nil error.
+func cockroachdbErrorsNewIsNonNil() {
+	err := cockroachdbErrors.New("some error")
+	print(err.Error())
+}
+
+// cockroachdbErrorsJoinIsNonNil checks that `cockroachdb/errors.Join` is
+// modeled as returning a non-nil error.
+// `Join` can return nil if all arguments are nil, but we model it as non-nil
+// for simplicity. This is a conscious trade-off.
+func cockroachdbErrorsJoinIsNonNil() {
+	err := cockroachdbErrors.Join()
+	print(err.Error())
+}

--- a/testdata/src/go.uber.org/trustedfunc/trustedfuncs.go
+++ b/testdata/src/go.uber.org/trustedfunc/trustedfuncs.go
@@ -24,6 +24,7 @@ import (
 	"os/exec"
 	"testing"
 
+	cockroachdbErrors "stubs/github.com/cockroachdb/errors"
 	"stubs/github.com/stretchr/testify/assert"
 	"stubs/github.com/stretchr/testify/require"
 	"stubs/github.com/stretchr/testify/suite"
@@ -1026,6 +1027,82 @@ func errorsAs(err error, num string, dummy bool) {
 		var exitErr *exec.ExitError
 		var nilError error
 		if ok := errors.As(nilError, &exitErr); dummy && ok {
+			// The following is an FP: since the `dummy && ok` is canonicalized to `if dummy { if ok { } }`,
+			// our current handling fails to find the `ok := errors.As(...)` call at the end of the block.
+			print(*exitErr) //want "unassigned variable `exitErr` dereferenced"
+			print(ok)
+		}
+	}
+}
+
+// nilable(err)
+func cockroachdbErrorsAs(err error, num string, dummy bool) {
+	switch num {
+	case "simple":
+		var exitErr *exec.ExitError
+		if cockroachdbErrors.As(err, &exitErr) {
+			print(*exitErr)
+		}
+		print(*exitErr) //want "unassigned variable `exitErr` dereferenced"
+	case "not in if block":
+		var exitErr *exec.ExitError
+		// Not checking the result of `cockroachdbErrors.As` would not guard the variable.
+		cockroachdbErrors.As(err, &exitErr)
+		print(*exitErr) //want "unassigned variable `exitErr` dereferenced"
+	case "two errors connected by AND":
+		var exitErr, anotherErr *exec.ExitError
+		if cockroachdbErrors.As(err, &exitErr) && cockroachdbErrors.As(err, &anotherErr) {
+			print(*exitErr)
+			print(*anotherErr)
+		}
+	case "errors.As with other conditionals connected by AND":
+		var exitErr *exec.ExitError
+		if cockroachdbErrors.As(err, &exitErr) && dummy {
+			print(*exitErr)
+		}
+	case "errors.As with other conditionals connected by OR":
+		var exitErr *exec.ExitError
+		if cockroachdbErrors.As(err, &exitErr) || dummy {
+			print(*exitErr) //want "unassigned variable `exitErr` dereferenced"
+		}
+	case "two errors connected by OR":
+		var exitErr, anotherErr *exec.ExitError
+		if cockroachdbErrors.As(err, &exitErr) || cockroachdbErrors.As(err, &anotherErr) {
+			// We do not know the nilability of either.
+			print(*exitErr)    //want "unassigned variable `exitErr` dereferenced"
+			print(*anotherErr) //want "unassigned variable `anotherErr` dereferenced"
+		}
+	case "nil dereference in first argument":
+		var exitErr *exec.ExitError
+		var nilError *error
+		if cockroachdbErrors.As(*nilError, &exitErr) { //want "unassigned variable `nilError` dereferenced"
+			print(*exitErr) // But this is fine!
+		}
+	case "short assignment in if statement":
+		var exitErr *exec.ExitError
+		var nilError error
+		if ok := cockroachdbErrors.As(nilError, &exitErr); ok {
+			print(*exitErr)
+			print(ok)
+		}
+	case "short assignment in if statement with OR condition":
+		var exitErr *exec.ExitError
+		var nilError error
+		if ok := cockroachdbErrors.As(nilError, &exitErr); ok || dummy {
+			print(*exitErr) //want "unassigned variable `exitErr` dereferenced"
+			print(ok)
+		}
+	case "short assignment in if statement with AND condition (ok && dummy)":
+		var exitErr *exec.ExitError
+		var nilError error
+		if ok := cockroachdbErrors.As(nilError, &exitErr); ok && dummy {
+			print(*exitErr)
+			print(ok)
+		}
+	case "short assignment in if statement with AND condition (dummy && ok)":
+		var exitErr *exec.ExitError
+		var nilError error
+		if ok := cockroachdbErrors.As(nilError, &exitErr); dummy && ok {
 			// The following is an FP: since the `dummy && ok` is canonicalized to `if dummy { if ok { } }`,
 			// our current handling fails to find the `ok := errors.As(...)` call at the end of the block.
 			print(*exitErr) //want "unassigned variable `exitErr` dereferenced"

--- a/testdata/src/stubs/github.com/cockroachdb/errors/errors.go
+++ b/testdata/src/stubs/github.com/cockroachdb/errors/errors.go
@@ -18,8 +18,9 @@ package errors
 // nilable(err, target)
 func As(err error, target any) bool { return false }
 
-// nilable(result 0)
 func New(text string) error { return nil }
 
-// nilable(errs[], result 0)
+func Newf(format string, args ...interface{}) error { return nil }
+
+// nilable(errs[])
 func Join(errs ...error) error { return nil }

--- a/testdata/src/stubs/github.com/cockroachdb/errors/errors.go
+++ b/testdata/src/stubs/github.com/cockroachdb/errors/errors.go
@@ -1,0 +1,25 @@
+//  Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// <nilaway no inference>
+package errors
+
+// nilable(err, target)
+func As(err error, target any) bool { return false }
+
+// nilable(result 0)
+func New(text string) error { return nil }
+
+// nilable(errs[], result 0)
+func Join(errs ...error) error { return nil }


### PR DESCRIPTION
https://github.com/cockroachdb/errors is a popular alternative to the stdlib `errors` package. It provides alternative versions of `errors.New`, `fmt.Errorf` (which it calls `errors.Newf`), and `errors.Join`, among other functions.

Nilaway currently flags more false positives for codebases that use `cockroachdb/errors` instead of stdlib `errors`, because the built-in special cases for stdlib `errors` don't carry over to `cockroachdb/errors`. This PR duplicates the special cases in `hook/assume_return.go` and `hook/replace_conditional.go` so that they work with `cockroachdb/errors`.

Code was produced with LLM assistance (Claude).