### PR TITLE
Fix false positive on typed-constant errors (#108)

### DIFF
--- a/assertion/function/assertiontree/backprop_util.go
+++ b/assertion/function/assertiontree/backprop_util.go
@@ -245,9 +245,18 @@ func isErrorReturnNil(rootNode *RootAssertionNode, errRet ast.Expr) bool {
 
 // isErrorReturnNonnil returns true if the error return is guaranteed to be nonnil, false otherwise
 func isErrorReturnNonnil(rootNode *RootAssertionNode, errRet ast.Expr) bool {
+	// The error value's type is not inhabited by nil (e.g., a named basic type such as
+	// `type Error string`), so it can never be nil.
+	if rootNode.Pass().ExprBarsNilness(errRet) {
+		return true
+	}
+	// The error value is a custom error type (struct or pointer-to-struct), e.g. a returned
+	// `&MyErr{}` or `MyErr{}`. Such values are assumed non-nil: a concrete value boxed into the
+	// error interface yields a non-nil interface.
 	if t := rootNode.Pass().TypesInfo.TypeOf(errRet); typeshelper.AsDeeplyStruct(t) != nil {
 		return true
 	}
+	// The error value is the return of a hook-modeled function known to produce a non-nil error.
 	if callExpr, ok := errRet.(*ast.CallExpr); ok {
 		if hook.AssumeReturn(rootNode.Pass(), callExpr) != nil {
 			return true

--- a/testdata/src/go.uber.org/errorreturn/errorreturn.go
+++ b/testdata/src/go.uber.org/errorreturn/errorreturn.go
@@ -838,3 +838,53 @@ func Wrapf(e error) error {
 	}
 	return fmt.Errorf("wrapped: %w", e)
 }
+
+// ***** the below test cases check that an error value whose type cannot be inhabited by nil (e.g.,
+// a named basic type such as `type Error string`) is correctly treated as a non-nil error. This
+// addresses the false positive reported in https://github.com/uber-go/nilaway/issues/108 *****
+
+type typedConstErr string
+
+func (e typedConstErr) Error() string { return string(e) }
+
+const anError typedConstErr = "this is an error"
+
+// retTypedConstErr returns a typed-constant error in the non-nil error position. Since
+// `typedConstErr` is a named basic type that nil cannot inhabit, `anError` is a valid non-nil error
+// that suppresses consumption of the (nil) non-error result, so no error is expected here.
+func retTypedConstErr(x bool) (*int, error) {
+	if x {
+		return nil, anError
+	}
+	i := 0
+	return &i, nil
+}
+
+// callRetTypedConstErr exercises the exact pattern from issue #108: the result is dereferenced only
+// on the non-error path, which must not be flagged as a potential nil panic.
+func callRetTypedConstErr() error {
+	ptr, err := retTypedConstErr(true)
+	if err != nil {
+		return err
+	}
+	print(*ptr)
+	return nil
+}
+
+// retTypedErrVar checks the same behavior when the error flows through a variable of the named basic
+// type rather than being returned directly.
+func retTypedErrVar(x bool) (*int, error) {
+	var e typedConstErr = "boom"
+	if x {
+		return nil, e
+	}
+	i := 0
+	return &i, nil
+}
+
+func callRetTypedErrVar() {
+	ptr, err := retTypedErrVar(true)
+	if err == nil {
+		print(*ptr)
+	}
+}


### PR DESCRIPTION
Fixes #108. NilAway reported a false positive when a named basic type (e.g. type Error string) was used as an error and returned as a typed constant, the error was not recognized as guaranteed non-nil, so the paired non-error result was wrongly treated as nilable.

`isErrorReturnNonnil` now returns early when the error value's type cannot be inhabited by nil (`ExprBarsNilness`)

### Testing
Added regression cases to testdata/src/go.uber.org/errorreturn/errorreturn.go covering the issue repro (typed constant and typed variable in the error position).