### PR TITLE
feat(struct-init-v2): add "-struct-init-v2" flag in config

### DIFF
--- a/assertion/function/analyzer.go
+++ b/assertion/function/analyzer.go
@@ -92,6 +92,7 @@ func run(p *analysis.Pass) ([]annotation.FullTrigger, error) {
 	// Construct experimental features. By default, enable all features on NilAway itself.
 	functionConfig := assertiontree.FunctionConfig{
 		EnableStructInitCheck: conf.ExperimentalStructInitEnable,
+		EnableStructInitV2:    conf.ExperimentalStructInitV2Enable,
 		EnableAnonymousFunc:   conf.ExperimentalAnonymousFuncEnable,
 	}
 	if strings.HasPrefix(pass.Pkg.Path(), config.NilAwayPkgPathPrefix) { //nolint:revive
@@ -99,6 +100,7 @@ func run(p *analysis.Pass) ([]annotation.FullTrigger, error) {
 		// TODO: enable anonymous function flag.
 	} else {
 		functionConfig.EnableStructInitCheck = conf.ExperimentalStructInitEnable
+		functionConfig.EnableStructInitV2 = conf.ExperimentalStructInitV2Enable
 		functionConfig.EnableAnonymousFunc = conf.ExperimentalAnonymousFuncEnable
 	}
 

--- a/assertion/function/assertiontree/function_context.go
+++ b/assertion/function/assertiontree/function_context.go
@@ -69,6 +69,8 @@ type FunctionContext struct {
 type FunctionConfig struct {
 	// EnableStructInitCheck is a flag to enable tracking struct initializations.
 	EnableStructInitCheck bool
+	// EnableStructInitV2 enables the allocation-site-sensitive struct init analysis (v2).
+	EnableStructInitV2 bool
 	// EnableAnonymousFunc is a flag to enable checking anonymous functions.
 	EnableAnonymousFunc bool
 }

--- a/config/config.go
+++ b/config/config.go
@@ -48,6 +48,9 @@ type Config struct {
 	GroupErrorMessages bool
 	// ExperimentalStructInitEnable indicates whether experimental struct initialization is enabled.
 	ExperimentalStructInitEnable bool
+	// ExperimentalStructInitV2Enable indicates whether the allocation-site-sensitive struct
+	// initialization analysis (v2) is enabled.
+	ExperimentalStructInitV2Enable bool
 	// ExperimentalAnonymousFuncEnable indicates whether experimental anonymous function support is enabled.
 	ExperimentalAnonymousFuncEnable bool
 	// PrintFullFilePath incidates whether to print full filenames in the output.
@@ -148,6 +151,8 @@ const (
 	ExcludeFileDocStringsFlag = "exclude-file-docstrings"
 	// ExperimentalStructInitEnableFlag is the flag name for the experimental struct init support.
 	ExperimentalStructInitEnableFlag = "experimental-struct-init"
+	// ExperimentalStructInitV2EnableFlag is the flag name for the allocation-site-sensitive struct init support (v2).
+	ExperimentalStructInitV2EnableFlag = "experimental-struct-init-v2"
 	// ExperimentalAnonymousFunctionFlag is the flag name for the experimental anonymous function support.
 	ExperimentalAnonymousFunctionFlag = "experimental-anonymous-function"
 	// PrintFullFilePathFlag is the flag name for printing full filenames in output.
@@ -168,6 +173,7 @@ func newFlagSet() flag.FlagSet {
 	_ = fs.String(ExcludePkgsFlag, "", "Comma-separated list of packages to exclude from analysis")
 	_ = fs.String(ExcludeFileDocStringsFlag, "", "Comma-separated list of docstrings to exclude from analysis")
 	_ = fs.Bool(ExperimentalStructInitEnableFlag, false, "Whether to enable experimental struct initialization support")
+	_ = fs.Bool(ExperimentalStructInitV2EnableFlag, false, "Whether to enable allocation-site-sensitive struct initialization support (v2)")
 	_ = fs.Bool(ExperimentalAnonymousFunctionFlag, false, "Whether to enable experimental anonymous function support")
 	_ = fs.Bool(PrintFullFilePathFlag, false, "Whether to show full filenames in output")
 	_ = fs.Bool(ExcludeTestFilesFlag, false, "Whether to exclude diagnostics involving test files")
@@ -194,6 +200,9 @@ func run(pass *analysis.Pass) (any, error) {
 	}
 	if enableStructInit, ok := pass.Analyzer.Flags.Lookup(ExperimentalStructInitEnableFlag).Value.(flag.Getter).Get().(bool); ok {
 		conf.ExperimentalStructInitEnable = enableStructInit
+	}
+	if enableExperimentalStructInitV2, ok := pass.Analyzer.Flags.Lookup(ExperimentalStructInitV2EnableFlag).Value.(flag.Getter).Get().(bool); ok {
+		conf.ExperimentalStructInitV2Enable = enableExperimentalStructInitV2
 	}
 	if enableAnonymousFunc, ok := pass.Analyzer.Flags.Lookup(ExperimentalAnonymousFunctionFlag).Value.(flag.Getter).Get().(bool); ok {
 		conf.ExperimentalAnonymousFuncEnable = enableAnonymousFunc


### PR DESCRIPTION
This change introduces `ExperimentalStructInitV2Enable` flag into config based on `experimental-struct-init-v2`. No consumers of this flags are introduced in this change.