### PR TITLE
Slicing an array yields a nonnil slice

### DIFF
--- a/assertion/function/assertiontree/parse_expr_producer.go
+++ b/assertion/function/assertiontree/parse_expr_producer.go
@@ -139,13 +139,13 @@ func (r *RootAssertionNode) ParseExprAsProducer(expr ast.Expr, doNotTrack bool) 
 	// this function is only to be used in cases when we have determined that the parsed
 	// expression is not trackable.
 	parseDeepRead := func(
-		recv TrackableExpr,                   // the already parsed prefix to `expr` - all we care about is whether nil
-		deepExpr ast.Expr,                    // the expression we identified is being deeply read for this parse
-		expr ast.Expr,                        // the overall expression being parsed - used to construct `annotation.ProduceTrigger`s
+		recv TrackableExpr, // the already parsed prefix to `expr` - all we care about is whether nil
+		deepExpr ast.Expr, // the expression we identified is being deeply read for this parse
+		expr ast.Expr, // the overall expression being parsed - used to construct `annotation.ProduceTrigger`s
 		rproducers []producer.ParsedProducer, // the, possibly already set, parse of `deepExpr`
-	// in general - our goal is to obtain the parse of `deepExpr` - then lift its deep producer to
-	// the shallow producer of a new `ParsedProducer`, and populate the new deep producer by a default
-	// based on type name if applicable
+		// in general - our goal is to obtain the parse of `deepExpr` - then lift its deep producer to
+		// the shallow producer of a new `ParsedProducer`, and populate the new deep producer by a default
+		// based on type name if applicable
 	) []producer.ParsedProducer {
 
 		if recv != nil {

--- a/assertion/function/assertiontree/parse_expr_producer.go
+++ b/assertion/function/assertiontree/parse_expr_producer.go
@@ -139,13 +139,13 @@ func (r *RootAssertionNode) ParseExprAsProducer(expr ast.Expr, doNotTrack bool) 
 	// this function is only to be used in cases when we have determined that the parsed
 	// expression is not trackable.
 	parseDeepRead := func(
-		recv TrackableExpr, // the already parsed prefix to `expr` - all we care about is whether nil
-		deepExpr ast.Expr, // the expression we identified is being deeply read for this parse
-		expr ast.Expr, // the overall expression being parsed - used to construct `annotation.ProduceTrigger`s
+		recv TrackableExpr,                   // the already parsed prefix to `expr` - all we care about is whether nil
+		deepExpr ast.Expr,                    // the expression we identified is being deeply read for this parse
+		expr ast.Expr,                        // the overall expression being parsed - used to construct `annotation.ProduceTrigger`s
 		rproducers []producer.ParsedProducer, // the, possibly already set, parse of `deepExpr`
-		// in general - our goal is to obtain the parse of `deepExpr` - then lift its deep producer to
-		// the shallow producer of a new `ParsedProducer`, and populate the new deep producer by a default
-		// based on type name if applicable
+	// in general - our goal is to obtain the parse of `deepExpr` - then lift its deep producer to
+	// the shallow producer of a new `ParsedProducer`, and populate the new deep producer by a default
+	// based on type name if applicable
 	) []producer.ParsedProducer {
 
 		if recv != nil {
@@ -471,9 +471,7 @@ func (r *RootAssertionNode) ParseExprAsProducer(expr ast.Expr, doNotTrack bool) 
 		// are value types and can never be nil; the resulting slice is backed by the array's
 		// storage. For example, `var a [4]int; _ = a[:0]` is a nonnil (empty) slice. This holds
 		// regardless of the indices, so we must check it before the `b[_:0:_]` case below (which
-		// would otherwise wrongly treat `a[:0]` as a nilable empty slice). IsDeeplyArray unwraps a
-		// pointer (so `*[N]T` is covered) and named types before checking. See
-		// https://github.com/uber-go/nilaway/issues/104.
+		// would otherwise wrongly treat `a[:0]` as a nilable empty slice).
 		if typeshelper.IsDeeplyArray(r.Pass().TypesInfo.Types[expr.X].Type) {
 			// Returning nil to indicate the slice expression results in a nonnil slice.
 			return nil, nil
@@ -638,4 +636,3 @@ func (r *RootAssertionNode) parseStructCreateExprAsProducer(expr ast.Expr, field
 
 	return nil
 }
-

--- a/assertion/function/assertiontree/parse_expr_producer.go
+++ b/assertion/function/assertiontree/parse_expr_producer.go
@@ -467,6 +467,17 @@ func (r *RootAssertionNode) ParseExprAsProducer(expr ast.Expr, doNotTrack bool) 
 		// reciever is non-trackable, just return nilable for index without check
 		return nil, parseDeepRead(recv, expr.X, expr, rproducers)
 	case *ast.SliceExpr:
+		// Slicing an array (or a pointer to an array) always yields a nonnil slice, since arrays
+		// are value types and can never be nil; the resulting slice is backed by the array's
+		// storage. For example, `var a [4]int; _ = a[:0]` is a nonnil (empty) slice. This holds
+		// regardless of the indices, so we must check it before the `b[_:0:_]` case below (which
+		// would otherwise wrongly treat `a[:0]` as a nilable empty slice). IsDeeplyArray unwraps a
+		// pointer (so `*[N]T` is covered) and named types before checking. See
+		// https://github.com/uber-go/nilaway/issues/104.
+		if typeshelper.IsDeeplyArray(r.Pass().TypesInfo.Types[expr.X].Type) {
+			// Returning nil to indicate the slice expression results in a nonnil slice.
+			return nil, nil
+		}
 		switch {
 		// For slice expressions `b[_:0:_]`, the result is always an empty (nilable in
 		// NilAway's eyes) slice. (`_` can be anything including empty.)
@@ -627,3 +638,4 @@ func (r *RootAssertionNode) parseStructCreateExprAsProducer(expr ast.Expr, field
 
 	return nil
 }
+

--- a/testdata/src/go.uber.org/arrays/arrays.go
+++ b/testdata/src/go.uber.org/arrays/arrays.go
@@ -187,6 +187,10 @@ func testSlicingArrayProducesNonnilSlice() {
 	_ = p[:0][0]
 	_ = p[:][0]
 
+	// Named array types (e.g., `blocks` is `[42]int`) behave the same.
+	var n blocks
+	_ = n[:0][0]
+
 	// Arrays produced by `new` are covered too: `new([N]T)` returns a nonnil `*[N]T`, so both the
 	// explicit-deref form `(*new([N]T))[:0]` (operand type `[N]T`) and the implicit-deref form
 	// `new([N]T)[:0]` (operand type `*[N]T`, auto-dereferenced) slice an array.

--- a/testdata/src/go.uber.org/arrays/arrays.go
+++ b/testdata/src/go.uber.org/arrays/arrays.go
@@ -162,3 +162,51 @@ func testArrayAliasPtr(aPtr *blocks, a blocks, bPtr *blockSlice, b blockSlice) {
 	for range b {
 	}
 }
+
+// testSlicingArrayProducesNonnilSlice verifies that slicing an array (or a pointer to an array)
+// always yields a nonnil slice, since arrays are value types that can never be nil; the resulting
+// slice is backed by the array's storage. Indexing or re-slicing the result must therefore not be
+// flagged as a potential nil panic, regardless of the slicing indices. See issue #104.
+func testSlicingArrayProducesNonnilSlice() {
+	var a [4]int
+
+	// `a[:0]` is an empty but nonnil slice (backed by the array), so consuming it is safe.
+	b := a[:0]
+	_ = b[0]
+	_ = b[1:2]
+
+	// Every other slicing form of the array is nonnil too, including those (like `[1:2]`) that for
+	// a regular slice would require the operand to be nonnil.
+	_ = a[:][0]
+	_ = a[0:][0]
+	_ = a[1:2][0]
+	_ = a[:0:0][0]
+
+	// Slicing a pointer to an array is nonnil as well.
+	p := &a
+	_ = p[:0][0]
+	_ = p[:][0]
+
+	// Named array types (e.g., `blocks` is `[42]int`) behave the same.
+	var n blocks
+	_ = n[:0][0]
+}
+
+// testSlicingArrayIssue104 reproduces the original false positive from
+// https://github.com/uber-go/nilaway/issues/104, where slicing a stack-allocated array (`buf[:0]`)
+// was wrongly treated as nilable, causing spurious nil-panic reports on the later index operations.
+func testSlicingArrayIssue104(maxlen int) []byte {
+	var buf [64]byte
+	answer := buf[:0]
+
+	for i := 0; i < maxlen; i++ {
+		answer = append(answer, byte(i))
+	}
+
+	alen := len(answer)
+	for i := 0; i < alen/2; i++ {
+		answer[i], answer[alen-1-i] = answer[alen-1-i], answer[i]
+	}
+
+	return answer
+}

--- a/testdata/src/go.uber.org/arrays/arrays.go
+++ b/testdata/src/go.uber.org/arrays/arrays.go
@@ -163,10 +163,10 @@ func testArrayAliasPtr(aPtr *blocks, a blocks, bPtr *blockSlice, b blockSlice) {
 	}
 }
 
-// testSlicingArrayProducesNonnilSlice verifies that slicing an array (or a pointer to an array)
-// always yields a nonnil slice, since arrays are value types that can never be nil; the resulting
-// slice is backed by the array's storage. Indexing or re-slicing the result must therefore not be
-// flagged as a potential nil panic, regardless of the slicing indices. See issue #104.
+// testSlicingArrayProducesNonnilSlice verifies that slicing an array always yields a nonnil slice,
+// since arrays are value types that can never be nil; the resulting slice is backed by the array's
+// storage. Indexing or re-slicing the result must therefore not be flagged as a potential nil
+// panic, regardless of the slicing indices or how the array is obtained. See issue #104.
 func testSlicingArrayProducesNonnilSlice() {
 	var a [4]int
 
@@ -187,9 +187,15 @@ func testSlicingArrayProducesNonnilSlice() {
 	_ = p[:0][0]
 	_ = p[:][0]
 
-	// Named array types (e.g., `blocks` is `[42]int`) behave the same.
-	var n blocks
-	_ = n[:0][0]
+	// Arrays produced by `new` are covered too: `new([N]T)` returns a nonnil `*[N]T`, so both the
+	// explicit-deref form `(*new([N]T))[:0]` (operand type `[N]T`) and the implicit-deref form
+	// `new([N]T)[:0]` (operand type `*[N]T`, auto-dereferenced) slice an array.
+	_ = (*new([64]byte))[:0][0]
+	_ = new([64]byte)[:0][0]
+
+	// Contrast: `make([]T, 0, N)` is nonnil as well, but for the unrelated reason that `make` never
+	// returns nil (not because of array slicing).
+	_ = make([]byte, 0, 64)[0]
 }
 
 // testSlicingArrayIssue104 reproduces the original false positive from


### PR DESCRIPTION
Slicing an array or a pointer to an array (e.g. `var a [N]byte; a[:0]`) always produces a **nonnil** slice — arrays are value types that can never be nil, and the resulting slice is backed by the array's storage. NilAway was incorrectly modeling the result as a nilable slice, producing spurious nil-panic reports whenever the result was later indexed or re-sliced.

This was the root cause of the false positives in #104, and it is common in real code.

Fixes #104 