### PR TITLE
typeshelper: follow type aliases, generics, to resolve underlying types

### DIFF
--- a/annotation/util.go
+++ b/annotation/util.go
@@ -65,7 +65,7 @@ func DeepNilabilityOfFuncRet(fn *types.Func, retNum int) ProducingAnnotationTrig
 		return &FuncReturnDeep{
 			TriggerIfDeepNilable: &TriggerIfDeepNilable{
 				Ann:        RetKeyFromRetNum(fn, retNum),
-				NeedsGuard: typeshelper.IsDeeplyMap(retType)},
+				NeedsGuard: typeshelper.IsDeeplyType[*types.Map](retType)},
 		}
 	}
 	return DeepNilabilityAsNamedType(retType)
@@ -79,7 +79,7 @@ func DeepNilabilityOfFld(fld *types.Var) ProducingAnnotationTrigger {
 			TriggerIfDeepNilable: &TriggerIfDeepNilable{
 				Ann: &FieldAnnotationKey{
 					FieldDecl: fld},
-				NeedsGuard: typeshelper.IsDeeplyMap(fld.Type())},
+				NeedsGuard: typeshelper.IsDeeplyType[*types.Map](fld.Type())},
 		}
 	}
 	return DeepNilabilityAsNamedType(fld.Type())
@@ -96,7 +96,7 @@ func DeepNilabilityOfVar(fdecl *types.Func, v *types.Var) ProducingAnnotationTri
 					Ann: &GlobalVarAnnotationKey{
 						VarDecl: v,
 					},
-					NeedsGuard: typeshelper.IsDeeplyMap(v.Type())},
+					NeedsGuard: typeshelper.IsDeeplyType[*types.Map](v.Type())},
 			}
 		}
 		if VarIsParam(fdecl, v) {
@@ -115,7 +115,7 @@ func DeepNilabilityOfVar(fdecl *types.Func, v *types.Var) ProducingAnnotationTri
 				Ann: &LocalVarAnnotationKey{
 					VarDecl: v,
 				},
-				NeedsGuard: typeshelper.IsDeeplyMap(v.Type()),
+				NeedsGuard: typeshelper.IsDeeplyType[*types.Map](v.Type()),
 			},
 		}
 	}
@@ -195,12 +195,12 @@ func paramAsDeepProducer(fdecl *types.Func, param *types.Var) ProducingAnnotatio
 		return &VariadicFuncParamDeep{
 			TriggerIfNilable: &TriggerIfNilable{
 				Ann:        paramKey,
-				NeedsGuard: typeshelper.IsDeeplyMap(param.Type())}}
+				NeedsGuard: typeshelper.IsDeeplyType[*types.Map](param.Type())}}
 	}
 	return &FuncParamDeep{
 		TriggerIfDeepNilable: &TriggerIfDeepNilable{
 			Ann:        paramKey,
-			NeedsGuard: typeshelper.IsDeeplyMap(param.Type())},
+			NeedsGuard: typeshelper.IsDeeplyType[*types.Map](param.Type())},
 	}
 }
 

--- a/assertion/function/assertiontree/backprop.go
+++ b/assertion/function/assertiontree/backprop.go
@@ -491,13 +491,13 @@ func backpropAcrossRange(rootNode *RootAssertionNode, lhs []ast.Expr, rhs ast.Ex
 	case 1:
 		// If we are ranging over a map slice or string with only a single lhs operand, then that
 		// operand will be int-valued.
-		if typeshelper.IsDeeplyMap(rhsType) || typeshelper.IsDeeplySlice(rhsType) || typeshelper.IsDeeplyArrayOrArrayPtr(rhsType) || typeIsString(rhsType) {
+		if typeshelper.IsDeeplyType[*types.Map](rhsType) || typeshelper.IsDeeplyType[*types.Slice](rhsType) || typeshelper.IsDeeplyArrayOrArrayPtr(rhsType) || typeIsString(rhsType) {
 			produceAsIndex(0)
 			return nil
 		}
 		// Iterating over a channel with only a single lhs operand will still result in deeply
 		// produced lhs values.
-		if typeshelper.IsDeeplyChan(rhsType) {
+		if typeshelper.IsDeeplyType[*types.Chan](rhsType) {
 			produceAsDeepRHS(0)
 			return nil
 		}

--- a/assertion/function/assertiontree/backprop.go
+++ b/assertion/function/assertiontree/backprop.go
@@ -491,7 +491,7 @@ func backpropAcrossRange(rootNode *RootAssertionNode, lhs []ast.Expr, rhs ast.Ex
 	case 1:
 		// If we are ranging over a map slice or string with only a single lhs operand, then that
 		// operand will be int-valued.
-		if typeshelper.IsDeeplyMap(rhsType) || typeshelper.IsDeeplySlice(rhsType) || typeshelper.IsDeeplyArray(rhsType) || typeIsString(rhsType) {
+		if typeshelper.IsDeeplyMap(rhsType) || typeshelper.IsDeeplySlice(rhsType) || typeshelper.IsDeeplyArrayOrArrayPtr(rhsType) || typeIsString(rhsType) {
 			produceAsIndex(0)
 			return nil
 		}

--- a/assertion/function/assertiontree/backprop_util.go
+++ b/assertion/function/assertiontree/backprop_util.go
@@ -462,7 +462,7 @@ func typeIsString(t types.Type) bool {
 func exprAsConsumedByAssignment(rootNode *RootAssertionNode, expr ast.Node) *annotation.ConsumeTrigger {
 	if exprType, ok := expr.(*ast.IndexExpr); ok {
 		t := rootNode.Pass().TypesInfo.TypeOf(exprType.X)
-		if typeshelper.IsDeeplyMap(t) {
+		if typeshelper.IsDeeplyType[*types.Map](t) {
 			return &annotation.ConsumeTrigger{
 				Annotation: &annotation.MapWrittenTo{ConsumeTriggerTautology: &annotation.ConsumeTriggerTautology{}},
 				Expr:       exprType.X,

--- a/assertion/function/assertiontree/parse_expr_producer.go
+++ b/assertion/function/assertiontree/parse_expr_producer.go
@@ -479,7 +479,7 @@ func (r *RootAssertionNode) ParseExprAsProducer(expr ast.Expr, doNotTrack bool) 
 		// storage. For example, `var a [4]int; _ = a[:0]` is a nonnil (empty) slice. This holds
 		// regardless of the indices, so we must check it before the `b[_:0:_]` case below (which
 		// would otherwise wrongly treat `a[:0]` as a nilable empty slice).
-		if typeshelper.IsDeeplyArray(r.Pass().TypesInfo.Types[expr.X].Type) {
+		if typeshelper.IsDeeplyArrayOrArrayPtr(r.Pass().TypesInfo.TypeOf(expr.X)) {
 			// Returning nil to indicate the slice expression results in a nonnil slice.
 			return nil, nil
 		}

--- a/assertion/function/assertiontree/rich_check_effect.go
+++ b/assertion/function/assertiontree/rich_check_effect.go
@@ -310,7 +310,7 @@ func NodeTriggersOkRead(rootNode *RootAssertionNode, nonceGenerator *guard.Nonce
 		}
 
 		rhsXType := rootNode.Pass().TypesInfo.Types[rhs.X].Type
-		if typeshelper.IsDeeplyMap(rhsXType) {
+		if typeshelper.IsDeeplyType[*types.Map](rhsXType) {
 			// Create a rich check effect for `v` part of the map read in `v, ok := mp[k]`
 			if lhsValueParsed := parseExpr(rootNode, lhs[0]); lhsValueParsed != nil {
 				// Here, the lhs `value` operand is trackable
@@ -360,7 +360,7 @@ func NodeTriggersOkRead(rootNode *RootAssertionNode, nonceGenerator *guard.Nonce
 		}
 
 		rhsXType := rootNode.Pass().TypesInfo.Types[rhs.X].Type
-		if rhs.Op == token.ARROW && typeshelper.IsDeeplyChan(rhsXType) {
+		if rhs.Op == token.ARROW && typeshelper.IsDeeplyType[*types.Chan](rhsXType) {
 			lhsValueParsed := parseExpr(rootNode, lhs[0])
 			if lhsValueParsed != nil {
 				// here, the lhs `value` operand is trackable

--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -531,7 +531,7 @@ func (r *RootAssertionNode) AddGuardMatch(expr ast.Expr, behavior GuardMatchBeha
 
 func (r *RootAssertionNode) consumeIndexExpr(expr ast.Expr) {
 	t := r.Pass().TypesInfo.Types[expr].Type
-	if typeshelper.IsDeeplySlice(t) {
+	if typeshelper.IsDeeplyType[*types.Slice](t) {
 		r.AddConsumption(&annotation.ConsumeTrigger{
 			Annotation: &annotation.SliceAccess{ConsumeTriggerTautology: &annotation.ConsumeTriggerTautology{}},
 			Expr:       expr,
@@ -811,7 +811,7 @@ func (r *RootAssertionNode) AddComputation(expr ast.Expr) {
 				conf := r.Pass().ResultOf[config.Analyzer].(*config.Config)
 				if conf.IsPkgInScope(funcObj.Pkg()) { // Check 3: invoked method is in scope
 					// Here, `t` can only be of type interface, struct, or named, of which we only support for struct and named types.
-					if !typeshelper.IsDeeplyInterface(r.Pass().TypesInfo.TypeOf(expr.X)) { // Check 4: invoking expression (caller) is of a non-interface type (e.g., struct or named)
+					if !typeshelper.IsDeeplyType[*types.Interface](r.Pass().TypesInfo.TypeOf(expr.X)) { // Check 4: invoking expression (caller) is of a non-interface type (e.g., struct or named)
 						allowNilable = true
 						// We are in the special case of supporting nilable receivers! Can be nilable depending on declaration annotation/inferred nilability.
 						r.AddConsumption(&annotation.ConsumeTrigger{

--- a/assertion/function/assertiontree/var_assertion_node.go
+++ b/assertion/function/assertiontree/var_assertion_node.go
@@ -64,7 +64,7 @@ func (v *varAssertionNode) DefaultTrigger() annotation.ProducingAnnotationTrigge
 	// want to analyze fields of an unassigned struct pointer, since at this point the pointer itself is nil.
 	// TODO: below logic won't be required once we standardize the expression `var s S` by replacing it with `S{}` in the
 	//  preprocessing phase
-	if !typeshelper.IsDeeplyPtr(v.decl.Type()) {
+	if !typeshelper.IsDeeplyType[*types.Pointer](v.decl.Type()) {
 		if structType := typeshelper.AsDeeplyStruct(v.decl.Type()); structType != nil {
 			if v.Root().functionContext.functionConfig.EnableStructInitCheck {
 				v.Root().addProductionForVarFieldNode(v, v.BuildExpr(nil))

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/klauspost/compress v1.18.6
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/goleak v1.3.0
+	golang.org/x/exp/typeparams v0.0.0-20260611194520-c48552f49976
 	golang.org/x/tools v0.45.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+golang.org/x/exp/typeparams v0.0.0-20260611194520-c48552f49976 h1:GTD/WuaexTazIG/SxLOz4rEKZPDVilmVVC2nz4xhwfE=
+golang.org/x/exp/typeparams v0.0.0-20260611194520-c48552f49976/go.mod h1:PqrXSW65cXDZH0k4IeUbhmg/bcAZDbzNz3byBpKCsXo=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
 golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=

--- a/testdata/src/go.uber.org/slices/inference/slices-with-inference.go
+++ b/testdata/src/go.uber.org/slices/inference/slices-with-inference.go
@@ -96,3 +96,26 @@ func helperReturnNonZeroSlicingNonNilProducerForNilableParam(b []int) []int {
 func helperReturnNonZeroSlicingNonNilProducerForNonNilParam(b []int) []int {
 	return b[1:3]
 }
+
+// Aliases of slice types must behave like the aliased slice type itself: indexing a nilable
+// alias-of-slice value gets the same slice-access check (aliases are materialized as
+// *types.Alias since Go 1.23, so they must be explicitly resolved when classifying the operand).
+type sliceAlias = []int
+
+var sliceAliasDummy bool
+
+func mkSliceAlias() sliceAlias {
+	if sliceAliasDummy {
+		return nil
+	}
+	return []int{1}
+}
+
+func testSliceAliasIndex() int {
+	s := mkSliceAlias()
+	if s != nil {
+		return s[0]
+	}
+	t := mkSliceAlias()
+	return t[0] //want "sliced into"
+}

--- a/util/typeshelper/typeshelper.go
+++ b/util/typeshelper/typeshelper.go
@@ -75,99 +75,137 @@ func IsSlice(t types.Type) bool {
 	}
 }
 
-// IsDeeplyArray returns true if `t` is of array type, including
-// transitively through Named types
+// IsDeeplyArray returns true if `t` is of array type, including transitively through named
+// types and aliases, as well as type parameters whose type sets contain only array types.
 func IsDeeplyArray(t types.Type) bool {
-	switch tt := UnwrapPtr(t).(type) {
-	case *types.Array:
-		return true
-	case *types.Named:
-		return IsDeeplyArray(tt.Underlying())
-	}
-	return false
+	return underlyingIs[*types.Array](t)
 }
 
-// IsDeeplySlice returns true if `t` is of slice type, including
-// transitively through Named types
-func IsDeeplySlice(t types.Type) bool {
-	if IsSlice(t) {
-		return true
-	}
-	if t, ok := t.(*types.Named); ok {
-		return IsDeeplySlice(t.Underlying())
-	}
-	return false
+// IsDeeplyArrayOrArrayPtr is like IsDeeplyArray, but additionally accepts pointers to arrays
+// (again resolving named types, aliases, and type parameters). Slice expressions and range
+// statements auto-dereference pointers to arrays, so for them an operand of either type
+// behaves like an array.
+func IsDeeplyArrayOrArrayPtr(t types.Type) bool {
+	return underlyingAlwaysSatisfies(t, func(u types.Type) bool {
+		if ptr, ok := u.(*types.Pointer); ok {
+			u = ptr.Elem().Underlying()
+		}
+		_, ok := u.(*types.Array)
+		return ok
+	})
 }
 
-// IsDeeplyMap returns true if `t` is of map type, including
-// transitively through Named types
-func IsDeeplyMap(t types.Type) bool {
-	if _, ok := t.(*types.Map); ok {
-		return true
-	}
-	if t, ok := t.(*types.Named); ok {
-		return IsDeeplyMap(t.Underlying())
-	}
-	return false
+// underlyingIs reports whether the underlying type of `t` (resolved as described in
+// underlyingAlwaysSatisfies) is a T.
+func underlyingIs[T types.Type](t types.Type) bool {
+	return underlyingAlwaysSatisfies(t, func(u types.Type) bool {
+		_, ok := u.(T)
+		return ok
+	})
 }
 
-// IsDeeplyPtr returns true if `t` is of pointer type, including
-// transitively through Named types
-func IsDeeplyPtr(t types.Type) bool {
-	if _, ok := t.(*types.Pointer); ok {
+// underlyingAlwaysSatisfies reports whether the underlying type of `t` satisfies pred. Named
+// types and aliases are resolved via Underlying(). For type parameters, the underlying type of
+// every term in the constraint's type set must satisfy pred. Since the elements of a constraint
+// interface intersect, this is conservative: the actual type set can only be smaller than the
+// enumerated terms, and type sets we cannot enumerate (such as method-only constraints) yield
+// false.
+func underlyingAlwaysSatisfies(t types.Type, pred func(types.Type) bool) bool {
+	if t == nil {
+		return false
+	}
+	if tp, ok := types.Unalias(t).(*types.TypeParam); ok {
+		iface, isIface := tp.Constraint().Underlying().(*types.Interface)
+		if !isIface {
+			return false
+		}
+		terms := constraintTerms(iface)
+		if len(terms) == 0 {
+			return false
+		}
+		for _, term := range terms {
+			if !pred(term.Underlying()) {
+				return false
+			}
+		}
 		return true
 	}
-	if t, ok := t.(*types.Named); ok {
-		return IsDeeplyPtr(t.Underlying())
-	}
-	return false
+	return pred(t.Underlying())
 }
 
-// IsDeeplyChan returns true if `t` is of channel type, including
-// transitively through Named types
-func IsDeeplyChan(t types.Type) bool {
-	if _, ok := t.(*types.Chan); ok {
-		return true
-	}
-	if t, ok := t.(*types.Named); ok {
-		return IsDeeplyChan(t.Underlying())
-	}
-	return false
-}
-
-// AsDeeplyStruct returns underlying struct type if the type is struct type or a pointer to a struct type
-// returns nil otherwise
-func AsDeeplyStruct(typ types.Type) *types.Struct {
-	if typ, ok := typ.(*types.Struct); ok {
-		return typ
-	}
-
-	if typ, ok := typ.(*types.Named); ok {
-		if resType, ok := typ.Underlying().(*types.Struct); ok {
-			return resType
+// constraintTerms returns the types of all type terms of the constraint interface `iface`,
+// recursing into embedded interfaces, both standalone (`interface{ Elem }`) and as union terms
+// (`interface{ Elem | ~[8]int }` -- go/types does not flatten interface-typed union terms, and
+// such terms are necessarily method-less per the spec). Method-only elements contribute no terms.
+func constraintTerms(iface *types.Interface) []types.Type {
+	var terms []types.Type
+	for i := 0; i < iface.NumEmbeddeds(); i++ {
+		switch e := types.Unalias(iface.EmbeddedType(i)).(type) {
+		case *types.Union:
+			for j := 0; j < e.Len(); j++ {
+				if emb, isIface := e.Term(j).Type().Underlying().(*types.Interface); isIface {
+					terms = append(terms, constraintTerms(emb)...)
+				} else {
+					terms = append(terms, e.Term(j).Type())
+				}
+			}
+		default:
+			if emb, isIface := e.Underlying().(*types.Interface); isIface {
+				terms = append(terms, constraintTerms(emb)...)
+			} else {
+				terms = append(terms, e)
+			}
 		}
 	}
+	return terms
+}
 
-	if ptType, ok := typ.(*types.Pointer); ok {
-		if namedType, ok := types.Unalias(ptType.Elem()).(*types.Named); ok {
-			if resType, ok := namedType.Underlying().(*types.Struct); ok {
-				return resType
+// IsDeeplySlice returns true if `t` is of slice type, including transitively through named
+// types and aliases, as well as type parameters whose type sets contain only slice types.
+func IsDeeplySlice(t types.Type) bool {
+	return underlyingIs[*types.Slice](t)
+}
+
+// IsDeeplyMap returns true if `t` is of map type, including transitively through named types
+// and aliases, as well as type parameters whose type sets contain only map types.
+func IsDeeplyMap(t types.Type) bool {
+	return underlyingIs[*types.Map](t)
+}
+
+// IsDeeplyPtr returns true if `t` is of pointer type, including transitively through named
+// types and aliases, as well as type parameters whose type sets contain only pointer types.
+func IsDeeplyPtr(t types.Type) bool {
+	return underlyingIs[*types.Pointer](t)
+}
+
+// IsDeeplyChan returns true if `t` is of channel type, including transitively through named
+// types and aliases, as well as type parameters whose type sets contain only channel types.
+func IsDeeplyChan(t types.Type) bool {
+	return underlyingIs[*types.Chan](t)
+}
+
+// AsDeeplyStruct returns the underlying struct type if `typ` is a struct or a pointer to a
+// named struct (resolving named types and aliases). Returns nil otherwise.
+// Note: pointer-to-anonymous-struct is intentionally excluded — the struct-init analyzer does
+// not yet handle anonymous struct initialization.
+func AsDeeplyStruct(typ types.Type) *types.Struct {
+	if s, ok := typ.Underlying().(*types.Struct); ok {
+		return s
+	}
+	if ptr, ok := types.Unalias(typ).(*types.Pointer); ok {
+		if named, ok := types.Unalias(ptr.Elem()).(*types.Named); ok {
+			if s, ok := named.Underlying().(*types.Struct); ok {
+				return s
 			}
 		}
 	}
 	return nil
 }
 
-// IsDeeplyInterface returns true if `t` is of struct type, including
-// transitively through Named types
+// IsDeeplyInterface returns true if `t` is of interface type, including transitively through
+// named types and aliases, as well as type parameters whose type sets contain only interface types.
 func IsDeeplyInterface(t types.Type) bool {
-	if _, ok := t.(*types.Interface); ok {
-		return true
-	}
-	if t, ok := t.(*types.Named); ok {
-		return IsDeeplyInterface(t.Underlying())
-	}
-	return false
+	return underlyingIs[*types.Interface](t)
 }
 
 // IsPointer checks whether the type `t` is an explicit or implicit pointer type, which could also be of deep type.

--- a/util/typeshelper/typeshelper.go
+++ b/util/typeshelper/typeshelper.go
@@ -20,6 +20,7 @@ import (
 	"go/types"
 
 	"go.uber.org/nilaway/util/tokenhelper"
+	"golang.org/x/exp/typeparams"
 )
 
 // ErrorType is the type of the builtin "error" interface.
@@ -75,13 +76,17 @@ func IsSlice(t types.Type) bool {
 	}
 }
 
-// IsDeeplyArray returns true if `t` is of array type, including transitively through named
-// types and aliases, as well as type parameters whose type sets contain only array types.
-func IsDeeplyArray(t types.Type) bool {
-	return underlyingIs[*types.Array](t)
+// IsDeeplyType returns true if the underlying type of `t` is a T (e.g., *types.Array), resolving
+// named types and aliases, as well as type parameters whose type sets contain only such types
+// (see underlyingAlwaysSatisfies for the exact type parameter handling).
+func IsDeeplyType[T types.Type](t types.Type) bool {
+	return underlyingAlwaysSatisfies(t, func(u types.Type) bool {
+		_, ok := u.(T)
+		return ok
+	})
 }
 
-// IsDeeplyArrayOrArrayPtr is like IsDeeplyArray, but additionally accepts pointers to arrays
+// IsDeeplyArrayOrArrayPtr is like IsDeeplyType[*types.Array], but additionally accepts pointers to arrays
 // (again resolving named types, aliases, and type parameters). Slice expressions and range
 // statements auto-dereference pointers to arrays, so for them an operand of either type
 // behaves like an array.
@@ -95,93 +100,31 @@ func IsDeeplyArrayOrArrayPtr(t types.Type) bool {
 	})
 }
 
-// underlyingIs reports whether the underlying type of `t` (resolved as described in
-// underlyingAlwaysSatisfies) is a T.
-func underlyingIs[T types.Type](t types.Type) bool {
-	return underlyingAlwaysSatisfies(t, func(u types.Type) bool {
-		_, ok := u.(T)
-		return ok
-	})
-}
-
 // underlyingAlwaysSatisfies reports whether the underlying type of `t` satisfies pred. Named
 // types and aliases are resolved via Underlying(). For type parameters, the underlying type of
-// every term in the constraint's type set must satisfy pred. Since the elements of a constraint
-// interface intersect, this is conservative: the actual type set can only be smaller than the
-// enumerated terms, and type sets we cannot enumerate (such as method-only constraints) yield
-// false.
+// every term in the constraint's normalized type set must satisfy pred. This is conservative:
+// type parameters with no structural restriction (e.g. `any`, or method-only constraints), an
+// empty type set, or a type set too complex to normalize all yield false.
 func underlyingAlwaysSatisfies(t types.Type, pred func(types.Type) bool) bool {
 	if t == nil {
 		return false
 	}
 	if tp, ok := types.Unalias(t).(*types.TypeParam); ok {
-		iface, isIface := tp.Constraint().Underlying().(*types.Interface)
-		if !isIface {
-			return false
-		}
-		terms := constraintTerms(iface)
-		if len(terms) == 0 {
+		// NormalTerms returns nil (no error) for an unconstrained type set, ErrEmptyTypeSet for
+		// an empty one, and an error for constraints that are invalid or exceed complexity
+		// bounds; in every such case we conservatively return false.
+		terms, err := typeparams.NormalTerms(tp)
+		if err != nil || len(terms) == 0 {
 			return false
 		}
 		for _, term := range terms {
-			if !pred(term.Underlying()) {
+			if !pred(term.Type().Underlying()) {
 				return false
 			}
 		}
 		return true
 	}
 	return pred(t.Underlying())
-}
-
-// constraintTerms returns the types of all type terms of the constraint interface `iface`,
-// recursing into embedded interfaces, both standalone (`interface{ Elem }`) and as union terms
-// (`interface{ Elem | ~[8]int }` -- go/types does not flatten interface-typed union terms, and
-// such terms are necessarily method-less per the spec). Method-only elements contribute no terms.
-func constraintTerms(iface *types.Interface) []types.Type {
-	var terms []types.Type
-	for i := 0; i < iface.NumEmbeddeds(); i++ {
-		switch e := types.Unalias(iface.EmbeddedType(i)).(type) {
-		case *types.Union:
-			for j := 0; j < e.Len(); j++ {
-				if emb, isIface := e.Term(j).Type().Underlying().(*types.Interface); isIface {
-					terms = append(terms, constraintTerms(emb)...)
-				} else {
-					terms = append(terms, e.Term(j).Type())
-				}
-			}
-		default:
-			if emb, isIface := e.Underlying().(*types.Interface); isIface {
-				terms = append(terms, constraintTerms(emb)...)
-			} else {
-				terms = append(terms, e)
-			}
-		}
-	}
-	return terms
-}
-
-// IsDeeplySlice returns true if `t` is of slice type, including transitively through named
-// types and aliases, as well as type parameters whose type sets contain only slice types.
-func IsDeeplySlice(t types.Type) bool {
-	return underlyingIs[*types.Slice](t)
-}
-
-// IsDeeplyMap returns true if `t` is of map type, including transitively through named types
-// and aliases, as well as type parameters whose type sets contain only map types.
-func IsDeeplyMap(t types.Type) bool {
-	return underlyingIs[*types.Map](t)
-}
-
-// IsDeeplyPtr returns true if `t` is of pointer type, including transitively through named
-// types and aliases, as well as type parameters whose type sets contain only pointer types.
-func IsDeeplyPtr(t types.Type) bool {
-	return underlyingIs[*types.Pointer](t)
-}
-
-// IsDeeplyChan returns true if `t` is of channel type, including transitively through named
-// types and aliases, as well as type parameters whose type sets contain only channel types.
-func IsDeeplyChan(t types.Type) bool {
-	return underlyingIs[*types.Chan](t)
 }
 
 // AsDeeplyStruct returns the underlying struct type if `typ` is a struct or a pointer to a
@@ -202,21 +145,15 @@ func AsDeeplyStruct(typ types.Type) *types.Struct {
 	return nil
 }
 
-// IsDeeplyInterface returns true if `t` is of interface type, including transitively through
-// named types and aliases, as well as type parameters whose type sets contain only interface types.
-func IsDeeplyInterface(t types.Type) bool {
-	return underlyingIs[*types.Interface](t)
-}
-
 // IsPointer checks whether the type `t` is an explicit or implicit pointer type, which could also be of deep type.
 // Examples of explicit pointer types are `*int`, `*S`, etc.
 // Examples of implicit pointer types are `[]int`, `map[string]*S`, `chan int`, etc.
 func IsPointer(t types.Type) bool {
-	return IsDeeplyPtr(t) ||
-		IsDeeplySlice(t) ||
-		IsDeeplyMap(t) ||
-		IsDeeplyArray(t) ||
-		IsDeeplyChan(t)
+	return IsDeeplyType[*types.Pointer](t) ||
+		IsDeeplyType[*types.Slice](t) ||
+		IsDeeplyType[*types.Map](t) ||
+		IsDeeplyType[*types.Array](t) ||
+		IsDeeplyType[*types.Chan](t)
 }
 
 // UnwrapPtr unwraps a pointer type and returns the element type. For all other types it returns

--- a/util/typeshelper/typeshelper_test.go
+++ b/util/typeshelper/typeshelper_test.go
@@ -96,7 +96,7 @@ func Generic[A ~[8]int, E ArrayConstraint, U ~[8]int | ~[16]int, X ~[8]int | ~[]
 		{"TypeParamSlice", typeParamOf("s"), false, false},
 		{"TypeParamAny", typeParamOf("m"), false, false},
 		// Unions whose terms are themselves (method-less) interfaces are not flattened by
-		// go/types, so constraintTerms must recurse into them.
+		// go/types, so normalization must recurse into them.
 		{"TypeParamInterfaceUnionArrays", typeParamOf("iu"), true, true},
 		{"TypeParamInterfaceUnionMixed", typeParamOf("ix"), false, false},
 		{"TypeParamPtrToArray", typeParamOf("p"), false, true},
@@ -105,7 +105,7 @@ func Generic[A ~[8]int, E ArrayConstraint, U ~[8]int | ~[16]int, X ~[8]int | ~[]
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			require.Equal(t, tt.wantArray, IsDeeplyArray(tt.typ), "IsDeeplyArray(%v)", tt.typ)
+			require.Equal(t, tt.wantArray, IsDeeplyType[*types.Array](tt.typ), "IsDeeplyType[*types.Array](%v)", tt.typ)
 			require.Equal(t, tt.wantOrArrayPtr, IsDeeplyArrayOrArrayPtr(tt.typ), "IsDeeplyArrayOrArrayPtr(%v)", tt.typ)
 		})
 	}

--- a/util/typeshelper/typeshelper_test.go
+++ b/util/typeshelper/typeshelper_test.go
@@ -15,12 +15,101 @@
 package typeshelper
 
 import (
+	"go/ast"
+	"go/parser"
 	"go/token"
 	"go/types"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestIsDeeplyArray(t *testing.T) {
+	t.Parallel()
+
+	const src = `package testpkg
+
+type NamedArray [8]int
+type NamedArray2 NamedArray
+type AliasArray = [8]int
+type NamedArrayPtr *[8]int
+type ArrayConstraint interface{ ~[8]int }
+type ArrayConstraint16 interface{ ~[16]int }
+
+var (
+	Array      [8]int
+	Slice      []int
+	NamedArr   NamedArray
+	NamedArr2  NamedArray2
+	AliasArr   AliasArray
+	Ptr        *[8]int
+	NamedPtr   NamedArrayPtr
+	Int        int
+	PtrToSlice *[]int
+)
+
+func Generic[A ~[8]int, E ArrayConstraint, U ~[8]int | ~[16]int, X ~[8]int | ~[]int, S ~[]int, M any, IU ArrayConstraint | ArrayConstraint16, IX ArrayConstraint | ~[]int, P ~*[8]int](a A, e E, u U, x X, s S, m M, iu IU, ix IX, p P) {}
+`
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "test.go", src, 0)
+	require.NoError(t, err)
+	pkg, err := (&types.Config{}).Check("testpkg", fset, []*ast.File{f}, nil)
+	require.NoError(t, err)
+
+	typeOf := func(name string) types.Type {
+		obj := pkg.Scope().Lookup(name)
+		require.NotNil(t, obj, "object %q not found", name)
+		return obj.Type()
+	}
+	params := pkg.Scope().Lookup("Generic").(*types.Func).Signature().Params()
+	typeParamOf := func(name string) types.Type {
+		for i := 0; i < params.Len(); i++ {
+			if p := params.At(i); p.Name() == name {
+				return p.Type()
+			}
+		}
+		require.Failf(t, "parameter not found", "parameter %q", name)
+		return nil
+	}
+
+	tests := []struct {
+		name           string
+		typ            types.Type
+		wantArray      bool
+		wantOrArrayPtr bool
+	}{
+		{"Nil", nil, false, false},
+		{"Array", typeOf("Array"), true, true},
+		{"Slice", typeOf("Slice"), false, false},
+		{"NamedArray", typeOf("NamedArr"), true, true},
+		{"NamedArrayOfNamedArray", typeOf("NamedArr2"), true, true},
+		{"AliasArray", typeOf("AliasArr"), true, true},
+		{"PtrToArray", typeOf("Ptr"), false, true},
+		{"NamedPtrToArray", typeOf("NamedPtr"), false, true},
+		{"Int", typeOf("Int"), false, false},
+		{"PtrToSlice", typeOf("PtrToSlice"), false, false},
+		{"TypeParamArray", typeParamOf("a"), true, true},
+		{"TypeParamEmbeddedArrayConstraint", typeParamOf("e"), true, true},
+		{"TypeParamArrayUnion", typeParamOf("u"), true, true},
+		{"TypeParamMixedUnion", typeParamOf("x"), false, false},
+		{"TypeParamSlice", typeParamOf("s"), false, false},
+		{"TypeParamAny", typeParamOf("m"), false, false},
+		// Unions whose terms are themselves (method-less) interfaces are not flattened by
+		// go/types, so constraintTerms must recurse into them.
+		{"TypeParamInterfaceUnionArrays", typeParamOf("iu"), true, true},
+		{"TypeParamInterfaceUnionMixed", typeParamOf("ix"), false, false},
+		{"TypeParamPtrToArray", typeParamOf("p"), false, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.wantArray, IsDeeplyArray(tt.typ), "IsDeeplyArray(%v)", tt.typ)
+			require.Equal(t, tt.wantOrArrayPtr, IsDeeplyArrayOrArrayPtr(tt.typ), "IsDeeplyArrayOrArrayPtr(%v)", tt.typ)
+		})
+	}
+}
 
 func TestIsIterType(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
While doing some prework for my next commit I realized that these don't resolve correctly, hiding some types from being checked for nilness.

Claude-assisted, human-reviewed.