### PR TITLE
Model well-known stdlib globals (os.Stdout/Stderr/Stdin, os.Args) as non-nil

### DIFF
--- a/assertion/function/assertiontree/parse_expr_producer.go
+++ b/assertion/function/assertiontree/parse_expr_producer.go
@@ -188,6 +188,13 @@ func (r *RootAssertionNode) ParseExprAsProducer(expr ast.Expr, doNotTrack bool) 
 	case *ast.Ident:
 		return parseIdent(expr)
 	case *ast.SelectorExpr:
+		// Some well-known stdlib package-level variables (e.g., os.Stdout/Stderr/Stdin, os.Args) are
+		// documented to be non-nil, but NilAway would otherwise infer them as nilable. Short-circuit
+		// to a nonnil producer for those reads.
+		if prod := hook.AssumeGlobalVarNonnil(r.Pass(), expr); prod != nil {
+			return nil, []producer.ParsedProducer{producer.ShallowParsedProducer{Producer: prod}}
+		}
+
 		if r.isPkgName(expr.X) {
 			// if we've reduced to a package-qualified identifier like pkg.A, just interpret it
 			// as a bare identifier

--- a/hook/assume_global_var.go
+++ b/hook/assume_global_var.go
@@ -1,0 +1,52 @@
+//  Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hook
+
+import (
+	"go/ast"
+	"regexp"
+
+	"go.uber.org/nilaway/annotation"
+	"go.uber.org/nilaway/util/analysishelper"
+)
+
+// AssumeGlobalVarNonnil returns a nonnil producer for reads of well-known standard-library global
+// variables that are documented to be non-nil but whose initializers NilAway would otherwise infer
+// as possibly-nil. For example, `os.Stdout`/`os.Stderr`/`os.Stdin` are assigned from `NewFile`,
+// which returns nil only for a negative file descriptor, and `os.Args` is always populated by the
+// runtime; in practice all of these are non-nil. Modeling them here removes a large class of false
+// positives on idiomatic code like `io.Copy(os.Stdout, r)` or `os.Args[1]`. If the given selector
+// does not match any known global, nil is returned.
+func AssumeGlobalVarNonnil(pass *analysishelper.EnhancedPass, sel *ast.SelectorExpr) *annotation.ProduceTrigger {
+	for i := range _assumeGlobalVarsNonnil {
+		if _assumeGlobalVarsNonnil[i].matchSel(pass, sel) {
+			return &annotation.ProduceTrigger{
+				Annotation: &annotation.TrustedFuncNonnil{ProduceTriggerNever: &annotation.ProduceTriggerNever{}},
+				Expr:       sel,
+			}
+		}
+	}
+	return nil
+}
+
+// _assumeGlobalVarsNonnil is the set of standard-library global variables assumed to be non-nil.
+var _assumeGlobalVarsNonnil = []trustedSig{
+	// `os.Stdout`, `os.Stderr`, `os.Stdin`, and `os.Args` are documented to be non-nil.
+	{
+		kind:           _var,
+		enclosingRegex: regexp.MustCompile(`^os$`),
+		nameRegex:      regexp.MustCompile(`^(Stdout|Stderr|Stdin|Args)$`),
+	},
+}

--- a/hook/assume_return.go
+++ b/hook/assume_return.go
@@ -38,7 +38,7 @@ func AssumeReturn(pass *analysishelper.EnhancedPass, call *ast.CallExpr) *annota
 
 func matchTrustedFuncs(pass *analysishelper.EnhancedPass, call *ast.CallExpr) *annotation.ProduceTrigger {
 	for sig, act := range _assumeReturns {
-		if sig.match(pass, call) {
+		if sig.matchCall(pass, call) {
 			return act(call)
 		}
 	}
@@ -130,38 +130,38 @@ func isErrorWrapperFunc(pass *analysishelper.EnhancedPass, call *ast.CallExpr) b
 
 type assumeReturnAction func(call *ast.CallExpr) *annotation.ProduceTrigger
 
-var _assumeReturns = map[trustedFuncSig]assumeReturnAction{
+var _assumeReturns = map[trustedSig]assumeReturnAction{
 	// `errors.New`
 	{
 		kind:           _func,
 		enclosingRegex: regexp.MustCompile(`^errors$`),
-		funcNameRegex:  regexp.MustCompile(`^New$`),
+		nameRegex:      regexp.MustCompile(`^New$`),
 	}: nonnilProducer,
 
 	// `fmt.Errorf`
 	{
 		kind:           _func,
 		enclosingRegex: regexp.MustCompile(`^fmt$`),
-		funcNameRegex:  regexp.MustCompile(`^Errorf$`),
+		nameRegex:      regexp.MustCompile(`^Errorf$`),
 	}: nonnilProducer,
 
 	// `github.com/pkg/errors`
 	{
 		kind:           _func,
 		enclosingRegex: regexp.MustCompile(`^(stubs/)?github\.com/pkg/errors$`),
-		funcNameRegex:  regexp.MustCompile(`^Errorf$`),
+		nameRegex:      regexp.MustCompile(`^Errorf$`),
 	}: nonnilProducer,
 	{
 		kind:           _func,
 		enclosingRegex: regexp.MustCompile(`^(stubs/)?github\.com/pkg/errors$`),
-		funcNameRegex:  regexp.MustCompile(`^New$`),
+		nameRegex:      regexp.MustCompile(`^New$`),
 	}: nonnilProducer,
 
 	// `github.com/cockroachdb/errors`
 	{
 		kind:           _func,
 		enclosingRegex: regexp.MustCompile(`^(stubs/)?github\.com/cockroachdb/errors$`),
-		funcNameRegex:  regexp.MustCompile(`^New(f)?$`),
+		nameRegex:      regexp.MustCompile(`^New(f)?$`),
 	}: nonnilProducer,
 
 	// `errors.Join`
@@ -173,14 +173,14 @@ var _assumeReturns = map[trustedFuncSig]assumeReturnAction{
 	{
 		kind:           _func,
 		enclosingRegex: regexp.MustCompile(`^errors$`),
-		funcNameRegex:  regexp.MustCompile(`^Join$`),
+		nameRegex:      regexp.MustCompile(`^Join$`),
 	}: nonnilProducer,
 
 	// `github.com/cockroachdb/errors.Join`
 	{
 		kind:           _func,
 		enclosingRegex: regexp.MustCompile(`^(stubs/)?github\.com/cockroachdb/errors$`),
-		funcNameRegex:  regexp.MustCompile(`^Join$`),
+		nameRegex:      regexp.MustCompile(`^Join$`),
 	}: nonnilProducer,
 
 	// `strings.Split`
@@ -194,7 +194,7 @@ var _assumeReturns = map[trustedFuncSig]assumeReturnAction{
 	{
 		kind:           _func,
 		enclosingRegex: regexp.MustCompile(`^strings$`),
-		funcNameRegex:  regexp.MustCompile(`^Split(After)?$`),
+		nameRegex:      regexp.MustCompile(`^Split(After)?$`),
 	}: nonnilProducer,
 
 	// `google.golang.org/grpc/status.Error`
@@ -204,7 +204,7 @@ var _assumeReturns = map[trustedFuncSig]assumeReturnAction{
 	{
 		kind:           _func,
 		enclosingRegex: regexp.MustCompile(`^(stubs/)?(google\.golang\.org/grpc|google\.golang\.org/grpc/status)$`),
-		funcNameRegex:  regexp.MustCompile(`^Errorf?$`),
+		nameRegex:      regexp.MustCompile(`^Errorf?$`),
 	}: nonnilProducer,
 }
 

--- a/hook/hook.go
+++ b/hook/hook.go
@@ -28,58 +28,86 @@ import (
 	"go.uber.org/nilaway/util/typeshelper"
 )
 
-// funcKind indicates the kind of the trusted function:
+// trustedKind indicates the kind of the trusted entity:
 // (1) _method: it is a method of a struct;
-// (2) _func: it is a top-level function of a package.
-type funcKind uint8
+// (2) _func: it is a top-level function of a package;
+// (3) _var: it is a package-level variable.
+type trustedKind uint8
 
 const (
-	_method funcKind = iota
+	_method trustedKind = iota
 	_func
+	_var
 )
 
-// trustedFuncSig defines the signature of a function that we "trust" to have a certain effect on its arguments, for example.
-type trustedFuncSig struct {
-	kind           funcKind
+// trustedSig defines the signature of a function, method, or package-level variable that we "trust"
+// to have a certain known effect or nilability.
+type trustedSig struct {
+	kind           trustedKind
 	enclosingRegex *regexp.Regexp
-	funcNameRegex  *regexp.Regexp
+	nameRegex      *regexp.Regexp
 }
 
-// match checks if a given call expression matches with a trusted function's signature. Namely,
-// it performs a strict matching for the function / method name and a user-defined regex match for
-// the enclosing package or struct path.
-func (t *trustedFuncSig) match(pass *analysishelper.EnhancedPass, call *ast.CallExpr) bool {
+// matchCall checks if a given call expression invokes a trusted function or method (i.e., a
+// signature of kind _func or _method). It performs a strict match on the called name and a regex
+// match on the enclosing path:
+//   - _func:   match enclosing "<pkg path>". E.g., for `assert.Error(err)`, path = github.com/stretchr/testify/assert
+//   - _method: match "<pkg path>.<struct name>". E.g., for `u.Require().Error(err)`, path = github.com/stretchr/testify/require.Assertions
+//
+// Trusted package-level variables (kind _var) are matched separately via matchSel, since they are
+// read as bare selectors rather than calls.
+func (t *trustedSig) matchCall(pass *analysishelper.EnhancedPass, call *ast.CallExpr) bool {
+	if t.kind != _func && t.kind != _method {
+		return false
+	}
 	sel, ok := call.Fun.(*ast.SelectorExpr)
-	if !ok || !t.funcNameRegex.MatchString(sel.Sel.Name) {
+	if !ok || !t.nameRegex.MatchString(sel.Sel.Name) {
 		return false
 	}
 
-	// Match fully qualified path of the call expression with the expected path specified in `t`
-	// if function, match enclosing "<pkg path>". E.g., for `assert.Error(err)`, path = github.com/stretchr/testify/assert
-	// if method, match with "<pkg path>.<struct name>". E.g., for `u.Require().Error(err)`, path = github.com/stretchr/testify/require.Assertions
-	if funcObj, ok := pass.TypesInfo.ObjectOf(sel.Sel).(*types.Func); ok && funcObj.Pkg() != nil {
-		recv := funcObj.Type().(*types.Signature).Recv()
-		path := funcObj.Pkg().Path()
+	funcObj, ok := pass.TypesInfo.ObjectOf(sel.Sel).(*types.Func)
+	if !ok || funcObj.Pkg() == nil {
+		return false
+	}
+	recv := funcObj.Type().(*types.Signature).Recv()
+	path := funcObj.Pkg().Path()
 
-		// return early if the kind of `t` and `funcObj` don't match. Both should be functions (or methods) for the match to be performed
-		// `recv != nil` implies `funcObj` is a method, while `recv == nil` means it is a function
-		if (t.kind == _func && recv != nil) || (t.kind == _method && recv == nil) {
+	// return early if the kind of `t` and `funcObj` don't match. Both should be functions (or methods) for the match to be performed
+	// `recv != nil` implies `funcObj` is a method, while `recv == nil` means it is a function
+	if (t.kind == _func && recv != nil) || (t.kind == _method && recv == nil) {
+		return false
+	}
+
+	// add struct name to the path
+	if recv != nil {
+		if n, ok := typeshelper.UnwrapPtr(recv.Type()).(*types.Named); ok {
+			path = path + "." + n.Obj().Name()
+		} else {
+			// we should likely never hit this case, but is only added for extra safety since
+			// `util.TypeAsDeeplyNamed` can return nil
 			return false
 		}
-
-		// add struct name to the path
-		if recv != nil {
-			if n, ok := typeshelper.UnwrapPtr(recv.Type()).(*types.Named); ok {
-				path = path + "." + n.Obj().Name()
-			} else {
-				// we should likely never hit this case, but is only added for extra safety since
-				// `util.TypeAsDeeplyNamed` can return nil
-				return false
-			}
-		}
-		return t.enclosingRegex.MatchString(path)
 	}
-	return false
+	return t.enclosingRegex.MatchString(path)
+}
+
+// matchSel checks if a given selector expression reads a trusted package-level variable (i.e., a
+// signature of kind _var). E.g., for `os.Stdout`, path = os. It requires the object to be a genuine
+// package-level variable (its enclosing scope is the package scope), ruling out struct fields and
+// locals so that, e.g., a `Stdout` field on some local struct does not match.
+//
+// This is intentionally independent of how the variable is later used: a read like `os.Stdout`,
+// `os.Stdout.Write(...)` (as a method receiver), or `os.Args[0]` (as an index operand) all parse the
+// bare selector as a producer, so all are covered here without involving matchCall.
+func (t *trustedSig) matchSel(pass *analysishelper.EnhancedPass, sel *ast.SelectorExpr) bool {
+	if t.kind != _var || !t.nameRegex.MatchString(sel.Sel.Name) {
+		return false
+	}
+	varObj, ok := pass.TypesInfo.ObjectOf(sel.Sel).(*types.Var)
+	if !ok || varObj.Pkg() == nil || varObj.Parent() != varObj.Pkg().Scope() {
+		return false
+	}
+	return t.enclosingRegex.MatchString(varObj.Pkg().Path())
 }
 
 // newNilBinaryExpr creates a new binary expression "expr op nil".

--- a/hook/no_return_call.go
+++ b/hook/no_return_call.go
@@ -31,21 +31,21 @@ import (
 //
 // `testing.TB.Fatal`-related: they are interface methods without implementations.
 func IsNoReturnCall(pass *analysishelper.EnhancedPass, call *ast.CallExpr) bool {
-	return slices.ContainsFunc(_terminatingCalls, func(sig trustedFuncSig) bool { return sig.match(pass, call) })
+	return slices.ContainsFunc(_terminatingCalls, func(sig trustedSig) bool { return sig.matchCall(pass, call) })
 }
 
-var _terminatingCalls = []trustedFuncSig{
+var _terminatingCalls = []trustedSig{
 	// `zap.Logger.Fatal`
 	{
 		kind:           _method,
 		enclosingRegex: regexp.MustCompile(`^(stubs/)?go\.uber\.org/zap.Logger$`),
-		funcNameRegex:  regexp.MustCompile(`^Fatal$`),
+		nameRegex:      regexp.MustCompile(`^Fatal$`),
 	},
 	// `zap.SugaredLogger.Fatal` / `zap.SugaredLogger.Fatalf` / `zap.SugaredLogger.Fatalln` / `zap.SugaredLogger.Fatalw`
 	{
 		kind:           _method,
 		enclosingRegex: regexp.MustCompile(`^(stubs/)?go\.uber\.org/zap.SugaredLogger$`),
-		funcNameRegex:  regexp.MustCompile(`^Fatal(f|ln|w)?$`),
+		nameRegex:      regexp.MustCompile(`^Fatal(f|ln|w)?$`),
 	},
 	// `testing.TB.Fatal` / `testing.TB.Fatalf` / `testing.TB.SkipNow` / `testing.TB.Skip` / `testing.TB.Skipf`
 	// since it is an interface rather than a concrete implementation, the control flow analyzer
@@ -53,6 +53,6 @@ var _terminatingCalls = []trustedFuncSig{
 	{
 		kind:           _method,
 		enclosingRegex: regexp.MustCompile(`^testing.TB$`),
-		funcNameRegex:  regexp.MustCompile(`^(Fatal|Fatalf|SkipNow|Skip|Skipf)$`),
+		nameRegex:      regexp.MustCompile(`^(Fatal|Fatalf|SkipNow|Skip|Skipf)$`),
 	},
 }

--- a/hook/replace_conditional.go
+++ b/hook/replace_conditional.go
@@ -30,7 +30,7 @@ import (
 // If the call does not match any known function, nil is returned.
 func ReplaceConditional(pass *analysishelper.EnhancedPass, call *ast.CallExpr) ast.Expr {
 	for sig, act := range _replaceConditionals {
-		if sig.match(pass, call) {
+		if sig.matchCall(pass, call) {
 			return act(pass, call)
 		}
 	}
@@ -69,15 +69,15 @@ var _errorAsAction replaceConditionalAction = func(_ *analysishelper.EnhancedPas
 	}
 }
 
-var _replaceConditionals = map[trustedFuncSig]replaceConditionalAction{
+var _replaceConditionals = map[trustedSig]replaceConditionalAction{
 	{
 		kind:           _func,
 		enclosingRegex: regexp.MustCompile(`^errors$`),
-		funcNameRegex:  regexp.MustCompile(`^As$`),
+		nameRegex:      regexp.MustCompile(`^As$`),
 	}: _errorAsAction,
 	{
 		kind:           _func,
 		enclosingRegex: regexp.MustCompile(`^(stubs/)?github\.com/cockroachdb/errors$`),
-		funcNameRegex:  regexp.MustCompile(`^As$`),
+		nameRegex:      regexp.MustCompile(`^As$`),
 	}: _errorAsAction,
 }

--- a/hook/split_blocks_on.go
+++ b/hook/split_blocks_on.go
@@ -32,7 +32,7 @@ import (
 // nilability of the arguments after certain functions with side effects.
 func SplitBlockOn(pass *analysishelper.EnhancedPass, call *ast.CallExpr) ast.Expr {
 	for sig, act := range _splitBlockOn {
-		if sig.match(pass, call) {
+		if sig.matchCall(pass, call) {
 			return act.action(pass, call, act.argIndex)
 		}
 	}
@@ -286,7 +286,7 @@ var requireLen splitBlockOnAction = func(pass *analysishelper.EnhancedPass, call
 
 // _splitBlockOn defines the map of trusted functions and their corresponding actions on a
 // particular argument.
-var _splitBlockOn = map[trustedFuncSig]struct {
+var _splitBlockOn = map[trustedSig]struct {
 	action   splitBlockOnAction
 	argIndex int
 }{
@@ -294,73 +294,73 @@ var _splitBlockOn = map[trustedFuncSig]struct {
 	{
 		kind:           _method,
 		enclosingRegex: regexp.MustCompile(`^(stubs/)?github\.com/stretchr/testify/(suite\.Suite|assert\.Assertions|require\.Assertions)$`),
-		funcNameRegex:  regexp.MustCompile(`^(Nil(f)?|NoError(f)?)$`),
+		nameRegex:      regexp.MustCompile(`^(Nil(f)?|NoError(f)?)$`),
 	}: {action: nilBinaryExpr, argIndex: 0},
 	{
 		kind:           _method,
 		enclosingRegex: regexp.MustCompile(`^(stubs/)?github\.com/stretchr/testify/(suite\.Suite|assert\.Assertions|require\.Assertions)$`),
-		funcNameRegex:  regexp.MustCompile(`^(NotNil(f)?|Error(f)?)$`),
+		nameRegex:      regexp.MustCompile(`^(NotNil(f)?|Error(f)?)$`),
 	}: {action: nonnilBinaryExpr, argIndex: 0},
 	{
 		kind:           _method,
 		enclosingRegex: regexp.MustCompile(`^(stubs/)?github\.com/stretchr/testify/(suite\.Suite|assert\.Assertions|require\.Assertions)$`),
-		funcNameRegex:  regexp.MustCompile(`^True(f)?$`),
+		nameRegex:      regexp.MustCompile(`^True(f)?$`),
 	}: {action: selfExpr, argIndex: 0},
 	{
 		kind:           _method,
 		enclosingRegex: regexp.MustCompile(`^(stubs/)?github\.com/stretchr/testify/(suite\.Suite|assert\.Assertions|require\.Assertions)$`),
-		funcNameRegex:  regexp.MustCompile(`^False(f)?$`),
+		nameRegex:      regexp.MustCompile(`^False(f)?$`),
 	}: {action: negatedSelfExpr, argIndex: 0},
 	{
 		kind:           _method,
 		enclosingRegex: regexp.MustCompile(`^(stubs/)?github\.com/stretchr/testify/(suite\.Suite|assert\.Assertions|require\.Assertions)$`),
-		funcNameRegex:  regexp.MustCompile(`^(Greater(f)?|Less(f)?|Equal(f)?|GreaterOrEqual(f)?|LessOrEqual(f)?|NotEqual(f)?)$`),
+		nameRegex:      regexp.MustCompile(`^(Greater(f)?|Less(f)?|Equal(f)?|GreaterOrEqual(f)?|LessOrEqual(f)?|NotEqual(f)?)$`),
 	}: {action: requireComparators, argIndex: 0},
 	{
 		kind:           _method,
 		enclosingRegex: regexp.MustCompile(`^(stubs/)?github\.com/stretchr/testify/(suite\.Suite|assert\.Assertions|require\.Assertions)$`),
-		funcNameRegex:  regexp.MustCompile(`^Len(f)?$`),
+		nameRegex:      regexp.MustCompile(`^Len(f)?$`),
 	}: {action: requireLen, argIndex: 0},
 
 	// `assert` and `require`
 	{
 		kind:           _func,
 		enclosingRegex: regexp.MustCompile(`^(stubs/)?github\.com/stretchr/testify/(assert|require)$`),
-		funcNameRegex:  regexp.MustCompile(`^(Nil(f)?|NoError(f)?)$`),
+		nameRegex:      regexp.MustCompile(`^(Nil(f)?|NoError(f)?)$`),
 	}: {action: nilBinaryExpr, argIndex: 1},
 	{
 		kind:           _func,
 		enclosingRegex: regexp.MustCompile(`^(stubs/)?github\.com/stretchr/testify/(assert|require)$`),
-		funcNameRegex:  regexp.MustCompile(`^(NotNil(f)?|Error(f)?)$`),
+		nameRegex:      regexp.MustCompile(`^(NotNil(f)?|Error(f)?)$`),
 	}: {action: nonnilBinaryExpr, argIndex: 1},
 	{
 		kind:           _func,
 		enclosingRegex: regexp.MustCompile(`^(stubs/)?github\.com/stretchr/testify/(assert|require)$`),
-		funcNameRegex:  regexp.MustCompile(`^True(f)?$`),
+		nameRegex:      regexp.MustCompile(`^True(f)?$`),
 	}: {action: selfExpr, argIndex: 1},
 	{
 		kind:           _func,
 		enclosingRegex: regexp.MustCompile(`^(stubs/)?github\.com/stretchr/testify/(assert|require)$`),
-		funcNameRegex:  regexp.MustCompile(`^False(f)?$`),
+		nameRegex:      regexp.MustCompile(`^False(f)?$`),
 	}: {action: negatedSelfExpr, argIndex: 1},
 	{
 		kind:           _func,
 		enclosingRegex: regexp.MustCompile(`^(stubs/)?github\.com/stretchr/testify/(assert|require)$`),
-		funcNameRegex:  regexp.MustCompile(`^(Greater(f)?|Less(f)?|Equal(f)?|GreaterOrEqual(f)?|LessOrEqual(f)?|NotEqual(f)?)$`),
+		nameRegex:      regexp.MustCompile(`^(Greater(f)?|Less(f)?|Equal(f)?|GreaterOrEqual(f)?|LessOrEqual(f)?|NotEqual(f)?)$`),
 	}: {action: requireComparators, argIndex: 1},
 	{
 		kind:           _func,
 		enclosingRegex: regexp.MustCompile(`^(stubs/)?github\.com/stretchr/testify/(assert|require)$`),
-		funcNameRegex:  regexp.MustCompile(`^Len(f)?$`),
+		nameRegex:      regexp.MustCompile(`^Len(f)?$`),
 	}: {action: requireLen, argIndex: 1},
 	{
 		kind:           _func,
 		enclosingRegex: regexp.MustCompile(`^(stubs/)?github\.com/stretchr/testify/(assert|require)$`),
-		funcNameRegex:  regexp.MustCompile(`^(Empty(f)?|NotEmpty(f)?)$`),
+		nameRegex:      regexp.MustCompile(`^(Empty(f)?|NotEmpty(f)?)$`),
 	}: {action: requireZeroComparators, argIndex: 1},
 	{
 		kind:           _method,
 		enclosingRegex: regexp.MustCompile(`^(stubs/)?github\.com/stretchr/testify/(suite\.Suite|assert\.Assertions|require\.Assertions)$`),
-		funcNameRegex:  regexp.MustCompile(`^(Empty(f)?|NotEmpty(f)?)$`),
+		nameRegex:      regexp.MustCompile(`^(Empty(f)?|NotEmpty(f)?)$`),
 	}: {action: requireZeroComparators, argIndex: 0},
 }

--- a/testdata/src/go.uber.org/trustedfunc/inference/os_globals.go
+++ b/testdata/src/go.uber.org/trustedfunc/inference/os_globals.go
@@ -1,0 +1,49 @@
+//  Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inference
+
+import "os"
+
+// osGlobalsTest verifies that reads of the well-known stdlib globals os.Stdout/Stderr/Stdin and
+// os.Args are treated as non-nil, so dereferencing/indexing them is not flagged. Without this
+// support, NilAway infers these as nilable (their initializers can technically return nil), which
+// produces a large class of false positives on idiomatic code.
+func osGlobalsTest(c string, p []byte) {
+	switch c {
+	case "os.Stdout":
+		// Method call dereferences the receiver; os.Stdout is non-nil.
+		_, _ = os.Stdout.Write(p)
+	case "os.Stderr":
+		_, _ = os.Stderr.Write(p)
+	case "os.Stdin":
+		_, _ = os.Stdin.Read(p)
+	case "os.Args":
+		// Indexing/ranging dereferences the slice; os.Args is non-nil.
+		print(os.Args[0])
+		for _, a := range os.Args {
+			print(a)
+		}
+	}
+}
+
+// osGlobalsFlowTest verifies the non-nil assumption also propagates when the global is assigned to a
+// local and then consumed.
+func osGlobalsFlowTest(p []byte) {
+	f := os.Stdout
+	_, _ = f.Write(p)
+
+	args := os.Args
+	print(args[0])
+}


### PR DESCRIPTION
NilAway infers `os.Stdout`, `os.Stderr`, `os.Stdin`, and `os.Args` as potentially nil, because their initializers technically can return nil (`os.Std*` come from `NewFile`, which returns nil for a negative fd; `os.Args` is populated by the runtime). In practice all four are always non-nil, so every use — `io.Copy(os.Stdout, r)`, `os.Stderr.Write(...)`, `os.Args[1]`, etc. -- produces a false positive. On the Go standard library alone this accounts for ~184 of the unique diagnostics.
 
This PR teaches NilAway to treat reads of these globals as non-nil, via the existing `hook` framework.

We also did a bit refactor on the hook framework to allow accepting variables instead of just function and methods.