### PR TITLE
Track `len(s) - positive >= 0` / `len(s) + negative >= 0` as a non-nil check in AddNilCheck

### DIFF
--- a/assertion/function/assertiontree/util.go
+++ b/assertion/function/assertiontree/util.go
@@ -279,6 +279,24 @@ func AddNilCheck(pass *analysishelper.EnhancedPass, expr ast.Expr) (trueCheck, f
 				return noop, noop, true
 			},
 		},
+		{
+			// `len(a) - 1 >= 0`
+			// Unlike the looser `len(a) ... >= [positive-int]` heuristic above, this is sound:
+			// `len(a) - 1 >= 0` implies `len(a) >= 1`, so `a` is non-nil. We require the exact
+			// `len(a) - 1` structure (rather than the loose `extractLenArgs` matching) so that we
+			// do not unsoundly conclude anything from, e.g., `len(a) - 1 + b >= 0`.
+			// Automatic cases:
+			//   - `0 <= len(a) - 1`
+			//   - `len(a) - 1 < 0`
+			//   - `0 > len(a) - 1`
+			op: token.GEQ,
+			matcher: func(x, y ast.Expr) (RootFunc, RootFunc, bool) {
+				if arg, ok := lenMinusOneArg(pass, x); ok && pass.IsZero(y) {
+					return produceNegativeNilChecks(arg), noop, false
+				}
+				return noop, noop, true
+			},
+		},
 	}
 
 	// Apply the checkers.
@@ -324,6 +342,23 @@ func extractLenArgs(expr ast.Expr, allowNested bool) []ast.Expr {
 		return allowNested
 	})
 	return args
+}
+
+// lenMinusOneArg returns the argument `a` and true if `expr` has the exact form `len(a) - 1`.
+// Otherwise, it returns nil and false. This structural check (rather than the looser
+// `extractLenArgs`) lets us soundly conclude `len(a) >= 1` from `len(a) - 1 >= 0`.
+func lenMinusOneArg(pass *analysishelper.EnhancedPass, expr ast.Expr) (ast.Expr, bool) {
+	bin, ok := ast.Unparen(expr).(*ast.BinaryExpr)
+	if !ok || bin.Op != token.SUB {
+		return nil, false
+	}
+	if v, ok := pass.ConstInt(bin.Y); !ok || v != 1 {
+		return nil, false
+	}
+	if lenArgs := extractLenArgs(bin.X, false /* allowNested */); len(lenArgs) == 1 {
+		return lenArgs[0], true
+	}
+	return nil, false
 }
 
 // likelyPositiveInt return true if the given expression is likely a positive integer. We

--- a/assertion/function/assertiontree/util.go
+++ b/assertion/function/assertiontree/util.go
@@ -280,15 +280,15 @@ func AddNilCheck(pass *analysishelper.EnhancedPass, expr ast.Expr) (trueCheck, f
 			},
 		},
 		{
-			// `len(a) - 1 >= 0` implies `len(a) >= 1`, so `a` is non-nil. We match the exact
-			// `len(a) - 1` structure so that this check is sound.
-			// Automatic cases:
+			// `len(a) - c >= 0` (positive `c`) or `len(a) + c >= 0` (negative `c`) both imply
+			// `len(a) >= 1`, so `a` is non-nil. We match this exact structure so the check is
+			// sound. The automatic cases below are shown for `len(a) - 1`:
 			//   - `0 <= len(a) - 1`
 			//   - `len(a) - 1 < 0`
 			//   - `0 > len(a) - 1`
 			op: token.GEQ,
 			matcher: func(x, y ast.Expr) (RootFunc, RootFunc, bool) {
-				if arg, ok := lenMinusOneArg(pass, x); ok && pass.IsZero(y) {
+				if arg, ok := lenMinusPositiveArg(pass, x); ok && pass.IsZero(y) {
 					return produceNegativeNilChecks(arg), noop, false
 				}
 				return noop, noop, true
@@ -341,14 +341,32 @@ func extractLenArgs(expr ast.Expr, allowNested bool) []ast.Expr {
 	return args
 }
 
-// lenMinusOneArg returns the argument `a` and true if `expr` has the exact form `len(a) - 1`.
-// Otherwise, it returns nil and false.
-func lenMinusOneArg(pass *analysishelper.EnhancedPass, expr ast.Expr) (ast.Expr, bool) {
+// lenMinusPositiveArg returns the argument `a` and true if `expr` has the form `len(a) - c` with
+// a positive constant `c`, or `len(a) + c` with a negative constant `c`. In both cases `expr`
+// equals `len(a) - k` for some integer `k >= 1`, so combined with `>= 0` it soundly implies
+// `len(a) >= 1`, i.e., `a` is non-nil. We require the `len(a)` term on the left and a constant
+// offset (rather than the looser `extractLenArgs` matching) so that we do not unsoundly conclude
+// anything from, e.g., `len(a) - 1 + b >= 0` or `c - len(a) >= 0`.
+func lenMinusPositiveArg(pass *analysishelper.EnhancedPass, expr ast.Expr) (ast.Expr, bool) {
 	bin, ok := ast.Unparen(expr).(*ast.BinaryExpr)
-	if !ok || bin.Op != token.SUB {
+	if !ok {
 		return nil, false
 	}
-	if v, ok := pass.ConstInt(bin.Y); !ok || v != 1 {
+	c, ok := pass.ConstInt(bin.Y)
+	if !ok {
+		return nil, false
+	}
+	// Compute `k` such that `bin` equals `len(a) - k`, then require `k >= 1`.
+	var k int64
+	switch bin.Op {
+	case token.SUB: // `len(a) - c`, sound when `c` is positive.
+		k = c
+	case token.ADD: // `len(a) + c`, sound when `c` is negative.
+		k = -c
+	default:
+		return nil, false
+	}
+	if k < 1 {
 		return nil, false
 	}
 	if lenArgs := extractLenArgs(bin.X, false /* allowNested */); len(lenArgs) == 1 {

--- a/assertion/function/assertiontree/util.go
+++ b/assertion/function/assertiontree/util.go
@@ -282,10 +282,11 @@ func AddNilCheck(pass *analysishelper.EnhancedPass, expr ast.Expr) (trueCheck, f
 		{
 			// `len(a) - c >= 0` (positive `c`) or `len(a) + c >= 0` (negative `c`) both imply
 			// `len(a) >= 1`, so `a` is non-nil. We match this exact structure so the check is
-			// sound. The automatic cases below are shown for `len(a) - 1`:
-			//   - `0 <= len(a) - 1`
-			//   - `len(a) - 1 < 0`
-			//   - `0 > len(a) - 1`
+			// sound. The converse/inverse/contrapositive are derived automatically, e.g. for
+			// `len(a) - c`:
+			//   - `0 <= len(a) - c`
+			//   - `len(a) - c < 0`
+			//   - `0 > len(a) - c`
 			op: token.GEQ,
 			matcher: func(x, y ast.Expr) (RootFunc, RootFunc, bool) {
 				if arg, ok := lenMinusPositiveArg(pass, x); ok && pass.IsZero(y) {

--- a/assertion/function/assertiontree/util.go
+++ b/assertion/function/assertiontree/util.go
@@ -280,11 +280,8 @@ func AddNilCheck(pass *analysishelper.EnhancedPass, expr ast.Expr) (trueCheck, f
 			},
 		},
 		{
-			// `len(a) - 1 >= 0`
-			// Unlike the looser `len(a) ... >= [positive-int]` heuristic above, this is sound:
-			// `len(a) - 1 >= 0` implies `len(a) >= 1`, so `a` is non-nil. We require the exact
-			// `len(a) - 1` structure (rather than the loose `extractLenArgs` matching) so that we
-			// do not unsoundly conclude anything from, e.g., `len(a) - 1 + b >= 0`.
+			// `len(a) - 1 >= 0` implies `len(a) >= 1`, so `a` is non-nil. We match the exact
+			// `len(a) - 1` structure so that this check is sound.
 			// Automatic cases:
 			//   - `0 <= len(a) - 1`
 			//   - `len(a) - 1 < 0`
@@ -345,8 +342,7 @@ func extractLenArgs(expr ast.Expr, allowNested bool) []ast.Expr {
 }
 
 // lenMinusOneArg returns the argument `a` and true if `expr` has the exact form `len(a) - 1`.
-// Otherwise, it returns nil and false. This structural check (rather than the looser
-// `extractLenArgs`) lets us soundly conclude `len(a) >= 1` from `len(a) - 1 >= 0`.
+// Otherwise, it returns nil and false.
 func lenMinusOneArg(pass *analysishelper.EnhancedPass, expr ast.Expr) (ast.Expr, bool) {
 	bin, ok := ast.Unparen(expr).(*ast.BinaryExpr)
 	if !ok || bin.Op != token.SUB {

--- a/testdata/src/go.uber.org/slices/slices.go
+++ b/testdata/src/go.uber.org/slices/slices.go
@@ -267,6 +267,26 @@ func lengthCheckAsNilCheckTest(a []int) int {
 		for i := 0; i <= len(a) + 2 + b; i ++ {
 			_ = a[i]
 		}
+
+	// `len(a) - 1 >= 0` implies `len(a) >= 1`, so `a` is non-nil.
+	case 35:
+		if len(a) - 1 >= 0 {
+			return a[0]
+		}
+	case 36:
+		if 0 <= len(a) - 1 {
+			return a[0]
+		}
+	case 37:
+		if len(a) - 1 < 0 {
+			return 0
+		}
+		return a[0]
+	case 38:
+		if 0 > len(a) - 1 {
+			return 0
+		}
+		return a[0]
 	}
 	return 0
 }

--- a/testdata/src/go.uber.org/slices/slices.go
+++ b/testdata/src/go.uber.org/slices/slices.go
@@ -268,7 +268,8 @@ func lengthCheckAsNilCheckTest(a []int) int {
 			_ = a[i]
 		}
 
-	// `len(a) - 1 >= 0` implies `len(a) >= 1`, so `a` is non-nil.
+	// `len(a) - 1 >= 0` implies `len(a) >= 1`, so `a` is non-nil. The same holds for any
+	// `len(a) - positive >= 0` or `len(a) + negative >= 0`.
 	case 35:
 		if len(a) - 1 >= 0 {
 			return a[0]
@@ -287,6 +288,37 @@ func lengthCheckAsNilCheckTest(a []int) int {
 			return 0
 		}
 		return a[0]
+	case 39:
+		if len(a) - 5 >= 0 {
+			return a[0]
+		}
+	case 40:
+		if len(a) + (-1) >= 0 {
+			return a[0]
+		}
+	case 41:
+		if len(a) + (-3) >= 0 {
+			return a[0]
+		}
+	case 42:
+		if 0 <= len(a) + (-2) {
+			return a[0]
+		}
+	case 43:
+		// `len(a) - 0 >= 0` is always true, so it tells us nothing: `a` may be nil.
+		if len(a) - 0 >= 0 {
+			return a[0] //want "sliced into"
+		}
+	case 44:
+		// `len(a) + 1 >= 0` is always true, so it tells us nothing: `a` may be nil.
+		if len(a) + 1 >= 0 {
+			return a[0] //want "sliced into"
+		}
+	case 45:
+		// `5 - len(a) >= 0` means `len(a) <= 5`, which tells us nothing: `a` may be nil.
+		if 5 - len(a) >= 0 {
+			return a[0] //want "sliced into"
+		}
 	}
 	return 0
 }


### PR DESCRIPTION
Adds a sound heuristic to `AddNilCheck` so that a conditional that guarantees a slice/map has at least one element marks it as non-nil in the guarded branch. This addresses the false positive called out in #94.

The supported forms are any expression that reduces to `len(s) - k >= 0` with integer `k >= 1`:
- `len(s) - c >= 0` where `c` is a **positive** constant
- `len(s) + c >= 0` where `c` is a **negative** constant

In both cases `len(s) - k >= 0` implies `len(s) >= k >= 1`, so `s` cannot be nil in that branch.

## Details
- New checker (op `token.GEQ`) in `AddNilCheck` backed by the `lenMinusPositiveArg` helper. The existing driver loop derives the converse/inverse/contrapositive automatically, so the following forms are covered for free (shown for `len(a) - 1`):
  - `0 <= len(a) +- c`
  - `len(a) +- c < 0` (non-nil in the false branch)
  - `0 > len(a) +- c` (non-nil in the false branch)

## Soundness
The helper deliberately keeps the match tight so we never conclude non-nil unsoundly:
- The `len(...)` term must be on the **left**, so `c - len(s) >= 0` (which only bounds the length from above) is rejected.
- The offset must be a **constant**, so `len(s) - 1 + b >= 0` is rejected.
- `k >= 1` is required, so the always-true / no-information cases `len(s) - 0 >= 0` and `len(s) + 1 >= 0` are rejected.

## Scope
Limited to the constant-offset arithmetic form above. The broader case from #94 with the length captured into a variable first (`n := len(s); if n == 0 { return }`) is out of scope.

## Testing
- Added cases in `testdata/src/go.uber.org/slices/slices.go` covering the supported forms (`len(a) - 1`, `len(a) - 5`, `len(a) + (-1)`, `len(a) + (-3)`, and their automatic flips, all expecting no error) plus negative cases that must still report (`len(a) - 0 >= 0`, `len(a) + 1 >= 0`, `5 - len(a) >= 0`).