### PR TITLE
Fix false positive for errors.As guard in right operand of &&

### DIFF
--- a/assertion/function/assertiontree/util.go
+++ b/assertion/function/assertiontree/util.go
@@ -22,6 +22,7 @@ import (
 	"slices"
 
 	"go.uber.org/nilaway/annotation"
+	"go.uber.org/nilaway/hook"
 	"go.uber.org/nilaway/util/analysishelper"
 	"go.uber.org/nilaway/util/tokenhelper"
 	"go.uber.org/nilaway/util/typeshelper"
@@ -158,6 +159,18 @@ func AddNilCheck(pass *analysishelper.EnhancedPass, expr ast.Expr) (trueCheck, f
 		trueNilCheck, falseNilCheck, isNoop := AddNilCheck(pass, e.X)
 		return falseNilCheck, trueNilCheck, isNoop
 	}
+
+	if callExpr, ok := expr.(*ast.CallExpr); ok {
+		replaced := hook.ReplaceConditional(pass, callExpr)
+		if replaced == nil {
+			return noop, noop, true
+		}
+		if replacedBin, ok := replaced.(*ast.BinaryExpr); ok && replacedBin.Op == token.LAND {
+			return AddNilCheck(pass, replacedBin.Y)
+		}
+		return noop, noop, true
+	}
+
 	binExpr, ok := expr.(*ast.BinaryExpr)
 	if !ok {
 		// `expr` is not a direct or indirect binary expression - do no work

--- a/testdata/src/go.uber.org/trustedfunc/trustedfuncs.go
+++ b/testdata/src/go.uber.org/trustedfunc/trustedfuncs.go
@@ -984,6 +984,12 @@ func errorsAs(err error, num string, dummy bool) {
 		if errors.As(err, &exitErr) && dummy {
 			print(*exitErr)
 		}
+	case "method call on target in short-circuit AND (right operand)":
+		var exitErr *exec.ExitError
+		_ = errors.As(err, &exitErr) && exitErr.Exited()
+	case "field access on target in short-circuit AND (right operand)":
+		var myErr *exec.Error
+		_ = errors.As(err, &myErr) && myErr.Name == ""
 	case "errors.As with other conditionals connected by OR":
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) || dummy {


### PR DESCRIPTION
When errors.As(err, &target) appears as the left operand of && in a non-conditional context (e.g. assignment or return statement), go/cfg represents the whole statement as a single flat CFG node, so the existing replaceConditional preprocessing never fires and the right operand has no nil guard for target.

Fix by extending AddNilCheck to handle *ast.CallExpr: if ReplaceConditional recognises the call (e.g. errors.As → "call && target != nil"), we extract and return the nil check from the right operand of that replacement. This lets the existing LAND handling in AddComputation propagate the guard to field/selector accesses in the right operand without any CFG restructuring.

Adds test cases for the method-call and field-access variants of the pattern.

Claude-assisted, human-reviewed.