### PR TITLE
test(structinit-v2): lay down struct-init-v2 testdata suite

### DIFF
--- a/nilaway_test.go
+++ b/nilaway_test.go
@@ -103,6 +103,32 @@ func TestStructInit(t *testing.T) { //nolint:paralleltest
 	analysistest.Run(t, testdata, Analyzer, "go.uber.org/structinit/funcreturnfields", "go.uber.org/structinit/local", "go.uber.org/structinit/global", "go.uber.org/structinit/paramfield", "go.uber.org/structinit/paramsideeffect", "go.uber.org/structinit/defaultfield")
 }
 
+func TestStructInitV2(t *testing.T) { //nolint:paralleltest
+	//	err := config.Analyzer.Flags.Set(config.StructInitV2EnableFlag, "true")
+	//	require.NoError(t, err)
+	//	defer func() {
+	//		err := config.Analyzer.Flags.Set(config.StructInitV2EnableFlag, "false")
+	//		require.NoError(t, err)
+	//	}()
+	//
+	//	testdata := analysistest.TestData()
+	//	analysistest.Run(t, testdata, Analyzer,
+	//		"go.uber.org/structinitv2/local",
+	//		"go.uber.org/structinitv2/global",
+	//		"go.uber.org/structinitv2/defaultfield",
+	//		"go.uber.org/structinitv2/deep",
+	//		"go.uber.org/structinitv2/paramfield",
+	//		"go.uber.org/structinitv2/paramsideeffect",
+	//		"go.uber.org/structinitv2/funcreturnfields",
+	//		"go.uber.org/structinitv2/returnshape/app",
+	//		"go.uber.org/structinitv2/crosspkg/app",
+	//		"go.uber.org/structinitv2/crosspkgside/app",
+	//		"go.uber.org/structinitv2/limitations",
+	//	)
+	//
+	t.Skip("struct-init-v2 testdata is not wired")
+}
+
 func TestAnonymousFunction(t *testing.T) { //nolint:paralleltest
 	// We specifically do not set this test to be parallel since we need to enable the
 	// experimental support for anonymous function to test this feature.

--- a/testdata/src/go.uber.org/structinitv2/crosspkg/app/app.go
+++ b/testdata/src/go.uber.org/structinitv2/crosspkg/app/app.go
@@ -1,0 +1,37 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package app checks that two sibling packages with same-named constructors returning the same
+// shared type keep distinct cross-package inference sites: p1.New always sets Aptr while p2.New
+// leaves it nil, so only the deref of p2.New().Aptr must be flagged.
+package app
+
+import (
+	"go.uber.org/structinitv2/crosspkg/p1"
+	"go.uber.org/structinitv2/crosspkg/p2"
+)
+
+func usePtr(p *int) { print(p) }
+
+// safeUsesP1 dereferences a field that p1.New always initializes: no error.
+func safeUsesP1() {
+	a := p1.New()
+	usePtr(a.Aptr.Ptr)
+}
+
+// unsafeUsesP2 dereferences a field that p2.New leaves nil: error.
+func unsafeUsesP2() {
+	a := p2.New()
+	usePtr(a.Aptr.Ptr) //want "uninitialized field `Aptr`"
+}

--- a/testdata/src/go.uber.org/structinitv2/crosspkg/p1/p1.go
+++ b/testdata/src/go.uber.org/structinitv2/crosspkg/p1/p1.go
@@ -1,0 +1,23 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package p1 has a constructor New that always initializes the Aptr field. See package app.
+package p1
+
+import "go.uber.org/structinitv2/crosspkg/shared"
+
+// New always initializes Aptr.
+func New() *shared.A {
+	return &shared.A{Aptr: &shared.Leaf{}}
+}

--- a/testdata/src/go.uber.org/structinitv2/crosspkg/p2/p2.go
+++ b/testdata/src/go.uber.org/structinitv2/crosspkg/p2/p2.go
@@ -1,0 +1,24 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package p2 has a constructor New (same name as p1.New) that leaves the Aptr field nil. See
+// package app.
+package p2
+
+import "go.uber.org/structinitv2/crosspkg/shared"
+
+// New leaves Aptr uninitialized.
+func New() *shared.A {
+	return &shared.A{}
+}

--- a/testdata/src/go.uber.org/structinitv2/crosspkg/shared/shared.go
+++ b/testdata/src/go.uber.org/structinitv2/crosspkg/shared/shared.go
@@ -1,0 +1,28 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package shared defines a struct type returned by both sibling constructors p1.New and p2.New.
+// See package app.
+package shared
+
+// A is returned by both p1.New and p2.New.
+type A struct {
+	Ptr  *int
+	Aptr *Leaf
+}
+
+// Leaf is the dereference target of A.Aptr.
+type Leaf struct {
+	Ptr *int
+}

--- a/testdata/src/go.uber.org/structinitv2/crosspkgside/app/app.go
+++ b/testdata/src/go.uber.org/structinitv2/crosspkgside/app/app.go
@@ -1,0 +1,35 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package app checks cross-package parameter side effects: a function in package writer nils a
+// field of its argument, and the caller must observe the post-call nil at the dereference.
+package app
+
+import "go.uber.org/structinitv2/crosspkgside/writer"
+
+// tCrossPkgSideEffect passes a value with an initialized Child to a cross-package function that
+// nils it; the post-call deref of the now-nil Child is reported.
+func tCrossPkgSideEffect() *int {
+	b := &writer.Node{Child: &writer.Leaf{}}
+	writer.WriteNil(b) // sets b.Child = nil across the package boundary
+	return b.Child.Ptr //want "field `Child` of param 0 of `WriteNil` accessed field `Ptr`"
+}
+
+// tCrossPkgDeepSideEffect passes a value with an initialized Mid.Child to a cross-package function
+// that nils the nested field; the post-call deref of the now-nil Mid.Child is reported.
+func tCrossPkgDeepSideEffect() *int {
+	b := &writer.Outer{Mid: &writer.Node{Child: &writer.Leaf{}}}
+	writer.WriteDeepNil(b) // sets b.Mid.Child = nil across the package boundary
+	return b.Mid.Child.Ptr //want "field `Mid.Child` of param 0 of `WriteDeepNil` accessed field `Ptr`"
+}

--- a/testdata/src/go.uber.org/structinitv2/crosspkgside/writer/writer.go
+++ b/testdata/src/go.uber.org/structinitv2/crosspkgside/writer/writer.go
@@ -1,0 +1,42 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package writer defines struct types and functions that mutate a field of their parameter. It is
+// imported by the sibling app package to exercise the cross-package parameter-side-effect boundary.
+package writer
+
+// Leaf is the dereference target.
+type Leaf struct {
+	Ptr *int
+}
+
+// Node holds the nilable field that is mutated across the package boundary.
+type Node struct {
+	Child *Leaf
+}
+
+// WriteNil sets the Child field of its parameter to nil.
+func WriteNil(x *Node) {
+	x.Child = nil
+}
+
+// Outer nests a Node, giving a depth-2 field path (Mid.Child).
+type Outer struct {
+	Mid *Node
+}
+
+// WriteDeepNil sets the nested Mid.Child field of its parameter to nil.
+func WriteDeepNil(o *Outer) {
+	o.Mid.Child = nil
+}

--- a/testdata/src/go.uber.org/structinitv2/deep/deep.go
+++ b/testdata/src/go.uber.org/structinitv2/deep/deep.go
@@ -1,0 +1,93 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package deep checks that field nilability is tracked at depth >= 2, both within a function and
+// across return and parameter boundaries. Depth is modeled with a chain of distinct types
+// (A -> A2 -> A3 -> A4).
+package deep
+
+type A struct {
+	ptr  *int
+	aptr *A2
+}
+
+type A2 struct {
+	ptr  *int
+	aptr *A3
+}
+
+type A3 struct {
+	ptr  *int
+	aptr *A4
+}
+
+type A4 struct {
+	ptr *int
+}
+
+// --- intra-procedural depth ---
+
+func depth2Nil() {
+	a := &A{aptr: &A2{}}   // a.aptr.aptr is nil
+	print(a.aptr.aptr.ptr) //want "uninitialized field `aptr`"
+}
+
+func depth2Ok() {
+	a := &A{aptr: &A2{aptr: &A3{}}}
+	print(a.aptr.aptr.ptr)
+}
+
+func depth3Nil() {
+	a := &A{aptr: &A2{aptr: &A3{}}} // a.aptr.aptr.aptr is nil
+	print(a.aptr.aptr.aptr.ptr)     //want "uninitialized field `aptr`"
+}
+
+func depth3Ok() {
+	a := &A{aptr: &A2{aptr: &A3{aptr: &A4{}}}}
+	print(a.aptr.aptr.aptr.ptr)
+}
+
+// --- across the return boundary ---
+
+func giveNil() *A { return &A{aptr: &A2{}} } // result.aptr.aptr is nil
+
+func useReturnNil() {
+	b := giveNil()
+	print(b.aptr.aptr.ptr) //want "uninitialized field `aptr`"
+}
+
+func giveOk() *A { return &A{aptr: &A2{aptr: &A3{}}} }
+
+func useReturnOk() {
+	b := giveOk()
+	print(b.aptr.aptr.ptr)
+}
+
+// --- across the parameter boundary ---
+
+func takesDeep(c *A) {
+	print(c.aptr.aptr.ptr) //want "uninitialized field `aptr`"
+}
+
+func callDeepNil() {
+	takesDeep(&A{aptr: &A2{}}) // supplies aptr.aptr == nil
+}
+
+func takesDeepOk(c *A) {
+	print(c.aptr.aptr.ptr)
+}
+
+func callDeepOk() {
+	takesDeepOk(&A{aptr: &A2{aptr: &A3{}}})
+}

--- a/testdata/src/go.uber.org/structinitv2/defaultfield/defaultfield.go
+++ b/testdata/src/go.uber.org/structinitv2/defaultfield/defaultfield.go
@@ -1,0 +1,89 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package defaultfield checks the escape policy for nil struct fields:
+//
+//  1. A nil field that escapes into analyzed code (returned to, passed to, or mutated by a function
+//     NilAway can see) and is then dereferenced IS reported, at the dereference.
+//  2. A nil field that escapes into unanalyzed code, or a parameter with no in-package caller, gets
+//     NilAway's standard optimistic treatment and is NOT reported.
+package defaultfield
+
+type A struct {
+	ptr  *int
+	aptr *A2
+}
+
+type A2 struct {
+	ptr  *int
+	aptr *A3
+}
+
+type A3 struct {
+	ptr *int
+}
+
+// ---------------------------------------------------------------------------
+// Escape into analyzed code: tracked precisely and deeply, and REPORTED.
+// ---------------------------------------------------------------------------
+
+// A nil field escapes via a return value and is dereferenced deeply by the caller.
+func makeNil() *A { return &A{aptr: &A2{}} } // result.aptr.aptr is nil
+
+func derefReturned() {
+	b := makeNil()
+	print(b.aptr.aptr.ptr) //want "uninitialized field `aptr`"
+}
+
+// A nil field escapes via an argument into an analyzed callee that dereferences it deeply.
+func sink(c *A) {
+	print(c.aptr.aptr.ptr) //want "uninitialized field `aptr`"
+}
+
+func escapeIntoSink() {
+	sink(&A{aptr: &A2{}}) // supplies aptr.aptr == nil
+}
+
+// A nil field escapes via a callee's side effect and is dereferenced by the caller afterwards.
+func clobber(c *A) { c.aptr = nil }
+
+func derefAfterSideEffect() {
+	b := &A{aptr: &A2{}}
+	clobber(b)
+	print(b.aptr.ptr) //want "field `aptr`"
+}
+
+// ---------------------------------------------------------------------------
+// Unknown caller / unanalyzed escape: optimistic, NOT reported (by design).
+// ---------------------------------------------------------------------------
+
+// No in-package caller constrains `c`, so this stays optimistic and is not flagged.
+func unknownCaller(c *A) {
+	print(c.aptr.aptr.ptr)
+}
+
+// The struct is allocated nil-fielded and escapes to an unanalyzed sink (an interface), but no
+// analyzed dereference observes the nil, so it stays optimistic.
+func escapeToUnanalyzed() {
+	var s any = &A{} // escapes into an interface; consumer unknown
+	_ = s
+}
+
+// Properly initialized along every in-package path: no error.
+func neverNil(c *A) {
+	if c.aptr == nil {
+		return
+	}
+	print(c.aptr.ptr)
+}

--- a/testdata/src/go.uber.org/structinitv2/funcreturnfields/funcreturnbasic.go
+++ b/testdata/src/go.uber.org/structinitv2/funcreturnfields/funcreturnbasic.go
@@ -1,0 +1,151 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package funcreturnfields tests nilability flowing through fields of a function or method result.
+package funcreturnfields
+
+import (
+	"go.uber.org/structinit/multipackage/packageone"
+)
+
+// leaf is shared by A11/A12/A21/A22 across this package.
+type leaf struct {
+	ptr *int
+}
+
+type A11 struct {
+	ptr  *int
+	aptr *leaf
+}
+
+// giveA initializes aptr, so the field read below is safe.
+func giveA() *A11 {
+	t := &A11{}
+	t.aptr = &leaf{}
+	return t
+}
+
+func m11() *int {
+	var b = giveA()
+	return b.aptr.ptr
+}
+
+// giveEmptyA12 leaves aptr nil, so the field read is flagged.
+
+type A12 struct {
+	ptr  *int
+	aptr *leaf
+}
+
+func giveEmptyA12() *A12 {
+	t := &A12{}
+	return t
+}
+
+func m12() *int {
+	var b = giveEmptyA12()
+	return b.aptr.ptr //want "uninitialized"
+}
+
+// Testing function with multiple returns
+func giveOneEmptyAndOneNonEmptyA12() (*A12, *A12) {
+	t1 := &A12{}
+	t1.aptr = new(leaf)
+
+	t2 := &A12{}
+
+	return t1, t2
+}
+
+func m123() {
+	var b1, b2 = giveOneEmptyAndOneNonEmptyA12()
+	print(b1.aptr.ptr, b2.aptr.ptr) //want "uninitialized"
+}
+
+// Testing function with multiple returns
+func giveTwoEmptyA12() (*A12, *A12) {
+	t1 := &A12{}
+	return t1, t1
+}
+
+func m124() {
+	var b1, b2 = giveTwoEmptyA12()
+	print(b1.aptr.ptr, b2.aptr.ptr) //want "uninitialized" "uninitialized"
+}
+
+// Testing function with multiple returns
+func giveTwoNonEmptyA12() (*A12, *A12) {
+	t1 := &A12{aptr: new(leaf)}
+
+	return t1, t1
+}
+
+func m125() {
+	var b1, b2 = giveTwoNonEmptyA12()
+	print(b1.aptr.ptr, b2.aptr.ptr)
+}
+
+// In this test, rhs giveEmptyA122(someInt) takes an argument.
+func giveEmptyA122(someInt int) *A12 {
+	t := &A12{}
+	return t
+}
+
+func m122(someInt int) *int {
+	var b = giveEmptyA122(someInt)
+	return b.aptr.ptr //want "accessed field `ptr`"
+}
+
+// B12 is a named type.
+
+type B12 A12
+
+func giveEmptyB12() *B12 {
+	t := &B12{}
+	return t
+}
+
+func mb12() *int {
+	var b = giveEmptyB12()
+	return b.aptr.ptr //want "accessed field `ptr`"
+}
+
+// B122 is a type alias.
+
+type B122 = A12
+
+func giveEmptyB122() *B122 {
+	t := &B122{}
+	return t
+}
+
+func mb122() *int {
+	var b = giveEmptyB122()
+	return b.aptr.ptr //want "accessed field `ptr`"
+}
+
+// Anonymous field from a different package.
+
+type fakeSchema struct {
+	packageone.S
+}
+
+func slice() packageone.S {
+	f := &fakeSchema{}
+	return f.S
+}
+
+func m3() {
+	print(slice()[0]) //want "sliced into"
+}

--- a/testdata/src/go.uber.org/structinitv2/funcreturnfields/funcreturnwitherrors.go
+++ b/testdata/src/go.uber.org/structinitv2/funcreturnfields/funcreturnwitherrors.go
@@ -1,0 +1,227 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Tests the (value, error) constructor pattern: a struct returned alongside a non-nil (or unknown)
+// error is never observed by a caller that checks `err != nil`, so its possibly-nil fields must not
+// poison the success-path summary; but a caller that ignores the error is still flagged.
+
+package funcreturnfields
+
+import (
+	"errors"
+	"fmt"
+)
+
+// 1. Always returns a non-nil error: the nil-fielded value is never observed on the success path.
+type myErr struct{}
+
+func (myErr) Error() string { return "myErr message" }
+
+func giveEmptyACompositeWithErr() (*A11, error) {
+	return &A11{}, &myErr{}
+}
+
+func m09() *int {
+	t, err := giveEmptyACompositeWithErr()
+	if err != nil {
+		return new(int)
+	}
+	// No error: giveEmptyACompositeWithErr never returns a nil error, so this is unreachable.
+	return t.aptr.ptr
+}
+
+// 2. Returns the nil-fielded value with a NIL error: the field nilability reaches the success path.
+func giveEmptyACompositeWithErr2() (*A11, error) {
+	return &A11{}, nil
+}
+
+func m88() *int {
+	t, err := giveEmptyACompositeWithErr2()
+	if err != nil {
+		return new(int)
+	}
+	return t.aptr.ptr //want "accessed field `ptr`"
+}
+
+// 3. One success path returns the nil-fielded value: it reaches the caller's success path.
+func dummy() bool { return true }
+func giveEmptyACompositeWithErr3() (*A11, error) {
+	if dummy() {
+		return &A11{}, nil
+	}
+	return &A11{}, &myErr{}
+}
+
+func m78() *int {
+	t, err := giveEmptyACompositeWithErr3()
+	if err != nil {
+		return new(int)
+	}
+	return t.aptr.ptr //want "accessed field `ptr`"
+}
+
+// 4. Success path returns a fully-initialized value: no error.
+func giveEmptyACompositeWithErr4() (*A11, error) {
+	return &A11{aptr: new(leaf)}, nil
+}
+
+func m48() *int {
+	t, err := giveEmptyACompositeWithErr4()
+	if err != nil {
+		return new(int)
+	}
+	return t.aptr.ptr
+}
+
+// 5. Success path initializes the field; only the error path leaves it nil -> no success-path error.
+func giveEmptyACompositeWithErr5() (*A11, error) {
+	if dummy() {
+		return &A11{aptr: new(leaf)}, nil
+	}
+	return &A11{}, &myErr{}
+}
+
+func m58() *int {
+	t, err := giveEmptyACompositeWithErr5()
+	if err != nil {
+		return new(int)
+	}
+	return t.aptr.ptr
+}
+
+// 6. Success path leaves the field nil; the error path initializes it -> success-path error.
+func giveEmptyACompositeWithErr6() (*A11, error) {
+	if dummy() {
+		return &A11{}, nil
+	}
+	return &A11{aptr: new(leaf)}, &myErr{}
+}
+
+func m68() *int {
+	t, err := giveEmptyACompositeWithErr6()
+	if err != nil {
+		return new(int)
+	}
+	return t.aptr.ptr //want "accessed field `ptr`"
+}
+
+// 7. Discharge must recognize error constructors (`errors.New`, `fmt.Errorf`), not just non-nil
+// error literals; both must discharge the nil-fielded error-path return.
+func giveEmptyACompositeWithErrNew() (*A11, error) {
+	if dummy() {
+		return &A11{aptr: new(leaf)}, nil
+	}
+	return &A11{}, errors.New("boom")
+}
+
+func m07a() *int {
+	t, err := giveEmptyACompositeWithErrNew()
+	if err != nil {
+		return new(int)
+	}
+	return t.aptr.ptr
+}
+
+func giveEmptyACompositeWithErrf() (*A11, error) {
+	if dummy() {
+		return &A11{aptr: new(leaf)}, nil
+	}
+	return &A11{}, fmt.Errorf("boom: %d", 1)
+}
+
+func m07b() *int {
+	t, err := giveEmptyACompositeWithErrf()
+	if err != nil {
+		return new(int)
+	}
+	return t.aptr.ptr
+}
+
+// 8. Success path fills the field from a local variable (not an inline allocation); a non-nil local
+// must be tracked as non-nil at the return. The error path is discharged by `errors.New`.
+func giveACompositeFromLocalWithErr() (*A11, error) {
+	if dummy() {
+		return &A11{}, errors.New("boom")
+	}
+	p := new(leaf)
+	return &A11{aptr: p}, nil
+}
+
+func m08a() *int {
+	t, err := giveACompositeFromLocalWithErr()
+	if err != nil {
+		return new(int)
+	}
+	return t.aptr.ptr
+}
+
+// 9. Same local-variable success path, but the local is genuinely nil -> the field nilability must
+// still flow to the success path and be reported.
+func giveNilLocalComposite() (*A11, error) {
+	if dummy() {
+		return &A11{aptr: new(leaf)}, errors.New("boom")
+	}
+	var p *leaf
+	return &A11{aptr: p}, nil
+}
+
+func m09b() *int {
+	t, err := giveNilLocalComposite()
+	if err != nil {
+		return new(int)
+	}
+	return t.aptr.ptr //want "accessed field `ptr`"
+}
+
+// 10. Caller-side guard: a caller that derefs the value without checking the error must be flagged,
+// because it may observe the error-path value where the field is nil (m58, which checks the error,
+// stays safe).
+func m10unchecked() *int {
+	t, _ := giveEmptyACompositeWithErr5() // error ignored: t may be the error-path (nil-field) value
+	return t.aptr.ptr                     //want "accessed field `ptr`"
+}
+
+// 11. Discarding the error with `_` can never discharge the guard: there is no error variable to
+// check.
+func m11discarded() *int {
+	t, _ := giveACompositeFromLocalWithErr()
+	return t.aptr.ptr //want "accessed field `ptr`"
+}
+
+// 12. Error-path zero struct paired with an error variable (not a constructor), returned inside an
+// `if err != nil` guard. `err` is not definitely non-nil but not definitely nil either, so the
+// error-path zero struct's fields must not be bound into the summary; a caller that checks the error
+// is safe.
+func giveACompositeOrErrVar() (*A11, error) {
+	_, err := giveEmptyACompositeWithErr4() // err: a variable of unknown nilability
+	if err != nil {
+		return &A11{}, err // zero struct + error variable inside the guard: must not bind
+	}
+	return &A11{aptr: new(leaf)}, nil
+}
+
+func m12errVarChecked() *int {
+	t, err := giveACompositeOrErrVar()
+	if err != nil {
+		return new(int)
+	}
+	return t.aptr.ptr // safe: error-path zero struct not bound; success path sets aptr
+}
+
+// 13. Same constructor, but the caller does not check the error: the caller-side guard still flags
+// it, because the value may be the error-path zero struct.
+func m13errVarUnchecked() *int {
+	t, _ := giveACompositeOrErrVar()
+	return t.aptr.ptr //want "accessed field `ptr`"
+}

--- a/testdata/src/go.uber.org/structinitv2/funcreturnfields/functionreturntransitive.go
+++ b/testdata/src/go.uber.org/structinitv2/funcreturnfields/functionreturntransitive.go
@@ -1,0 +1,51 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package funcreturnfields
+
+// Direct return of a composite literal local.
+
+func giveEmptyA() *A11 {
+	t := &A11{}
+	return t
+}
+
+func m07() *int {
+	b := giveEmptyA()
+	return b.aptr.ptr //want "accessed field `ptr`"
+}
+
+// Direct return of a composite literal.
+func giveEmptyAComposite() *A11 {
+	return &A11{}
+}
+
+func m08() *int {
+	t := giveEmptyAComposite()
+	return t.aptr.ptr //want "accessed field `ptr`"
+}
+
+// Transitive return through another function call.
+func giveEmptyA11Fun() *A11 {
+	return &A11{}
+}
+
+func giveEmptyACallFun() *A11 {
+	return giveEmptyA11Fun()
+}
+
+func m10() *int {
+	t := giveEmptyACallFun()
+	return t.aptr.ptr //want "accessed field `ptr`"
+}

--- a/testdata/src/go.uber.org/structinitv2/funcreturnfields/methodreturnbasic.go
+++ b/testdata/src/go.uber.org/structinitv2/funcreturnfields/methodreturnbasic.go
@@ -1,0 +1,56 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package funcreturnfields
+
+// Same as funcreturnbasic.go, but for methods.
+
+// giveA initializes aptr, so the field read is safe.
+
+type A21 struct {
+	ptr  *int
+	aptr *leaf
+}
+
+type Pool struct{}
+
+func (pool *Pool) giveA() *A21 {
+	t := &A21{}
+	t.aptr = &leaf{}
+	return t
+}
+
+func m21() *int {
+	pool := new(Pool)
+	var b = pool.giveA()
+	return b.aptr.ptr
+}
+
+// giveEmptyA leaves aptr nil, so the field read is flagged.
+
+type A22 struct {
+	ptr  *int
+	aptr *leaf
+}
+
+func (pool *Pool) giveEmptyA() *A22 {
+	t := &A22{}
+	return t
+}
+
+func m22() *int {
+	pool := new(Pool)
+	var b = pool.giveEmptyA()
+	return b.aptr.ptr //want "accessed field `ptr`"
+}

--- a/testdata/src/go.uber.org/structinitv2/global/global.go
+++ b/testdata/src/go.uber.org/structinitv2/global/global.go
@@ -1,0 +1,120 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package global checks allocation-site-sensitive tracking of package-level global struct fields. A
+// field is flagged when a write provably leaves it nil, or when it is nil at the declaration and is
+// never written; a field that is later written non-nil is safe.
+package global
+
+type A struct {
+	ptr  *int
+	aptr *leaf
+}
+
+type leaf struct {
+	ptr *int
+}
+
+// Positive: one function leaves a global's field nil, another reads it.
+
+var gWrite = &A{aptr: new(leaf)} // aptr non-nil at the declaration ...
+
+func nilTheField() { gWrite.aptr = nil } // ... but a function leaves it nil
+
+func readWrite() {
+	print(gWrite.aptr.ptr) //want "field `aptr` of global `gWrite`"
+}
+
+// Positive: a field nil at the declaration and never written is flagged.
+
+var gDecl = &A{} // aptr omitted -> nil at the declaration, and never written
+
+func readDecl() {
+	print(gDecl.aptr.ptr) //want "field `aptr` of global `gDecl`"
+}
+
+// Under-report (documented): a lazily-initialized global guarded by `if g == nil { return }` is
+// not summarized, even though initGuarded provably leaves the field nil.
+
+var gGuarded *A = nil
+
+func initGuarded() {
+	gGuarded = &A{}
+	gGuarded.aptr = nil
+}
+
+func readGuarded() {
+	if gGuarded == nil {
+		return
+	}
+	print(gGuarded.aptr.ptr) // under-report: guarded lazy global
+}
+
+// Negative: last write wins. The trailing non-nil write determines the field's value.
+
+var gLast *A = nil
+
+func initLast() {
+	gLast = &A{}           // aptr nil here ...
+	gLast.aptr = new(leaf) // ... but overwritten non-nil (last write wins)
+}
+
+func readLast() {
+	if gLast == nil {
+		return
+	}
+	print(gLast.aptr.ptr) // safe: net write leaves gLast.aptr non-nil
+}
+
+// Positive (accepted false positive): the global is mutated only through an escaped pointer, so no
+// write is captured and the stale declaration shape (aptr nil) is flagged.
+
+var gEsc = &A{} // aptr nil at the declaration, mutated only via escape below
+
+func setup(pp **A) { *pp = &A{aptr: new(leaf)} }
+
+func escapeIt() { setup(&gEsc) } // mutates gEsc.aptr through a pointer (non-nil)
+
+func readEsc() {
+	print(gEsc.aptr.ptr) //want "field `aptr` of global `gEsc`"
+}
+
+// Negative: fully initialized at the declaration, never written.
+
+var gOK = &A{aptr: &leaf{ptr: new(int)}}
+
+func readOK() {
+	print(*gOK.aptr.ptr) // safe
+}
+
+// Negative: nil at the declaration but written non-nil by a function, so the read is safe.
+
+var gInit = &A{} // aptr nil at the declaration ...
+
+func setupInit() { gInit.aptr = new(leaf) } // ... but a function writes it non-nil
+
+func readInit() {
+	print(gInit.aptr.ptr) // safe: aptr is written non-nil
+}
+
+// Negative: a function replaces the whole sub-struct with an initialized one, so the deep read is
+// safe.
+
+var gSub = &A{aptr: new(leaf)} // aptr non-nil, aptr.ptr nil at the declaration ...
+
+func setupSub() { gSub.aptr = &leaf{ptr: new(int)} } // ... aptr replaced, now with aptr.ptr non-nil
+
+func readSub() {
+	print(*gSub.aptr.ptr) // safe: aptr replaced with an initialized sub-struct
+}

--- a/testdata/src/go.uber.org/structinitv2/limitations/caller_precluded_branch.go
+++ b/testdata/src/go.uber.org/structinitv2/limitations/caller_precluded_branch.go
@@ -1,0 +1,62 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package limitations
+
+// False positive: context-insensitive return merge of a caller-precluded branch. A constructor
+// returns a struct with an omitted field only on a branch that the sole caller's precondition makes
+// dead, but the field is flagged anyway.
+//
+// The return summary is context-insensitive: one site per (function, result index, field path),
+// merged over every return statement with no relation to the caller's arguments. The dead branch's
+// nil field therefore poisons the merged summary. There is no error result here, so this is purely a
+// cross-function precondition the analysis cannot correlate.
+
+type precludedCriteria struct{ ReturnSelfIfRoot bool }
+type precludedRequest struct{ Criteria *precludedCriteria }
+type precludedThriftReq struct{ x int }
+
+// precludedMap returns an empty request on nil input, else a fully populated one. The Criteria-nil
+// return is reachable only when thriftReq == nil.
+func precludedMap(thriftReq *precludedThriftReq) *precludedRequest {
+	if thriftReq == nil {
+		return &precludedRequest{} // Criteria nil — dead for callers that pass a non-nil thriftReq
+	}
+	return &precludedRequest{Criteria: &precludedCriteria{ReturnSelfIfRoot: true}}
+}
+
+// precludedCaller is the false positive: it guards `args != nil`, so precludedMap always takes the
+// populated branch — but the merged summary says nilable.
+func precludedCaller(args *precludedThriftReq) bool {
+	if args == nil {
+		return false
+	}
+	protoReq := precludedMap(args)            // args is non-nil here, so Criteria is set
+	return protoReq.Criteria.ReturnSelfIfRoot //want "field `Criteria` of result 0 of `precludedMap` accessed field `ReturnSelfIfRoot`"
+}
+
+// precludedMapAlwaysSet is the negative control: it sets Criteria on every return path, so the
+// summary is unconditionally non-nil. This isolates the dead nil-input branch as the source of the
+// false positive.
+func precludedMapAlwaysSet(thriftReq *precludedThriftReq) *precludedRequest {
+	if thriftReq == nil {
+		return &precludedRequest{Criteria: &precludedCriteria{}}
+	}
+	return &precludedRequest{Criteria: &precludedCriteria{ReturnSelfIfRoot: true}}
+}
+
+func precludedCallerOK(args *precludedThriftReq) bool {
+	protoReq := precludedMapAlwaysSet(args)
+	return protoReq.Criteria.ReturnSelfIfRoot // safe — no //want
+}

--- a/testdata/src/go.uber.org/structinitv2/limitations/constructor_error_return.go
+++ b/testdata/src/go.uber.org/structinitv2/limitations/constructor_error_return.go
@@ -1,0 +1,72 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package limitations
+
+import "errors"
+
+// Regression guard: (value, error) discharge for the idiomatic `return &T{}, err` early return
+// (a zero/partial struct paired with the just-checked error variable). The error-checked field
+// dereferences below are now correct and carry no //want.
+//
+// Discharge is flow-sensitive on both sides: the supply side binds a return's field nilability only
+// when the error is definitely nil, so a non-nil-or-unknown error (including the `err` variable
+// returned inside an `if err != nil` block) does not bind the zero struct's nil fields; the caller
+// side still flags a caller that does not check the error.
+
+type ctorErrInner struct{ x int }
+type ctorErrVerifyRequest struct {
+	req       *ctorErrInner
+	parsedURL *ctorErrInner
+}
+
+func ctorErrMkID() (int, error) { return 0, nil }
+
+// ctorErrBuild's early return pairs a zero struct with the error variable `err`. The error is not
+// definitely nil, so the omitted fields must not be bound into the success-path summary.
+func ctorErrBuild(r, p *ctorErrInner) (*ctorErrVerifyRequest, error) {
+	_, err := ctorErrMkID()
+	if err != nil {
+		return &ctorErrVerifyRequest{}, err // zero struct + error variable: not bound
+	}
+	vr := &ctorErrVerifyRequest{req: r, parsedURL: p}
+	return vr, nil
+}
+
+// ctorErrCaller returns on err!=nil, so both fields are set when the derefs run; not flagged.
+func ctorErrCaller(r, p *ctorErrInner) {
+	vr, err := ctorErrBuild(r, p)
+	if err != nil {
+		return
+	}
+	_ = vr.req.x       // safe — no //want
+	_ = vr.parsedURL.x // safe — no //want
+}
+
+// ctorErrBuildConstructorErr pairs the zero struct with an error constructor (`errors.New`), which is
+// definitely non-nil. Kept as a second regression case for the constructor path.
+func ctorErrBuildConstructorErr(r, p *ctorErrInner) (*ctorErrVerifyRequest, error) {
+	if r == nil {
+		return &ctorErrVerifyRequest{}, errors.New("bad") // definitely-non-nil error: discharged
+	}
+	return &ctorErrVerifyRequest{req: r, parsedURL: p}, nil
+}
+
+func ctorErrCallerOK(r, p *ctorErrInner) {
+	vr, err := ctorErrBuildConstructorErr(r, p)
+	if err != nil {
+		return
+	}
+	_ = vr.req.x // safe — no //want
+}

--- a/testdata/src/go.uber.org/structinitv2/limitations/correlated_guards.go
+++ b/testdata/src/go.uber.org/structinitv2/limitations/correlated_guards.go
@@ -1,0 +1,37 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package limitations
+
+// False positive: a field's nil producer is not cleared across two guards correlated by the same
+// predicate. The analysis admits the infeasible path where the assignment block (gated on
+// `Source == nil && caller != ""`) is skipped while the deref block (gated on `caller != ""`) runs.
+// The zero-value allocation `var request corrReq` is load-bearing: it gives Source a definitely-nil
+// producer that a bare parameter would not.
+
+type corrSource struct{ Caller *string }
+type corrReq struct{ Source *corrSource }
+
+// corrCorrelatedGuards is the false positive: whenever the `caller != ""` deref block runs, the
+// earlier block has already set Source non-nil, but the two predicates are not tied together.
+func corrCorrelatedGuards(caller string) corrReq {
+	var request corrReq // zero value: request.Source is definitely nil
+	if request.Source == nil && caller != "" {
+		request.Source = &corrSource{}
+	}
+	if caller != "" {
+		request.Source.Caller = &caller //want "uninitialized field `Source` accessed field `Caller`"
+	}
+	return request
+}

--- a/testdata/src/go.uber.org/structinitv2/limitations/decode_localvar_field.go
+++ b/testdata/src/go.uber.org/structinitv2/limitations/decode_localvar_field.go
@@ -1,0 +1,55 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package limitations
+
+// Regression guard: a pointer field initialized from a local variable that holds a non-nil
+// allocation is tracked as non-nil, the same as an inline composite literal. A field set from a
+// trackable lvalue (local variable, parameter, or field chain) is resolved against the variable's
+// real value, so the safe deref below carries no //want.
+
+type decodePayload struct{ id *int }
+type decodeOAuthCode struct{ Payload *decodePayload }
+
+type decodeErr struct{}
+
+func (decodeErr) Error() string { return "decode failed" }
+
+// decodeHelper allocates a fresh payload and returns it with a nil error on success; the only
+// nil-payload return is paired with a non-nil error.
+func decodeHelper(enc string) (*decodePayload, error) {
+	pl := &decodePayload{}
+	if enc == "" {
+		return nil, decodeErr{}
+	}
+	return pl, nil
+}
+
+// decodeAndDeref: `payload` is provably non-nil here (the err!=nil path returned), so the field set
+// from it is non-nil at the deref.
+func decodeAndDeref(enc string) *int {
+	payload, err := decodeHelper(enc)
+	if err != nil {
+		return nil
+	}
+	verified := &decodeOAuthCode{Payload: payload} // field set from the checked, non-nil local
+	return verified.Payload.id                     // safe — no //want
+}
+
+// decodeInlineLiteralOK is the negative control: the field is set from an inline composite literal
+// instead of a local variable, isolating the variable-vs-literal split.
+func decodeInlineLiteralOK() *int {
+	verified := &decodeOAuthCode{Payload: &decodePayload{}}
+	return verified.Payload.id // safe — no //want
+}

--- a/testdata/src/go.uber.org/structinitv2/limitations/field_from_local_var.go
+++ b/testdata/src/go.uber.org/structinitv2/limitations/field_from_local_var.go
@@ -1,0 +1,48 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package limitations
+
+// Regression guard: the map-field variant of decode_localvar_field. A map field set from a local
+// variable holding a non-nil map literal is tracked as non-nil, so an index-write to it does not
+// panic and is not flagged. The true-positive control below (a nil map variable) must still fire.
+
+type fieldVarState struct {
+	tags map[string]string
+}
+
+// fieldVarWriteFromVar: `tags` is a non-nil map literal, so the index-write cannot panic.
+func fieldVarWriteFromVar() {
+	tags := map[string]string{"a": "b"}
+	state := &fieldVarState{tags: tags} // map field set from a non-nil local
+	state.tags["step"] = "x"            // safe — no //want
+	_ = state
+}
+
+// fieldVarWriteInlineOK is the negative control: the field is an inline map literal. Isolates the
+// variable-vs-literal split.
+func fieldVarWriteInlineOK() {
+	state := &fieldVarState{tags: map[string]string{"a": "b"}}
+	state.tags["step"] = "x" // safe — no //want
+	_ = state
+}
+
+// fieldVarWriteFromNilVar is the true-positive control: the field is set from a nil map variable, so
+// the index-write genuinely panics and must still be reported.
+func fieldVarWriteFromNilVar() {
+	var tags map[string]string // nil
+	state := &fieldVarState{tags: tags}
+	state.tags["step"] = "x" //want "written to at an index"
+	_ = state
+}

--- a/testdata/src/go.uber.org/structinitv2/limitations/limitations.go
+++ b/testdata/src/go.uber.org/structinitv2/limitations/limitations.go
@@ -1,0 +1,223 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package limitations collects the known false negatives and false positives of the struct-init
+// analysis, plus regression guards for behavior that is now correct. Each case is a deliberate
+// consequence of a precision/soundness boundary, not an accidental bug.
+//
+// Conventions (matching the analysistest framework):
+//   - A false negative is a real nil panic the analysis fails to report: the line carries no //want,
+//     and a comment notes the missed report.
+//   - A false positive is a safe deref the analysis wrongly reports: the line carries a //want
+//     matching the spurious diagnostic, and a comment marks it as spurious.
+//
+// A structural cause shared by several cases: the interprocedural boundary summary is
+// context-insensitive — there is one inference site per (function, kind, param/return index, field
+// path), shared by every caller. Allocation-site sensitivity holds within a function, but once a
+// value crosses a boundary all callers merge into that single site.
+package limitations
+
+// Leaf is the bottom of the type chain; ptr is the dereference target.
+type Leaf struct {
+	ptr *int
+}
+
+// Node holds a single nilable field (a depth-1 boundary field).
+type Node struct {
+	child *Leaf
+}
+
+// Outer nests a Node, giving a depth-2 path (mid.child).
+type Outer struct {
+	mid *Node
+}
+
+// ---------------------------------------------------------------------------------------------
+// Regression guards: deep binding through a trackable value (variable / field chain)
+// ---------------------------------------------------------------------------------------------
+//
+// A deep (depth >= 2) nil carried into a boundary through a local variable is tracked, reaching
+// parity with the inline-allocation case.
+
+// Deep nil supplied to a parameter through a local variable.
+func derefDeepParam(x *Outer) *int {
+	return x.mid.child.ptr //want "field `mid.child` of param 0 of `derefDeepParam`"
+}
+
+func tDeepParamViaVar() *int {
+	t := &Outer{mid: &Node{}} // t.mid.child is nil at depth 2
+	return derefDeepParam(t)
+}
+
+// Deep nil returned through a local variable.
+func mkDeepViaVar() *Outer {
+	t := &Outer{mid: &Node{}} // t.mid.child is nil at depth 2
+	return t
+}
+
+func tReturnDeepViaVar() *int {
+	b := mkDeepViaVar()
+	return b.mid.child.ptr //want "field `mid.child` of result 0 of `mkDeepViaVar`"
+}
+
+// ---------------------------------------------------------------------------------------------
+// Regression guards: deep and explicit-deref direct parameter-field writes
+// ---------------------------------------------------------------------------------------------
+//
+// A deep write (`o.mid.child = ...`) or an explicit-deref write (`(*x).child = ...`) inside a callee
+// is captured and re-produced by the caller, keyed by the full field path.
+
+// Direct multi-level field write inside the callee.
+func writeDeepField(o *Outer) {
+	o.mid.child = nil
+}
+
+func tDeepDirectWrite() *int {
+	b := &Outer{mid: &Node{child: &Leaf{}}}
+	writeDeepField(b)
+	return b.mid.child.ptr //want "field `mid.child` of param 0 of `writeDeepField`"
+}
+
+// Field write through an explicit (parenthesized) dereference; `(*x).child` collapses to `x.child`.
+func writeViaDeref(x *Node) {
+	(*x).child = nil
+}
+
+func tWriteViaDeref() *int {
+	b := &Node{}
+	b.child = &Leaf{}
+	writeViaDeref(b)
+	return b.child.ptr //want "field `child` of param 0 of `writeViaDeref`"
+}
+
+// Negative control: a deep write that sets the field non-nil must not be reported, confirming the
+// write-set carries the written value's nilability rather than merely "this path was touched".
+func writeDeepFieldNonNil(o *Outer) {
+	o.mid.child = &Leaf{}
+}
+
+func tDeepDirectWriteNonNil() *int {
+	b := &Outer{mid: &Node{}} // b.mid.child is nil at allocation...
+	writeDeepFieldNonNil(b)   // ...but the callee writes it non-nil
+	return b.mid.child.ptr    // safe — no //want
+}
+
+// Deep write through a method receiver.
+func (o *Outer) writeDeepRecv() {
+	o.mid.child = nil
+}
+
+func tDeepRecvWrite() *int {
+	b := &Outer{mid: &Node{child: &Leaf{}}}
+	b.writeDeepRecv()
+	return b.mid.child.ptr //want "field `mid.child` of method receiver of `writeDeepRecv`"
+}
+
+// ---------------------------------------------------------------------------------------------
+// FALSE NEGATIVES (under-reports — no //want)
+// ---------------------------------------------------------------------------------------------
+
+// False negative: a naked named return has no result expression, so the constructor's shape is never
+// summarized.
+func nakedReturn() (n *Node) {
+	n = &Node{} // n.child is nil
+	return
+}
+
+func tNakedReturn() *int {
+	b := nakedReturn()
+	return b.child.ptr
+}
+
+// False negative: forwarding a parameter through a non-parameter local. Re-binding the parameter to a
+// local first (`y := x`) breaks the forwarding link, so the forwardee's write is not attributed to
+// the forwarder.
+func writeNilField(x *Node) {
+	x.child = nil
+}
+
+func fwdViaLocal(x *Node) {
+	y := x // y is a local, not a parameter — no forwarding edge is recorded
+	writeNilField(y)
+}
+
+func tForwardViaLocal() *int {
+	b := &Node{}
+	b.child = &Leaf{}
+	fwdViaLocal(b)
+	return b.child.ptr
+}
+
+// False negative: forwarding a parameter through a func-value call. A dynamic callee cannot be
+// resolved, so no forwarding edge is recorded and the call is treated as transparent.
+func fwdViaFuncValue(x *Node, fn func(*Node)) {
+	fn(x)
+}
+
+func tForwardViaFuncValue() *int {
+	b := &Node{}
+	b.child = &Leaf{}
+	fwdViaFuncValue(b, writeNilField)
+	return b.child.ptr
+}
+
+// ---------------------------------------------------------------------------------------------
+// FALSE POSITIVES (over-reports — //want required)
+// ---------------------------------------------------------------------------------------------
+
+// False positive: the same variable passed to several parameters. The caller re-produces the field
+// from the first parameter's site, so the first parameter's nil write is reported even though the
+// last write through the alias is non-nil. The field is non-nil at allocation and the alias's last
+// write is non-nil, so the first parameter's write is the only possible nil source.
+func initFirstNilSecondNonNil(a1 *Node, a2 *Node) {
+	a1.child = nil     // first param's write (the spurious winner)
+	a2.child = &Leaf{} // a1 and a2 alias the same object, so this is the real final value (non-nil)
+}
+
+func tSameVarMultiParam() *int {
+	a := &Node{child: &Leaf{}} // non-nil at allocation: isolates the param write as the only nil source
+	initFirstNilSecondNonNil(a, a)
+	return a.child.ptr //want "field `child` of param 0 of `initFirstNilSecondNonNil`"
+}
+
+// False positive: a field written nil only inside one branch is summarized as unconditionally
+// nilable, so a caller on the path where the branch is not taken is still flagged.
+func condWriteSingleBranch(x *Node, b bool) {
+	if b {
+		x.child = nil
+	}
+}
+
+func tConditionalWrite() *int {
+	a := &Node{}
+	a.child = &Leaf{}               // caller-initialized: non-nil
+	condWriteSingleBranch(a, false) // b == false: child is NOT written, stays non-nil
+	return a.child.ptr              //want "field `child` of param 0 of `condWriteSingleBranch`"
+}
+
+// False positive: both branches write the field, but the summary merges them and keeps the nilable
+// value, so a caller that takes the non-nil branch is wrongly flagged.
+func condBranchOneNil(x *Node, b bool) {
+	if b {
+		x.child = nil // one branch nils the field...
+	} else {
+		x.child = &Leaf{} // ...the other sets it non-nil; the merge keeps nilable
+	}
+}
+
+func tBranchConservativeMerge() *int {
+	a := &Node{child: &Leaf{}} // non-nil at allocation
+	condBranchOneNil(a, false) // b == false: child is really non-nil at runtime
+	return a.child.ptr         //want "field `child` of param 0 of `condBranchOneNil`"
+}

--- a/testdata/src/go.uber.org/structinitv2/limitations/limitations_deepwrite.go
+++ b/testdata/src/go.uber.org/structinitv2/limitations/limitations_deepwrite.go
@@ -1,0 +1,87 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Edge-case guards for the deep / explicit-deref parameter-field write detectors (see the deep-write
+// cases in limitations.go): a top-level by-value copy must not alias its source, a double-pointer
+// write must be rejected, and a recursive field path must be skipped while the analysis still
+// terminates. Each is a deliberate no-report case.
+//
+// This file defines one self-recursive type (recNode) solely to exercise the recursion guard; the
+// other tests use the non-recursive Outer/Node/Leaf types from limitations.go.
+package limitations
+
+// ---------------------------------------------------------------------------------------------
+// GUARD: a top-level by-value struct copy does not alias its source
+// ---------------------------------------------------------------------------------------------
+//
+// `g(*x)` passes a copy of the struct, so a field the callee mutates is not visible to the caller's
+// `x`. A top-level `*x` argument must therefore not record a forwarding edge.
+
+// byValWriteNil takes a Node by value and nils its field — invisible to any caller's pointer.
+func byValWriteNil(n Node) {
+	n.child = nil
+}
+
+// passByValue passes a by-value copy (`*x`), so no forwarding edge is recorded.
+func passByValue(x *Node) {
+	byValWriteNil(*x)
+}
+
+func tByValueCopyNoForward() *int {
+	b := &Node{child: &Leaf{}} // child non-nil
+	passByValue(b)             // the copy is mutated; b.child is unchanged
+	return b.child.ptr         // safe — must NOT be reported (no //want)
+}
+
+// ---------------------------------------------------------------------------------------------
+// GUARD: a double-pointer write is rejected
+// ---------------------------------------------------------------------------------------------
+//
+// `(*x).child` with x of type **Node addresses a field two pointer levels deep. The path resolves to
+// no struct type and is skipped, so the mutation is an under-report and the analysis must not crash.
+
+func writeViaDoublePtr(x **Node) {
+	(*x).child = nil
+}
+
+func tWriteViaDoublePtr() *int {
+	inner := &Node{child: &Leaf{}} // inner.child non-nil
+	pp := &inner                   // pp is **Node
+	writeViaDoublePtr(pp)          // double-pointer write is not tracked
+	return (*pp).child.ptr         // under-report — not reported (no //want)
+}
+
+// ---------------------------------------------------------------------------------------------
+// GUARD: a recursive field path is skipped (and the analysis terminates)
+// ---------------------------------------------------------------------------------------------
+//
+// A deep write whose path re-enters a struct type already on the chain (`r.next.leaf`) would let the
+// path grow without bound. Such paths are skipped, so the write is an under-report but collection and
+// inference still terminate.
+
+// recNode is self-recursive via next; it exists solely to drive the recursion-guard test.
+type recNode struct {
+	next *recNode
+	leaf *Leaf
+}
+
+func writeRecDeep(r *recNode) {
+	r.next.leaf = nil // path "next.leaf" re-enters recNode at "next" -> skipped
+}
+
+func tRecDeepWrite() *int {
+	b := &recNode{next: &recNode{leaf: &Leaf{}}}
+	writeRecDeep(b)        // recursive-path write is skipped (under-report)
+	return b.next.leaf.ptr // not reported (no //want); analysis still terminates
+}

--- a/testdata/src/go.uber.org/structinitv2/limitations/localvar_addressof_struct.go
+++ b/testdata/src/go.uber.org/structinitv2/limitations/localvar_addressof_struct.go
@@ -1,0 +1,40 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package limitations
+
+// Regression guard: the decode_localvar_field case, shown to survive an address-of-value-struct
+// indirection and a depth-2 receiver. A field set from a local variable holding a non-nil value (or
+// a function result) is resolved against the variable's real value, so the deref below carries no
+// //want.
+
+type addrOfTimeFilter struct{ v int }
+type addrOfFilterRuleSet struct{ TimeFilter *addrOfTimeFilter }
+type addrOfCardMetadata struct{ FilterRules *addrOfFilterRuleSet }
+type addrOfInboxCard struct{ Metadata *addrOfCardMetadata }
+
+// addrOfMakeRuleSet always returns a non-nil set.
+func addrOfMakeRuleSet() *addrOfFilterRuleSet {
+	var rs addrOfFilterRuleSet
+	return &rs // unconditionally non-nil
+}
+
+// addrOfMap: FilterRules is provably non-nil (addrOfMakeRuleSet's result), so the receiver chain
+// cannot be nil. (Reading the nilable .TimeFilter is safe; it is returned, not dereferenced.)
+func addrOfMap(inboxCard *addrOfInboxCard) *addrOfTimeFilter {
+	filterRules := addrOfMakeRuleSet()                       // non-nil
+	cardMeta := addrOfCardMetadata{FilterRules: filterRules} // field set from a local variable
+	inboxCard.Metadata = &cardMeta
+	return inboxCard.Metadata.FilterRules.TimeFilter // safe — no //want
+}

--- a/testdata/src/go.uber.org/structinitv2/limitations/value_typed_map_element.go
+++ b/testdata/src/go.uber.org/structinitv2/limitations/value_typed_map_element.go
@@ -1,0 +1,55 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package limitations
+
+// Regression guards: two cases around a value-typed map (`map[K]Struct`), each carrying no //want:
+//
+//  1. valMapReadDirect: indexing a value-typed map yields the zero struct on a miss (never nil), so a
+//     deep read through its address does not need a `, ok` guard.
+//  2. valMapBuild -> valMapDeepRead: the address of a local stored in a struct field follows the
+//     local's real value, so the field is non-nil across the boundary. The map is incidental here —
+//     a plain local reproduces the same shape.
+
+type valMapTabConfig struct{ TabID string }
+type valMapParams struct{ TabsConfig map[string]valMapTabConfig }
+
+// valMapReadDirect: a value-map miss is the zero struct and `p` is the address of a local, so the
+// deep read cannot panic.
+func valMapReadDirect(params valMapParams, key string) string {
+	tabConfig := params.TabsConfig[key] // value-typed map element: zero value on miss, never nil
+	p := &tabConfig
+	return p.TabID // no diagnostic
+}
+
+// valMapValueUseOK is the negative control: using the element as a value (no address-of, no pointer
+// deep read) isolates the address-of flow as the trigger.
+func valMapValueUseOK(params valMapParams, key string) string {
+	tabConfig := params.TabsConfig[key]
+	return tabConfig.TabID // safe — no //want
+}
+
+type valMapCardParams struct{ TabConfig *valMapTabConfig }
+
+func valMapDeepRead(p valMapCardParams) string {
+	return p.TabConfig.TabID // no diagnostic (p.TabConfig credited non-nil via the caller)
+}
+
+// valMapBuild: the element's address is stored in a pointer field of a struct bound to a local, then
+// crosses into valMapDeepRead. `&tabConfig` is non-nil, so the field is summarized non-nil.
+func valMapBuild(params valMapParams, key string) string {
+	tabConfig := params.TabsConfig[key]
+	cp := valMapCardParams{TabConfig: &tabConfig}
+	return valMapDeepRead(cp)
+}

--- a/testdata/src/go.uber.org/structinitv2/limitations/valuestruct_error_return.go
+++ b/testdata/src/go.uber.org/structinitv2/limitations/valuestruct_error_return.go
@@ -1,0 +1,80 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package limitations
+
+import "errors"
+
+// Regression guard: the (value, error) discharge of constructor_error_return.go, for a value struct
+// whose interface field's method is invoked across a further parameter boundary. The failure path's
+// zero `valErrParams{}` does not poison the success-path summary, so the non-nil Keysrv flows through
+// the boundary and the call below carries no //want.
+
+type valErrKeyService interface{ IssuerKeySpace(s string) int }
+type valErrParams struct{ Keysrv valErrKeyService }
+
+type valErrRealKS struct{}
+
+func (valErrRealKS) IssuerKeySpace(string) int { return 0 }
+
+func valErrGetKeySources(fail bool) (valErrKeyService, error) {
+	if fail {
+		return nil, errors.New("boom")
+	}
+	return valErrRealKS{}, nil
+}
+
+// valErrGetParams's failure return pairs the zero struct with the error variable `err`, which is not
+// definitely nil, so the omitted Keysrv field must not be bound into the success-path summary.
+func valErrGetParams(fail bool) (valErrParams, error) {
+	ks, err := valErrGetKeySources(fail)
+	if err != nil {
+		return valErrParams{}, err // zero value struct + error variable: not bound
+	}
+	return valErrParams{Keysrv: ks}, nil
+}
+
+// valErrNewAuthSSI: on every call reaching here Keysrv was set on valErrGetParams's success path.
+func valErrNewAuthSSI(p valErrParams) int {
+	return p.Keysrv.IssuerKeySpace("x") // safe — no //want
+}
+
+func valErrProvide(fail bool) int {
+	params, err := valErrGetParams(fail)
+	if err != nil {
+		return -1
+	}
+	return valErrNewAuthSSI(params)
+}
+
+// valErrGetParamsCtor pairs the zero struct with an error constructor (`errors.New`), which is
+// definitely non-nil. Kept as a second regression case for the constructor path.
+func valErrGetParamsCtor(fail bool) (valErrParams, error) {
+	if fail {
+		return valErrParams{}, errors.New("boom") // definitely-non-nil error: discharged
+	}
+	return valErrParams{Keysrv: valErrRealKS{}}, nil
+}
+
+func valErrUseCtor(p valErrParams) int {
+	return p.Keysrv.IssuerKeySpace("y") // safe — no //want
+}
+
+func valErrProvideOK(fail bool) int {
+	params, err := valErrGetParamsCtor(fail)
+	if err != nil {
+		return -1
+	}
+	return valErrUseCtor(params)
+}

--- a/testdata/src/go.uber.org/structinitv2/local/local.go
+++ b/testdata/src/go.uber.org/structinitv2/local/local.go
@@ -1,0 +1,138 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package local checks that uninitialized struct fields are caught within a single function.
+package local
+
+type A struct {
+	ptr  *int
+	aptr *leaf
+}
+
+type leaf struct {
+	ptr *int
+}
+
+func m() {
+	var b = &A{}
+	print(b.aptr.ptr) //want "uninitialized field `aptr`"
+}
+
+func m2() {
+	var b = A{}
+	print(b.aptr.ptr) //want "uninitialized field `aptr`"
+}
+
+func m3() {
+	var b = &A{aptr: new(leaf)}
+	print(b.aptr.ptr)
+}
+
+func m4() {
+	var b = &A{aptr: &leaf{}}
+	print(b.aptr.ptr)
+}
+
+func m5() {
+	var b = A{aptr: new(leaf)}
+	print(b.aptr.ptr)
+}
+
+// Initialization without explicit field key
+func m6() {
+	var b = A{new(int), new(leaf)}
+	print(b.aptr.ptr)
+}
+
+func m7() {
+	b := &A{}
+	print(b.aptr.ptr) //want "uninitialized field `aptr`"
+}
+
+func m8() {
+	b := &A{aptr: new(leaf)}
+	print(b.aptr.ptr)
+}
+
+func m9() {
+	var b *A
+	b = &A{}
+	print(b.aptr.ptr) //want "uninitialized field `aptr`"
+}
+
+func m10() {
+	var b *A
+	b = &A{aptr: new(leaf)}
+	print(b.aptr.ptr)
+}
+
+func m14() {
+	b := new(A)
+	print(b.aptr.ptr) //want "uninitialized field `aptr`"
+}
+
+func m15() {
+	var b A
+	print(b.aptr.ptr) //want "uninitialized field `aptr`"
+}
+
+// this test checks that we only get error for `b` being nil, and not for its uninitialized fields
+func m16() {
+	var b *A
+	print(b.aptr.ptr) //want "unassigned variable `b`"
+}
+
+// Testing unnamed struct
+func m12() {
+	var x = &struct{ a *A }{a: new(A)}
+	print(x.a.ptr)
+
+	y := new(struct{ a *A })
+	// TODO: unnamed struct initialization is not supported. Following line should give a warning
+	print(y.a.aptr)
+}
+
+// Tests use of anonymous fields
+// otherwise similar to the previous test
+
+type A11 struct {
+	ptr *int
+	*leaf
+}
+
+func m11() {
+	var b = &A11{}
+	print(b.leaf.ptr) //want "uninitialized field `leaf`"
+}
+
+// Tests use of promoted fields
+// similar to the previous test
+
+// TODO: Add support for promoted fields
+// This test should give an error
+
+type B13 struct {
+	A13
+}
+
+type A13 struct {
+	aptr *leaf
+	ptr  *int
+}
+
+func m13() {
+	var b = &B13{}
+	// This should actually give an error
+	print(b.aptr.ptr)
+}

--- a/testdata/src/go.uber.org/structinitv2/paramfield/paramfield.go
+++ b/testdata/src/go.uber.org/structinitv2/paramfield/paramfield.go
@@ -1,0 +1,155 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package paramfield tests nilability flowing through fields of a function or method parameter.
+package paramfield
+
+type A struct {
+	ptr  *int
+	aptr *leaf
+}
+
+type leaf struct {
+	ptr *int
+}
+
+func callF11() {
+	t := &A{aptr: &leaf{}}
+	f11(t)
+}
+
+func f11(c *A) {
+	print(c.aptr.ptr)
+}
+
+// Positive example
+
+func callF12() {
+	t := &A{}
+	f12(t)
+}
+
+func f12(c *A) {
+	print(c.aptr.ptr) //want "field `aptr` of param 0 of `f12`"
+}
+
+// Negative test
+
+func callF31() {
+	t1 := &A{}
+	t2 := &A{aptr: &leaf{}}
+	f31(t1, t2)
+}
+
+func f31(c *A, d *A) {
+	c.aptr = &leaf{}
+	g31(d, c)
+}
+
+func g31(c *A, d *A) {
+	// Both (param 0).aptr and (param 1).aptr are initialized in all calls to g31
+	print(c.aptr.ptr, d.aptr.ptr)
+}
+
+// Another negative test
+
+func m31(c *A) {
+	// c.aptr is initialized in all calls to m31
+	print(c.aptr.ptr)
+}
+
+func m32() {
+	d := &A{}
+	d.aptr = &leaf{}
+	m31(d)
+}
+
+func m33() {
+	d := &A{aptr: &leaf{}}
+	m31(d)
+}
+
+// Positive example with direct composite as parameter
+
+func callF14() {
+	f14(&A{})
+}
+
+func f14(c *A) {
+	print(c.aptr.ptr) //want "field `aptr` of param 0 of `f14`"
+}
+
+// Positive example with direct composite as parameter
+func giveA15() *A {
+	return &A{}
+}
+
+func callF15() {
+	f15(giveA15())
+}
+
+func f15(c *A) {
+	print(c.aptr.ptr) //want "field `aptr` of param 0 of `f15`"
+}
+
+// Negative example with direct composite as parameter
+
+func callF16() {
+	f16(&A{aptr: &leaf{}})
+}
+
+func f16(c *A) {
+	print(c.aptr.ptr)
+}
+
+// Negative example with direct composite as parameter
+func giveA17() *A {
+	return &A{aptr: new(leaf)}
+}
+
+func callF17() {
+	f17(giveA17())
+}
+
+func f17(c *A) {
+	print(c.aptr.ptr)
+}
+
+// Negative example with multiple return function as a parameter
+func giveA18() (*A, *A) {
+	return &A{aptr: new(leaf)}, &A{aptr: new(leaf)}
+}
+
+func callF18() {
+	f18(giveA18())
+}
+
+func f18(c *A, d *A) {
+	print(c.aptr.ptr, d.aptr.ptr)
+}
+
+// TODO: Handle this case
+// Positive example with multiple return function as a parameter
+func giveA19() (*A, *A) {
+	return &A{aptr: new(leaf)}, &A{}
+}
+
+func callF19() {
+	f19(giveA19())
+}
+
+func f19(c *A, d *A) {
+	// This should give a Nilaway error
+	print(c.aptr.ptr, d.aptr.ptr)
+}

--- a/testdata/src/go.uber.org/structinitv2/paramfield/receiverfield.go
+++ b/testdata/src/go.uber.org/structinitv2/paramfield/receiverfield.go
@@ -1,0 +1,98 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package paramfield
+
+// Negative example
+
+func callM21() {
+	t := &A{}
+	t.aptr = &leaf{}
+	t.m21()
+}
+
+func (c *A) m21() {
+	print(c.aptr.ptr)
+}
+
+// Positive example
+
+func callM22() {
+	t := &A{}
+	t.m22()
+}
+
+func (c *A) m22() {
+	print(c.aptr.ptr) //want "field `aptr` of method receiver of `m22`"
+}
+
+// Checking if Nilaway does not crash on unnamed receivers
+func (*A) m23() {}
+
+// Positive example with direct composite as parameter
+
+func callF24() {
+	(A{}).f24()
+}
+
+func (c A) f24() {
+	print(c.aptr.ptr) //want "field `aptr` of method receiver of `f24`"
+}
+
+// Positive example with direct composite as parameter
+func giveA25() *A {
+	return &A{}
+}
+
+func callF25() {
+	giveA25().f25()
+}
+
+func (c *A) f25() {
+	print(c.aptr.ptr) //want "field `aptr` of method receiver of `f25`"
+}
+
+// Negative example with direct composite as parameter
+
+func callF26() {
+	(&A{aptr: &leaf{}}).f26()
+}
+
+func (c *A) f26() {
+	print(c.aptr.ptr)
+}
+
+// Negative example with direct composite as parameter
+func giveA27() *A {
+	return &A{aptr: new(leaf)}
+}
+
+func callF27() {
+	giveA27().f27()
+}
+
+func (c *A) f27() {
+	print(c.aptr.ptr)
+}
+
+// No Nilaway error in this case.
+// But it is a special case and Nilaway should not crash on it
+
+type someError struct {
+	error
+}
+
+func (n someError) IsSomeError() bool {
+	return true
+}

--- a/testdata/src/go.uber.org/structinitv2/paramsideeffect/localfieldwrite.go
+++ b/testdata/src/go.uber.org/structinitv2/paramsideeffect/localfieldwrite.go
@@ -1,0 +1,72 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Tests in-place writes of a param's field from a local variable (`x.f = local`). A provably
+// non-nil local must not fire; a nil or possibly-nil local must still fire.
+
+package paramsideeffect
+
+type User struct{ Phone *int }
+type Req struct{ U *User }
+
+func getNilUser() *User { return nil }
+
+// Case 1 — direct call result (static snapshot): fires (TP).
+func enrichCallResult(r *Req) { r.U = getNilUser() }
+func readCallResult() *int {
+	r := &Req{}
+	enrichCallResult(r)
+	return r.U.Phone //want "field `U` of param 0 of `enrichCallResult`"
+}
+
+// Case 2 — direct nil (static snapshot): fires (TP).
+func enrichNil(r *Req) { r.U = nil }
+func readNil() *int {
+	r := &Req{}
+	enrichNil(r)
+	return r.U.Phone //want "field `U` of param 0 of `enrichNil`"
+}
+
+// Case 3 — local holding a nil call result (tie -> nilable): fires (TP).
+func enrichLocalNilCall(r *Req) {
+	u := getNilUser()
+	r.U = u
+}
+func readLocalNilCall() *int {
+	r := &Req{}
+	enrichLocalNilCall(r)
+	return r.U.Phone //want "field `U` of param 0 of `enrichLocalNilCall`"
+}
+
+// Case 4 — local declared nil (tie -> nilable): fires (TP).
+func enrichLocalVarNil(r *Req) {
+	var u *User
+	r.U = u
+}
+func readLocalVarNil() *int {
+	r := &Req{}
+	enrichLocalVarNil(r)
+	return r.U.Phone //want "field `U` of param 0 of `enrichLocalVarNil`"
+}
+
+// Case 5 — local holding a non-nil allocation (tie -> non-nil): NO fire.
+func enrichLocalNonNil(r *Req) {
+	u := &User{}
+	r.U = u
+}
+func readLocalNonNil() *int {
+	r := &Req{}
+	enrichLocalNonNil(r)
+	return r.U.Phone // safe: u is provably non-nil, so r.U is non-nil after the call
+}

--- a/testdata/src/go.uber.org/structinitv2/paramsideeffect/paramsideeffect.go
+++ b/testdata/src/go.uber.org/structinitv2/paramsideeffect/paramsideeffect.go
@@ -1,0 +1,166 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package paramsideeffect tests nilability when a callee writes a parameter's or receiver's field in
+// place, so the caller observes the post-call value.
+package paramsideeffect
+
+type A struct {
+	ptr    *int
+	aptr   *A
+	newPtr *A
+}
+
+func populate11(x *A) {
+	x.newPtr = &A{}
+}
+
+func m1() *int {
+	b := &A{}
+	b.aptr = &A{}
+	populate11(b)
+	print(b.newPtr.ptr)
+	return b.aptr.ptr
+}
+
+// Similar but positive test
+
+func populate12(x *A) {
+	x.newPtr = nil
+}
+
+func m12() *int {
+	b := &A{}
+	b.aptr = &A{}
+	populate12(b)
+	print(b.newPtr.ptr) //want "field `newPtr` of param 0 of `populate12`"
+	return b.aptr.ptr
+}
+
+// Negative test
+
+func (*A) populate13(x *A) {
+	x.newPtr = &A{}
+}
+
+func m3() *int {
+	b := &A{}
+	b.aptr = &A{aptr: new(A)}
+	b.aptr.populate13(b)
+	print(b.newPtr.ptr)
+	return b.aptr.ptr
+}
+
+// Negative test
+
+type B struct {
+	ptr1 *A
+	ptr2 *A
+	ptr3 *A
+}
+
+func setPtr1(a *B) {
+	a.ptr1 = new(A)
+}
+
+func setPtr2(a *B) {
+	a.ptr2 = new(A)
+}
+
+func setPtr3(a *B) {
+	a.ptr3 = new(A)
+}
+
+func m() {
+	a := &B{}
+	setPtr1(a)
+	print(a.ptr1.ptr)
+	setPtr2(a)
+	print(a.ptr1.ptr)
+	print(a.ptr2.ptr)
+	setPtr3(a)
+	print(a.ptr1.ptr)
+	print(a.ptr2.ptr)
+	print(a.ptr3.ptr)
+}
+
+// If identical arguments to function call
+
+func initializeFirst(a1 *A, a2 *A) {
+	a1.aptr = a2
+}
+func caller() {
+	a := &A{}
+	initializeFirst(a, a)
+	print(a.aptr.ptr)
+}
+
+// positive case
+func populate14(x *A) {
+	x.newPtr = nil
+}
+
+func m14() *int {
+	b := &A{}
+	b.newPtr = &A{}
+	populate14(b)
+	return b.newPtr.ptr //want "field `newPtr` of param 0 of `populate14`"
+}
+
+// negative case
+func populate15(x *A) {
+	x.newPtr = nil
+}
+
+func m15() *int {
+	b := &A{}
+	populate14(b)
+	b.newPtr = &A{}
+	return b.newPtr.ptr
+}
+
+// Following cases of false positives and false negatives are due to limitations of our current technique under these special cases
+// TODO: Find a better to way to handle these.
+// Another case of identical arguments to function call: False positive
+
+func initializeSecond(a1 *A, a2 *A) {
+	a1.aptr = nil
+	a2.aptr = new(A)
+}
+
+func caller2() {
+	a := &A{}
+	initializeSecond(a, a)
+	print(a.aptr.ptr) //want "field `aptr` of param 0 of `initializeSecond`"
+}
+
+// Another case of identical arguments to function call: False negative
+
+func initializeSecond2(a1 *A, a2 *A) {
+	a1.aptr = new(A)
+	a2.aptr = nil
+}
+
+func caller3() {
+	a := &A{}
+	initializeSecond2(a, a)
+	print(a.aptr.ptr)
+}
+
+// Test case for checking tracking of param side effects with a struct object
+func testStructObject() *int {
+	var b A
+	populate11(&b)
+	return b.newPtr.ptr
+}

--- a/testdata/src/go.uber.org/structinitv2/paramsideeffect/receiversideeffect.go
+++ b/testdata/src/go.uber.org/structinitv2/paramsideeffect/receiversideeffect.go
@@ -1,0 +1,43 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package paramsideeffect
+
+// Tests populating a method receiver.
+
+func (x *A) populateMethod() {
+	x.newPtr = &A{}
+}
+
+func m21() *int {
+	b := &A{}
+	b.aptr = &A{}
+	b.populateMethod()
+	print(b.newPtr.ptr)
+	return b.aptr.ptr
+}
+
+// Positive test
+
+func (x *A) populateMethod2() {
+	x.newPtr = nil
+}
+
+func m22() *int {
+	b := &A{}
+	b.aptr = &A{}
+	b.populateMethod2()
+	print(b.newPtr.ptr) //want "field `newPtr` of method receiver of `populateMethod2`"
+	return b.aptr.ptr
+}

--- a/testdata/src/go.uber.org/structinitv2/paramsideeffect/transitive.go
+++ b/testdata/src/go.uber.org/structinitv2/paramsideeffect/transitive.go
@@ -1,0 +1,230 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Tests transitive (forwarding) param side effects: a function that does not directly write a
+// parameter's field but forwards the parameter to another function/method that does. The write must
+// be attributed to the forwarder so callers re-produce the mutated field.
+
+package paramsideeffect
+
+// 1. Two-level forward, positive: writeNil nils x.f, fwdNil forwards x to it.
+
+func writeNil(x *A) {
+	x.newPtr = nil
+}
+
+func fwdNil(x *A) {
+	writeNil(x)
+}
+
+func tForwardPositive() *int {
+	b := &A{}
+	b.newPtr = &A{}
+	fwdNil(b)
+	return b.newPtr.ptr //want "field `newPtr` of param 0 of `fwdNil`"
+}
+
+// 2. Two-level forward, negative: writeNonNil sets x.f non-nil, forwarded through fwdNonNil, so no
+// diagnostic.
+
+func writeNonNil(x *A) {
+	x.newPtr = &A{}
+}
+
+func fwdNonNil(x *A) {
+	writeNonNil(x)
+}
+
+func tForwardNegative() *int {
+	b := &A{}
+	fwdNonNil(b)
+	return b.newPtr.ptr
+}
+
+// 3. Three-level chain to exercise the fixpoint past depth 2.
+
+func writeNil3(x *A) {
+	x.newPtr = nil
+}
+
+func fwd3a(x *A) {
+	writeNil3(x)
+}
+
+func fwd3b(x *A) {
+	fwd3a(x)
+}
+
+func tThreeLevelChain() *int {
+	b := &A{}
+	b.newPtr = &A{}
+	fwd3b(b)
+	return b.newPtr.ptr //want "field `newPtr` of param 0 of `fwd3b`"
+}
+
+// 4. Field-chain forward through a nested struct: fwdChain forwards x.mid to a writer of its leaf
+// field. The caller observes the write on the nested path mid.leaf.
+
+type inner struct {
+	leaf *A
+}
+
+type outer struct {
+	mid *inner
+}
+
+func writeNilLeaf(i *inner) {
+	i.leaf = nil
+}
+
+func fwdChain(o *outer) {
+	writeNilLeaf(o.mid)
+}
+
+func tFieldChainForward() *int {
+	b := &outer{mid: &inner{leaf: &A{}}}
+	fwdChain(b)
+	return b.mid.leaf.ptr //want "field `mid.leaf` of param 0 of `fwdChain`"
+}
+
+// 4b. Recursive-field forward: forwarding through a self-referential field (`A.aptr *A`) is not
+// supported and must be skipped — the analysis terminates and emits no diagnostic.
+
+func writeNilRecField(x *A) {
+	x.newPtr = nil
+}
+
+func fwdRecField(x *A) {
+	writeNilRecField(x.aptr)
+}
+
+func tRecursiveFieldForward() *int {
+	b := &A{aptr: &A{newPtr: &A{}}}
+	fwdRecField(b)
+	return b.aptr.newPtr.ptr // recursive field path not tracked: under-report, no want
+}
+
+// 5. Receiver forward: a method forwards its receiver to a writer method.
+
+func (x *A) populateRecv() {
+	x.newPtr = nil
+}
+
+func (x *A) fwdRecv() {
+	x.populateRecv()
+}
+
+func tReceiverForward() *int {
+	b := &A{}
+	b.newPtr = &A{}
+	b.fwdRecv()
+	return b.newPtr.ptr //want "field `newPtr` of method receiver of `fwdRecv`"
+}
+
+// 5b. Symmetric: the receiver itself is forwarded as a plain argument to a writer function.
+
+func writeNilArg(x *A) {
+	x.newPtr = nil
+}
+
+func (x *A) fwdRecvAsArg() {
+	writeNilArg(x)
+}
+
+func tReceiverForwardedAsArg() *int {
+	b := &A{}
+	b.newPtr = &A{}
+	b.fwdRecvAsArg()
+	return b.newPtr.ptr //want "field `newPtr` of method receiver of `fwdRecvAsArg`"
+}
+
+// 6. Recursive / cyclic forwarder: must terminate and produce the write from the base-case writer.
+
+func writeNilRec(x *A) {
+	x.newPtr = nil
+}
+
+func fwdRec(x *A, n int) {
+	if n <= 0 {
+		writeNilRec(x)
+		return
+	}
+	fwdRec(x, n-1)
+}
+
+func tRecursiveForward() *int {
+	b := &A{}
+	b.newPtr = &A{}
+	fwdRec(b, 3)
+	return b.newPtr.ptr //want "field `newPtr` of param 0 of `fwdRec`"
+}
+
+// 6b. Mutual recursion (g <-> h) with a writer at the base case.
+
+func writeNilMut(x *A) {
+	x.newPtr = nil
+}
+
+func fwdMutA(x *A, n int) {
+	if n <= 0 {
+		writeNilMut(x)
+		return
+	}
+	fwdMutB(x, n-1)
+}
+
+func fwdMutB(x *A, n int) {
+	fwdMutA(x, n-1)
+}
+
+func tMutualRecursion() *int {
+	b := &A{}
+	b.newPtr = &A{}
+	fwdMutA(b, 4)
+	return b.newPtr.ptr //want "field `newPtr` of param 0 of `fwdMutA`"
+}
+
+// 7. Negative non-forward (regression): an opaque/no-op call between two writes must NOT mark
+// unrelated fields. noop forwards nothing, so the caller's own non-nil value survives.
+
+func noop(x *A) {
+	_ = x
+}
+
+func tNonForwardNoFalsePositive() *int {
+	b := &A{}
+	b.newPtr = &A{}
+	noop(b)
+	return b.newPtr.ptr
+}
+
+// 8. Forward only re-produces the forwarded field; an unrelated field the caller initialized
+// non-nil must survive the forwarding call.
+
+func writeOneField(x *A) {
+	x.aptr = nil
+}
+
+func fwdOneField(x *A) {
+	writeOneField(x)
+}
+
+func tForwardOnlyAffectsWrittenField() *int {
+	b := &A{}
+	b.aptr = &A{}
+	b.newPtr = &A{}
+	fwdOneField(b)
+	print(b.aptr.ptr) //want "field `aptr` of param 0 of `fwdOneField`"
+	return b.newPtr.ptr
+}

--- a/testdata/src/go.uber.org/structinitv2/returnshape/app/app.go
+++ b/testdata/src/go.uber.org/structinitv2/returnshape/app/app.go
@@ -1,0 +1,171 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package app is the consumer side of the cross-package return-shape tests: the deep dereferences
+// land here, so the diagnostics are asserted with //want in this package. See package lib.
+package app
+
+import (
+	"go.uber.org/structinitv2/returnshape/lib"
+	"go.uber.org/structinitv2/returnshape/mid"
+)
+
+// ReturnDeepNil leaves Mid.Child nil; the deep deref must flag.
+func useReturnDeepNil() {
+	a := lib.ReturnDeepNil()
+	print(a.Mid.Child.Ptr) //want "field `Mid.Child` of result 0 of `ReturnDeepNil`"
+}
+
+// ReturnDeepNonNil initializes Mid.Child; the same deref must NOT flag.
+func useReturnDeepNonNil() {
+	a := lib.ReturnDeepNonNil()
+	print(a.Mid.Child.Ptr)
+}
+
+// Transitive across two package hops (app -> mid.ForwardImportedResult -> lib.ReturnDeepNil).
+func useForwardImportedResult() {
+	a := mid.ForwardImportedResult()
+	print(a.Mid.Child.Ptr) //want "field `Mid.Child` of result 0 of `ForwardImportedResult`"
+}
+
+// `return g()` is as deep as g's own return shape.
+func useReturnForwardedConstructor() {
+	a := lib.ReturnForwardedConstructor()
+	print(a.Mid.Child.Ptr) //want "field `Mid.Child` of result 0 of `ReturnForwardedConstructor`"
+}
+
+// Field-projection return `return x.In`; x.In.Child is nil.
+func useReturnProjection() {
+	a := lib.ReturnProjection()
+	print(a.Child.Ptr) //want "field `Child` of result 0 of `ReturnProjection`"
+}
+
+// ReturnProjectionSafe initializes Child; no flag.
+func useReturnProjectionSafe() {
+	a := lib.ReturnProjectionSafe()
+	print(a.Child.Ptr)
+}
+
+// Zero-value return `var x Outer; return x`; Mid is nil.
+func useReturnZeroValue() {
+	a := lib.ReturnZeroValue()
+	print(a.Mid.Child) //want "field `Mid` of result 0 of `ReturnZeroValue`"
+}
+
+// Naked named return is a documented under-report — NOT flagged.
+func useNaked() {
+	a := lib.NakedRet()
+	print(a.Mid.Child)
+}
+
+// The recursive constructor's top-level Ptr is tracked.
+func useRecTop() {
+	a := lib.MkRec()
+	print(*a.Ptr) //want "field `Ptr` of result 0 of `MkRec`"
+}
+
+// One unrolling of the recursive type is supported, and Self.Ptr is genuinely nil, so this flags.
+// Paths beyond the first unrolling (Self.Self.Ptr) stay under-reports.
+func useRecDeep() {
+	a := lib.MkRec()
+	print(*a.Self.Ptr) //want "field `Self.Ptr` of result 0 of `MkRec`"
+}
+
+// Param tie: b ties to t; t.Mid.Child is nil, so the deep deref flags.
+func useForwardParam() {
+	t := &lib.Outer{Mid: &lib.Node{}}
+	b := lib.ForwardParam(t)
+	print(b.Mid.Child.Ptr) //want "uninitialized field `Child`"
+}
+
+// The tie carries t's real (non-nil) shape; no flag.
+func useForwardParamSafe() {
+	t := &lib.Outer{Mid: &lib.Node{Child: &lib.Leaf{}}}
+	b := lib.ForwardParam(t)
+	print(b.Mid.Child.Ptr)
+}
+
+// ForwardParamNilField nils the field before forwarding; the deref must observe the post-call nil.
+func useForwardParamNilField() {
+	t := &lib.Node{Child: &lib.Leaf{}}
+	b := lib.ForwardParamNilField(t)
+	print(b.Child.Ptr) //want "field `Child` of param 0 of `ForwardParamNilField`"
+}
+
+// Receiver forwarding: b ties to the receiver t; t.Child is nil.
+func useRecv() {
+	t := &lib.Node{}
+	b := t.Self()
+	print(b.Child.Ptr) //want "uninitialized field `Child`"
+}
+
+// Field-projection param tie: b ties to t.In; t.In.Child is nil.
+func useForwardParamProjection() {
+	t := &lib.Wrap{In: &lib.Inner{}}
+	b := lib.ForwardParamProjection(t)
+	print(b.Child.Ptr) //want "uninitialized field `Child`"
+}
+
+// Transitive param tie: the tie reaches back to the caller's argument t, whose Mid.Child is nil.
+func useForwardParamTransitive() {
+	t := &lib.Outer{Mid: &lib.Node{}}
+	b := lib.ForwardParamTransitive(t)
+	print(b.Mid.Child.Ptr) //want "uninitialized field `Child`"
+}
+
+// The transitive tie carries t's real (non-nil) shape; no flag.
+func useForwardParamTransitiveSafe() {
+	t := &lib.Outer{Mid: &lib.Node{Child: &lib.Leaf{}}}
+	b := lib.ForwardParamTransitive(t)
+	print(b.Mid.Child.Ptr)
+}
+
+// Ambiguous multi-return forwarder: the result could be either parameter, so the tie bails — a
+// documented under-report, NOT flagged.
+func useForwardParamAmbiguous() {
+	t := &lib.Outer{Mid: &lib.Node{}}
+	w := &lib.Outer{Mid: &lib.Node{}}
+	b := lib.ForwardParamAmbiguous(t, w, true)
+	print(b.Mid.Child.Ptr)
+}
+
+// Cross-package transitive tie: the tie reaches the caller's argument t two package hops away.
+func useForwardParamCrossPkg() {
+	t := &lib.Outer{Mid: &lib.Node{}}
+	b := mid.ForwardParamCrossPkg(t)
+	print(b.Mid.Child.Ptr) //want "uninitialized field `Child`"
+}
+
+// Mixed sometimes constructs (Mid.Child nil) and sometimes forwards its param. The forwarding
+// summary is dropped, but the construct branch's own nil field is still a genuine true positive.
+func useMixed() {
+	t := &lib.Outer{Mid: &lib.Node{Child: &lib.Leaf{}}}
+	b := lib.Mixed(t, true)
+	print(b.Mid.Child.Ptr) //want "field `Mid.Child` of result 0 of `Mixed`"
+}
+
+// MixedSafe's construct branch is safe but it also forwards its param, so the forwarding tie is
+// dropped: even though t.Mid.Child is nil, b must NOT be tied to t, so this is NOT flagged.
+func useMixedSafe() {
+	t := &lib.Outer{Mid: &lib.Node{}}
+	b := lib.MixedSafe(t, true)
+	print(b.Mid.Child.Ptr)
+}
+
+// Spreading a multi-result call (`TwoOut()`) into a forwarder gives the tie a non-lvalue argument,
+// so it must bail. The deref is a sound under-report; the point is that analysis completes.
+func useForwardFirstParamSpread() {
+	b := lib.ForwardFirstParam(lib.TwoOut())
+	print(b.Mid.Child.Ptr)
+}

--- a/testdata/src/go.uber.org/structinitv2/returnshape/lib/lib.go
+++ b/testdata/src/go.uber.org/structinitv2/returnshape/lib/lib.go
@@ -1,0 +1,170 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package lib is the producer side of the cross-package return-shape tests: its constructors return
+// values whose deep field nilability is dereferenced only by the sibling app package. The struct
+// types are distinct at each level (Outer -> Node -> Leaf) so the deep paths are non-recursive.
+package lib
+
+// Leaf is the deepest struct; its Ptr is the dereference target.
+type Leaf struct {
+	Ptr *int
+}
+
+// Node nests a Leaf.
+type Node struct {
+	Child *Leaf
+}
+
+// Outer nests a Node, giving the depth-2 field path Mid.Child.
+type Outer struct {
+	Mid *Node
+}
+
+// ReturnDeepNil returns a value whose Mid is set but whose nested Mid.Child is left nil.
+func ReturnDeepNil() *Outer {
+	x := &Outer{Mid: &Node{}}
+	return x
+}
+
+// ReturnDeepNonNil is the negative control: it initializes Mid.Child, so the same deref is safe.
+func ReturnDeepNonNil() *Outer {
+	x := &Outer{Mid: &Node{Child: &Leaf{}}}
+	return x
+}
+
+// ReturnForwardedConstructor forwards a constructor's result directly (`return g()`), so it is as
+// deep as ReturnDeepNil's own return shape.
+func ReturnForwardedConstructor() *Outer {
+	return ReturnDeepNil()
+}
+
+// Inner and Wrap give a field-projection return target.
+type Inner struct {
+	Child *Leaf
+}
+
+// Wrap nests an Inner so ReturnProjection can return the projection x.In.
+type Wrap struct {
+	In *Inner
+}
+
+// ReturnProjection returns a field projection (`return x.In`); the result is an *Inner whose Child
+// is left nil.
+func ReturnProjection() *Inner {
+	x := &Wrap{In: &Inner{}}
+	return x.In
+}
+
+// ReturnProjectionSafe is the negative control for ReturnProjection: Child is initialized.
+func ReturnProjectionSafe() *Inner {
+	x := &Wrap{In: &Inner{Child: &Leaf{}}}
+	return x.In
+}
+
+// ReturnZeroValue returns a zero-value struct (`var x Outer; return x`), so Mid is nil. The value
+// form is summarized; the naked form below is not.
+func ReturnZeroValue() Outer {
+	var x Outer
+	return x
+}
+
+// NakedRet is a documented under-report: a naked named return has no result expression, so its shape
+// is not summarized and the cross-package deref is NOT flagged.
+func NakedRet() (x Outer) {
+	return
+}
+
+// Rec is a self-referential type: paths through Self are recursive and skipped past the first
+// unrolling, so MkRec's top-level Ptr is tracked but Self.Ptr is not.
+type Rec struct {
+	Ptr  *int
+	Self *Rec
+}
+
+// MkRec constructs a recursive value with Self set but Ptr (and Self.Ptr) nil.
+func MkRec() *Rec {
+	return &Rec{Self: &Rec{}}
+}
+
+// ForwardParam forwards its parameter to its result (`return x`); the result's shape is the caller's
+// argument, resolved per-call.
+func ForwardParam(x *Outer) *Outer {
+	return x
+}
+
+// ForwardParamNilField forwards its parameter but first nils a field of it, so a caller must observe
+// the post-call value of the forwarded field.
+func ForwardParamNilField(x *Node) *Node {
+	x.Child = nil
+	return x
+}
+
+// Self forwards its receiver to its result.
+func (n *Node) Self() *Node {
+	return n
+}
+
+// ForwardParamProjection forwards its parameter at a field projection (`return x.In`), so the caller
+// ties to arg.In.
+func ForwardParamProjection(x *Wrap) *Inner {
+	return x.In
+}
+
+// ForwardParamTransitive returns a call to ForwardParam passing its own parameter, so it too
+// forwards param 0 to result 0; a caller's deref observes its own argument shape.
+func ForwardParamTransitive(y *Outer) *Outer {
+	return ForwardParam(y)
+}
+
+// ForwardParamAmbiguous forwards a different parameter on each return site. Because the result could
+// be either parameter, the caller-side tie bails — a documented under-report.
+func ForwardParamAmbiguous(y *Outer, z *Outer, pick bool) *Outer {
+	if pick {
+		return ForwardParam(y)
+	}
+	return ForwardParam(z)
+}
+
+// Mixed constructs on one branch (Mid.Child nil) and forwards its parameter on the other, so both
+// the return-shape and param-forwarding summaries are dropped. The construct branch's own nil field
+// is still observed by a caller — a true positive the drop must not suppress.
+func Mixed(x *Outer, pick bool) *Outer {
+	if pick {
+		return &Outer{Mid: &Node{}}
+	}
+	return x
+}
+
+// MixedSafe is the false-positive guard: the construct branch is safe while the other forwards a
+// parameter, so the param-forwarding summary is dropped and a caller passing a nil-field argument is
+// not wrongly flagged.
+func MixedSafe(x *Outer, pick bool) *Outer {
+	if pick {
+		return &Outer{Mid: &Node{Child: &Leaf{}}}
+	}
+	return x
+}
+
+// TwoOut returns a struct and a bool so a caller can spread it into a forwarder's parameters
+// (`ForwardFirstParam(TwoOut())`).
+func TwoOut() (*Outer, bool) {
+	return &Outer{Mid: &Node{}}, true
+}
+
+// ForwardFirstParam forwards its first parameter. Called as `ForwardFirstParam(TwoOut())`, the tie's
+// candidate argument is the multi-result call itself, which is not a stable lvalue, so the tie bails.
+func ForwardFirstParam(x *Outer, ok bool) *Outer {
+	return x
+}

--- a/testdata/src/go.uber.org/structinitv2/returnshape/mid/mid.go
+++ b/testdata/src/go.uber.org/structinitv2/returnshape/mid/mid.go
@@ -1,0 +1,34 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package mid is the middle hop of the transitive cross-package return-shape test: it forwards a
+// constructor and a param-forwarder defined in lib, re-exporting their shapes so the app package (two
+// hops away) still sees the deep nil field.
+package mid
+
+import "go.uber.org/structinitv2/returnshape/lib"
+
+// ForwardImportedResult forwards lib.ReturnDeepNil's result, re-exporting the deep shape so a caller
+// two packages away inherits it.
+func ForwardImportedResult() *lib.Outer {
+	x := lib.ReturnDeepNil()
+	return x
+}
+
+// ForwardParamCrossPkg returns a call to lib.ForwardParam (a param-forwarder in another package), so
+// it forwards its own param 0 to result 0; a caller in app ties the result to its own argument across
+// two package hops.
+func ForwardParamCrossPkg(y *lib.Outer) *lib.Outer {
+	return lib.ForwardParam(y)
+}


### PR DESCRIPTION
`struct-init-v2` feature will introduce allocation-site sensitive struct field nil checks into nilaway.

This commit introduces tests that will be run and validated by the struct-init-v2 code. Future commits will enable these tests.