### PR TITLE
Fix crash when produced CFG is `nil`

### DIFF
--- a/assertion/function/analyzer.go
+++ b/assertion/function/analyzer.go
@@ -178,10 +178,18 @@ func run(p *analysis.Pass) ([]annotation.FullTrigger, error) {
 			if funcDecl.Body == nil {
 				continue
 			}
+			// Skip if ctrlflow did not produce a CFG. This happens for functions
+			// in ctrlflow's hard-coded knownIntrinsic list (e.g. runtime.Goexit,
+			// (*zap.Logger).Fatal), where buildDecl short-circuits CFG construction
+			// even though the body is non-nil — CFGs.FuncDecl then returns nil and
+			// downstream CFG processing would panic on the nil graph.
+			if graph == nil {
+				continue
+			}
 			// Skip if the function is too large based on CFG complexity.
 			// Use CFG block count as a more accurate measure of function complexity
 			// than token/byte count, which can be misleading due to comments and formatting.
-			if graph != nil && len(graph.Blocks) > _maxFuncSizeInCFGBlocks {
+			if len(graph.Blocks) > _maxFuncSizeInCFGBlocks {
 				err = errors.Join(err, fmt.Errorf("skipping function `%s()` at %s: function too large (%d CFG blocks, exceeds limit of %d blocks)",
 					funcDecl.Name.Name, pass.Fset.Position(funcDecl.Pos()), len(graph.Blocks), _maxFuncSizeInCFGBlocks))
 				continue

--- a/nilaway_test.go
+++ b/nilaway_test.go
@@ -75,6 +75,7 @@ func TestNilAway(t *testing.T) {
 		{name: "AbnormalFlow", patterns: []string{"go.uber.org/abnormalflow"}},
 		{name: "NoLint", patterns: []string{"go.uber.org/nolint"}},
 		{name: "Templ", patterns: []string{"go.uber.org/templ"}},
+		{name: "CtrlflowIntrinsic", patterns: []string{"go.uber.org/zap"}},
 	}
 
 	for _, tt := range tests {

--- a/testdata/src/go.uber.org/zap/zap.go
+++ b/testdata/src/go.uber.org/zap/zap.go
@@ -1,0 +1,17 @@
+// Reproduces a panic where ctrlflow returns a nil *cfg.CFG for a function
+// with a non-nil body. ctrlflow's buildDecl short-circuits CFG construction
+// for functions in its hard-coded knownIntrinsic list (see
+// golang.org/x/tools/go/analysis/passes/ctrlflow), so CFGs.FuncDecl returns
+// nil even when decl.Body != nil. The function analyzer must skip these
+// rather than dereference the nil graph in preprocess.copyGraph.
+//
+// (*Logger).Fatal and (*Logger).Panic are entries in that intrinsic list;
+// either alone is enough to trigger the panic. The package import path
+// must literally be "go.uber.org/zap" for ctrlflow's IsMethodNamed check
+// to match.
+
+package zap
+
+type Logger struct{}
+
+func (l *Logger) Fatal(msg string) {}


### PR DESCRIPTION
This pull request addresses a bug where the analyzer could panic when encountering functions for which the control flow graph (CFG) is not constructed (specifically, intrinsic functions like `(*zap.Logger).Fatal`). The changes ensure these cases are handled gracefully and add a regression test to prevent similar issues in the future.

A test case is added to prevent future regressions.