### PR TITLE
Fix contract inference using the receiver instead of the declared parameter

### DIFF
--- a/assertion/function/functioncontracts/analyzer_test.go
+++ b/assertion/function/functioncontracts/analyzer_test.go
@@ -122,6 +122,9 @@ func TestInfer(t *testing.T) {
 		getFuncObj(pass, "unknownToUnknownButSameValue"): {
 			Contract{Ins: []ContractVal{NonNil}, Outs: []ContractVal{NonNil}},
 		},
+		getFuncObj(pass, "SI2.cloneLike"): {
+			Contract{Ins: []ContractVal{NonNil}, Outs: []ContractVal{NonNil}},
+		},
 		// other functions should not exist in the map as the contract nonnil->nonnil does not hold
 		// for them.
 
@@ -185,6 +188,23 @@ func getFuncObj(pass *analysis.Pass, name string) *types.Func {
 	}
 	if len(parts) > 2 {
 		panic(fmt.Sprintf("invalid function name to look up, expected name or pkg.name, got %q", name))
+	}
+	// A "Type.Method" reference to a method of a named type in the current package.
+	if obj := pass.Pkg.Scope().Lookup(parts[0]); obj != nil {
+		typeName, ok := obj.(*types.TypeName)
+		if !ok {
+			panic(fmt.Sprintf("expected %q to be a type name in the current package, got %v", parts[0], obj))
+		}
+		named, ok := typeName.Type().(*types.Named)
+		if !ok {
+			panic(fmt.Sprintf("expected %q to be a named type, got %v", parts[0], typeName.Type()))
+		}
+		for i := 0; i < named.NumMethods(); i++ {
+			if m := named.Method(i); m.Name() == parts[1] {
+				return m
+			}
+		}
+		panic(fmt.Sprintf("cannot find method %q", name))
 	}
 	for _, imported := range pass.Pkg.Imports() {
 		if imported.Name() == parts[0] {

--- a/assertion/function/functioncontracts/infer.go
+++ b/assertion/function/functioncontracts/infer.go
@@ -208,7 +208,13 @@ func deriveContracts(
 ) Contracts {
 	// TODO: verify other or multiple param/return contracts in the future; for now we consider
 	//  contract(nonnil->nonnil) only.
-	param := fn.Params[0]
+	//
+	// For methods, fn.Params[0] is the receiver, while the contract (and its application at call
+	// sites, which uses the declared argument and parameter annotation sites) is about the
+	// declared parameter, so we skip the receiver here. Otherwise, fluent methods that return
+	// their receiver (e.g., `func (z *Int) Neg(x *Int) *Int { ...; return z }`) would incorrectly
+	// match the `param == ret` rule below via the receiver and be given a contract about `x`.
+	param := fn.Params[len(fn.Params)-fn.Signature.Params().Len()]
 	nonnilOrUnknownParamChoices := 0
 	nilParamChoices := 0
 	nonnilRetChoices := 0

--- a/assertion/function/functioncontracts/testdata/src/go.uber.org/infer/main.go
+++ b/assertion/function/functioncontracts/testdata/src/go.uber.org/infer/main.go
@@ -325,3 +325,22 @@ func twoCondsMerge(x *STR) *STR {
 func unknownToUnknownButSameValue(x *int) *int {
 	return x
 }
+
+type SI2 struct{}
+
+// contract(nonnil -> nonnil) does not hold: the contract is about the declared parameter x, not
+// the receiver, and this fluent method returns its receiver, which is unrelated to x. (In SSA the
+// receiver is fn.Params[0]; if we did not skip it, the receiver-valued return would incorrectly
+// match the param == ret rule and produce a contract about x.)
+func (s *SI2) fluent(x *SI2) *SI2 {
+	_ = x
+	return s
+}
+
+// contract(nonnil -> nonnil) holds for the declared parameter of a method.
+func (s *SI2) cloneLike(x *SI2) *SI2 {
+	if x == nil {
+		return nil
+	}
+	return new(SI2)
+}


### PR DESCRIPTION
In SSA, fn.Params[0] is the receiver for methods, while contract inference gates on (and call-site application uses) the declared parameter. As a result, fluent methods returning their receiver (e.g., `func (z *Int) Neg(x *Int) *Int { ...; return z }`) incorrectly matched the param == ret rule via the receiver and were given contract(nonnil -> nonnil) about `x`. Skip the receiver when selecting the parameter to verify the contract against.

Claude-assisted, human-reviewed.