### PR TITLE
Improve MergeFullTriggers to avoid new allocation

### DIFF
--- a/annotation/full_trigger.go
+++ b/annotation/full_trigger.go
@@ -168,8 +168,8 @@ func FullTriggerSlicesEq(left, right []FullTrigger) bool {
 // Consumer.GuardMatched into a single trigger with Consume.GuardMatched = false. In all other cases - such as
 // checking fixed point in propagation, the function FullTriggersEq
 // that does observe GuardMatched should be used instead of this function.
+// This function modifies the `left` slice, by appending the non-duplicate right triggers into it.
 func MergeFullTriggers(left []FullTrigger, right ...FullTrigger) []FullTrigger {
-	// We append non-duplicate right triggers in place into `left` slice.
 	// `left` is dedup-maintained by construction, so we compare each right trigger only against the
 	// original `left` prefix (origLen) and stop at the first match.
 	origLen := len(left)

--- a/annotation/full_trigger.go
+++ b/annotation/full_trigger.go
@@ -169,15 +169,9 @@ func FullTriggerSlicesEq(left, right []FullTrigger) bool {
 // checking fixed point in propagation, the function FullTriggersEq
 // that does observe GuardMatched should be used instead of this function.
 func MergeFullTriggers(left []FullTrigger, right ...FullTrigger) []FullTrigger {
-	// We append non-duplicate right triggers in place into `left` rather than allocating a fresh
-	// slice and copying all of `left` on every call. Callers always reassign the result
-	// (`x = MergeFullTriggers(x, ...)`) and don't alias `left`, so mutating it is safe. This turns
-	// one-at-a-time accumulation (the AddNewTriggers backprop hot path) from O(K^2) into amortized
-	// O(1) per add.
-	//
+	// We append non-duplicate right triggers in place into `left` slice.
 	// `left` is dedup-maintained by construction, so we compare each right trigger only against the
-	// original `left` prefix (origLen) and stop at the first match. Right triggers are not deduped
-	// against each other, matching the prior behavior.
+	// original `left` prefix (origLen) and stop at the first match.
 	origLen := len(left)
 	for _, r := range right {
 		matched := false

--- a/annotation/full_trigger.go
+++ b/annotation/full_trigger.go
@@ -169,40 +169,36 @@ func FullTriggerSlicesEq(left, right []FullTrigger) bool {
 // checking fixed point in propagation, the function FullTriggersEq
 // that does observe GuardMatched should be used instead of this function.
 func MergeFullTriggers(left []FullTrigger, right ...FullTrigger) []FullTrigger {
-	var out []FullTrigger
-	updateLeftGuard := make(map[int]bool)
-	skipRight := make(map[int]bool)
-
-	for i, l := range left {
-		for j, r := range right {
-			if !l.equalsModuloGuardMatched(r) {
+	// We append non-duplicate right triggers in place into `left` rather than allocating a fresh
+	// slice and copying all of `left` on every call. Callers always reassign the result
+	// (`x = MergeFullTriggers(x, ...)`) and don't alias `left`, so mutating it is safe. This turns
+	// one-at-a-time accumulation (the AddNewTriggers backprop hot path) from O(K^2) into amortized
+	// O(1) per add.
+	//
+	// `left` is dedup-maintained by construction, so we compare each right trigger only against the
+	// original `left` prefix (origLen) and stop at the first match. Right triggers are not deduped
+	// against each other, matching the prior behavior.
+	origLen := len(left)
+	for _, r := range right {
+		matched := false
+		for i := range origLen {
+			if !left[i].equalsModuloGuardMatched(r) {
 				continue
 			}
-
-			// Now we know that the two triggers are equal modulo GuardMatched. We should skip adding the right trigger
-			// to `out`. In case of a mismatch in GuardMatched, we update the left trigger to set GuardMatched = false,
-			// because right now, there is no use for guards in FullTriggers. If this changes, then make sure the merged
-			// trigger gets the intersection of the prior guard sets
-			if l.Consumer.GuardMatched && !r.Consumer.GuardMatched {
-				updateLeftGuard[i] = true
+			// Equal modulo GuardMatched, so drop the right trigger. On a GuardMatched mismatch we
+			// clear the left trigger's guard (guards are currently unused in FullTriggers; if that
+			// changes, use the intersection of the prior guard sets instead).
+			if left[i].Consumer.GuardMatched && !r.Consumer.GuardMatched {
+				left[i].Consumer.Guards = guard.NoGuards()
+				left[i].Consumer.GuardMatched = false
 			}
-			skipRight[j] = true
+			matched = true
+			break
+		}
+		if !matched {
+			left = append(left, r)
 		}
 	}
 
-	for i, l := range left {
-		if updateLeftGuard[i] {
-			l.Consumer.Guards = guard.NoGuards()
-			l.Consumer.GuardMatched = false
-		}
-		out = append(out, l)
-	}
-
-	for j, r := range right {
-		if !skipRight[j] {
-			out = append(out, r)
-		}
-	}
-
-	return out
+	return left
 }


### PR DESCRIPTION
## Summary
~10% faster wall-clock and −14% total allocations (−12.9 GB) on full stdlib, output unchanged.

## Method
- Workload — the project's own golden-test stdlib command:
  `nilaway -include-errors-in-files / -json -pretty-print=false -group-error-messages=true std`
- Hardware: Apple Silicon, 16 cores, `GOMAXPROCS=16`. 1 warm-up + 8 measured iterations per variant,
  **interleaved** (base, fix, base, fix …) to cancel thermal/background drift.

## Correctness
Output is **byte-for-byte identical** between base and fix (2,091,004 bytes of JSON diagnostics).
A perf-only change, no behavior change.

## Wall-clock & CPU (8 interleaved iterations)

| metric | base median | fix median | Δ |
|--------|------------:|-----------:|----:|
| real (wall) | 15.11 s | 13.63 s | **−9.8%** |
| user (CPU)  | 182.15 s | 162.88 s | **−10.6%** |
| sys (CPU)   | 11.50 s | 10.40 s | −9.6% |

Distributions do not overlap (base min 14.57 s > fix max 13.87 s) and the fix is also less noisy
(real σ: 0.44 s → 0.13 s). ~10% wall-clock speedup on full stdlib.

## Allocation / GC churn (heap profile, `alloc_space`)

| | total allocated over run |
|--|--:|
| base | 89.76 GB |
| fix  | 76.87 GB |
| **Δ** | **−12.89 GB (−14.4%)** |

`MergeFullTriggers` flat allocations (per `pprof -list`):
- base: **12.80 GB** (12.36 GB on the old `out = append(out, l)` full-copy line + 0.44 GB)
- fix:  **0.61 GB** (in-place `left = append(left, r)`)

The ~12.2 GB reduction in this single function accounts for essentially the entire 12.9 GB total
drop — direct confirmation that the per-call copy of `left` was the dominant allocation source.

