### PR TITLE
feat(struct-init-v2): wire struct field effects analyzer into nilaway

### DIFF
--- a/assertion/function/analyzer.go
+++ b/assertion/function/analyzer.go
@@ -30,6 +30,7 @@ import (
 	"go.uber.org/nilaway/assertion/anonymousfunc"
 	"go.uber.org/nilaway/assertion/function/assertiontree"
 	"go.uber.org/nilaway/assertion/function/functioncontracts"
+	"go.uber.org/nilaway/assertion/function/structfieldeffects"
 	"go.uber.org/nilaway/assertion/structfield"
 	"go.uber.org/nilaway/config"
 	"go.uber.org/nilaway/util/analysishelper"
@@ -56,6 +57,7 @@ var Analyzer = &analysis.Analyzer{
 		structfield.Analyzer,
 		anonymousfunc.Analyzer,
 		functioncontracts.Analyzer,
+		structfieldeffects.Analyzer,
 	},
 }
 
@@ -107,7 +109,8 @@ func run(p *analysis.Pass) ([]annotation.FullTrigger, error) {
 	ctrlflowResult := pass.ResultOf[ctrlflow.Analyzer].(*ctrlflow.CFGs)
 	anonymousFuncResult := pass.ResultOf[anonymousfunc.Analyzer].(*analysishelper.Result[map[*ast.FuncLit]*anonymousfunc.FuncLitInfo])
 	contractsResult := pass.ResultOf[functioncontracts.Analyzer].(*analysishelper.Result[functioncontracts.Map])
-	if err := errors.Join(anonymousFuncResult.Err, contractsResult.Err); err != nil {
+	structFieldEffectsResult := pass.ResultOf[structfieldeffects.Analyzer].(*analysishelper.Result[*structfieldeffects.ParamFieldEffects])
+	if err := errors.Join(anonymousFuncResult.Err, contractsResult.Err, structFieldEffectsResult.Err); err != nil {
 		return nil, err
 	}
 
@@ -118,6 +121,10 @@ func run(p *analysis.Pass) ([]annotation.FullTrigger, error) {
 	for _, info := range funcLitMap {
 		pkgFakeIdentMap[info.FakeFuncDecl.Name] = info.FakeFuncObj
 	}
+
+	// Field paths needed for the boundary bindings, precomputed by the struct field effects
+	// analyzer (empty when the analysis is disabled).
+	paramFieldEffects := structFieldEffectsResult.Res
 
 	// Set up variables for synchronization and communication.
 	ctx, cancel := context.WithCancel(context.Background())
@@ -199,7 +206,7 @@ func run(p *analysis.Pass) ([]annotation.FullTrigger, error) {
 
 			// Now, analyze the function declarations concurrently.
 			funcContext := assertiontree.NewFunctionContext(
-				pass, funcDecl, funcLit, functionConfig, funcLitMap, pkgFakeIdentMap, funcContracts)
+				pass, funcDecl, funcLit, functionConfig, funcLitMap, pkgFakeIdentMap, funcContracts, paramFieldEffects)
 			idx := funcIndex
 			wg.Go(func() { analyzeFunc(ctx, pass, funcDecl, funcContext, graph, idx, funcChan) })
 			funcIndex++

--- a/assertion/function/analyzer_test.go
+++ b/assertion/function/analyzer_test.go
@@ -87,7 +87,7 @@ func TestCancelledContext(t *testing.T) {
 	emptyPkgFakeIdentMap := make(map[*ast.Ident]types.Object)
 	emptyFuncContracts := make(functioncontracts.Map)
 	funcContext := assertiontree.NewFunctionContext(pass, funcDecl, nil, /* funcLit */
-		funcConfig, emptyFuncLitMap, emptyPkgFakeIdentMap, emptyFuncContracts)
+		funcConfig, emptyFuncLitMap, emptyPkgFakeIdentMap, emptyFuncContracts, nil)
 	// (3) Set up synchronization and communication for the goroutine we are going to spawn.
 	resultChan := make(chan functionResult)
 	var wg sync.WaitGroup
@@ -175,7 +175,7 @@ func TestBackpropFixpointConvergence(t *testing.T) {
 		emptyPkgFakeIdentMap := make(map[*ast.Ident]types.Object)
 		emptyFuncContracts := make(functioncontracts.Map)
 		funcContext := assertiontree.NewFunctionContext(pass, funcDecl, nil, /* funcLit */
-			funcConfig, emptyFuncLitMap, emptyPkgFakeIdentMap, emptyFuncContracts)
+			funcConfig, emptyFuncLitMap, emptyPkgFakeIdentMap, emptyFuncContracts, nil)
 		ctrlflowResult := pass.ResultOf[ctrlflow.Analyzer].(*ctrlflow.CFGs)
 
 		ctx, cancel := context.WithCancel(t.Context())

--- a/assertion/function/assertiontree/backprop.go
+++ b/assertion/function/assertiontree/backprop.go
@@ -33,6 +33,7 @@ import (
 	"go.uber.org/nilaway/util/asthelper"
 	"go.uber.org/nilaway/util/typeshelper"
 	"golang.org/x/tools/go/cfg"
+	"golang.org/x/tools/go/types/typeutil"
 )
 
 // backpropAcrossBlock iterates over all nodes in the CFG block in _reverse_ order, writes logs,
@@ -153,6 +154,10 @@ func backpropAcrossReturn(rootNode *RootAssertionNode, node *ast.ReturnStmt) err
 
 	if rootNode.functionContext.functionConfig.EnableStructInitCheck {
 		rootNode.addConsumptionsForFieldsOfParams()
+	}
+
+	if rootNode.functionContext.functionConfig.EnableStructInitV2 {
+		rootNode.bindReturnFieldsToContext(node)
 	}
 
 	if len(node.Results) == 1 {
@@ -319,7 +324,8 @@ func backpropAcrossAssignment(rootNode *RootAssertionNode, lhs, rhs []ast.Expr) 
 				// handle but does involve distinct semantics.
 				return backpropAcrossRange(rootNode, lhs, r.X)
 			case token.AND:
-				if !rootNode.functionContext.functionConfig.EnableStructInitCheck {
+				if !rootNode.functionContext.functionConfig.EnableStructInitCheck &&
+					!rootNode.functionContext.functionConfig.EnableStructInitV2 {
 					// This is the case of creating a pointer and assigning it to a variable, e.g., `x := &y`,
 					// where y is a non-pointer type (e.g., y := S{}).
 					// Here, the pointer is always nonnil, so we can just add a ProduceTriggerNever.
@@ -654,6 +660,15 @@ buildShadowMask:
 		}
 	}
 
+	// Attach field producers before generic assignment handling detaches LHS subtrees.
+	if rootNode.functionContext.functionConfig.EnableStructInitV2 {
+		for i := range lhs {
+			if !shadowMask[i] && !asthelper.IsEmptyExpr(lhs[i]) {
+				rootNode.addAllocationFieldProducers(lhs[i], rhs[i])
+			}
+		}
+	}
+
 	// This struct is declared to assist with deferring the second phase of the assignments
 	type deferredLanding struct {
 		lhsNode AssertionNode
@@ -804,6 +819,18 @@ func backpropAcrossManyToOneAssignment(rootNode *RootAssertionNode, lhs, rhs []a
 		// Eliminates checking of the `_` instances in the lhs of a multiple assignment
 		if asthelper.IsEmptyExpr(lhsVal) {
 			continue
+		}
+
+		// Bind return fields before LHS production detaches its subtree.
+		if rootNode.functionContext.functionConfig.EnableStructInitV2 {
+			if funcObj := typeutil.StaticCallee(rootNode.Pass().TypesInfo, rhsVal); funcObj != nil {
+				sig := funcObj.Type().(*types.Signature)
+				if i < sig.Results().Len() {
+					if st := typeshelper.AsDeeplyStruct(sig.Results().At(i).Type()); st != nil {
+						rootNode.addContextFieldProducers(st, lhsVal, funcObj, annotation.StructFieldReturnContext, i)
+					}
+				}
+			}
 		}
 
 		// Phase 1

--- a/assertion/function/assertiontree/function_context.go
+++ b/assertion/function/assertiontree/function_context.go
@@ -20,6 +20,7 @@ import (
 
 	"go.uber.org/nilaway/assertion/anonymousfunc"
 	"go.uber.org/nilaway/assertion/function/functioncontracts"
+	"go.uber.org/nilaway/assertion/function/structfieldeffects"
 	"go.uber.org/nilaway/util/analysishelper"
 )
 
@@ -63,6 +64,12 @@ type FunctionContext struct {
 
 	// funcContracts stores the function contracts of all the functions.
 	funcContracts functioncontracts.Map
+
+	// paramFieldEffects is the package-level boundary summary computed by the struct field effects
+	// analyzer. Read-only here and always non-nil (empty when the analysis is disabled): the boundary
+	// field binding consults the read-path accessors to bind only the field paths a boundary actually
+	// dereferences rather than the full type.
+	paramFieldEffects *structfieldeffects.ParamFieldEffects
 }
 
 // FunctionConfig is meant to hold all the user set configuration for analyzing a function
@@ -84,7 +91,13 @@ func NewFunctionContext(
 	funcLitMap map[*ast.FuncLit]*anonymousfunc.FuncLitInfo,
 	pkgFakeIdentMap map[*ast.Ident]types.Object,
 	funcContracts functioncontracts.Map,
+	effects *structfieldeffects.ParamFieldEffects,
 ) FunctionContext {
+	// Keep effects non-nil so the boundary lookups never need a nil guard; an empty summary
+	// (nil inner maps) reads back as "no effects", which is correct when the analysis is disabled.
+	if effects == nil {
+		effects = &structfieldeffects.ParamFieldEffects{}
+	}
 	return FunctionContext{
 		pass:                    pass,
 		funcDecl:                decl,
@@ -95,6 +108,7 @@ func NewFunctionContext(
 		funcLitMap:              funcLitMap,
 		pkgFakeIdentMap:         pkgFakeIdentMap,
 		funcContracts:           funcContracts,
+		paramFieldEffects:       effects,
 	}
 }
 

--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -749,6 +749,10 @@ func (r *RootAssertionNode) AddComputation(expr ast.Expr) {
 				// Add Consumptions for struct field params
 				r.addConsumptionsForArgAndReceiverFields(expr, fun)
 			}
+
+			if r.functionContext.functionConfig.EnableStructInitV2 {
+				r.bindArgAndReceiverFieldsToContext(expr, fun)
+			}
 		} else {
 			// here we have found either a builtin function like make or new,
 			// or a typecast like int(x) - in either case (at least for now), do nothing to try
@@ -1018,6 +1022,10 @@ func (r *RootAssertionNode) ProcessEntry() {
 		if r.functionContext.functionConfig.EnableStructInitCheck {
 			// process field Assertion nodes of function parameters
 			r.addProductionsForParamFields(child, builtExpr)
+		}
+
+		if r.functionContext.functionConfig.EnableStructInitV2 {
+			r.addParamFieldProducers(builtExpr)
 		}
 
 		r.AddProduction(&annotation.ProduceTrigger{

--- a/assertion/function/assertiontree/structinitv2.go
+++ b/assertion/function/assertiontree/structinitv2.go
@@ -1,0 +1,440 @@
+//  Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package assertiontree
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"strings"
+
+	"go.uber.org/nilaway/annotation"
+	"go.uber.org/nilaway/guard"
+	"go.uber.org/nilaway/util/asthelper"
+	"go.uber.org/nilaway/util/typeshelper"
+	"golang.org/x/tools/go/types/typeutil"
+)
+
+// asStructAllocation inspects expr and, if it allocates a struct value, returns the (deeply
+// resolved) struct type together with the composite-literal element expressions (nil when the
+// allocation has no explicit field initializers, e.g. `new(A)`). The boolean result reports
+// whether expr is a struct allocation.
+//
+// Recognized forms: `A{...}`, `&A{...}`, and `new(A)`.
+func (r *RootAssertionNode) asStructAllocation(expr ast.Expr) (*types.Struct, []ast.Expr, bool) {
+	switch e := expr.(type) {
+	case *ast.UnaryExpr:
+		if e.Op == token.AND {
+			return r.asStructAllocation(e.X)
+		}
+	case *ast.ParenExpr:
+		return r.asStructAllocation(e.X)
+	case *ast.CompositeLit:
+		if structType := typeshelper.AsDeeplyStruct(r.Pass().TypesInfo.TypeOf(e)); structType != nil {
+			return structType, e.Elts, true
+		}
+	case *ast.CallExpr:
+		if ident, ok := e.Fun.(*ast.Ident); ok && r.ObjectOf(ident) == typeshelper.BuiltinNew {
+			// new(A) yields a *A whose fields are all zero-valued (nil for nilable fields).
+			if structType := typeshelper.AsDeeplyStruct(r.Pass().TypesInfo.TypeOf(e)); structType != nil {
+				return structType, nil, true
+			}
+		}
+	}
+	return nil, nil, false
+}
+
+// addAllocationFieldProducers attaches, for every nilable field of a struct value allocated on the
+// RHS of an assignment and bound to lhsVal, a producer describing that field's nilability at
+// this allocation site:
+//   - a field with no initializer  -> StructFieldNil (definitely nil)
+//   - a field initialized to expr e -> the (shallow) producer of e (e.g. nonnil for `&A{}` or
+//     `new(A)`, nil for an explicit `nil`)
+//
+// If the RHS is instead a call to a struct-returning function, the value's fields are bound,
+// symbolically, to that function's return context sites (see addContextFieldProducers), so
+// the nilability flows interprocedurally through inference.
+//
+// It must be called before the generic assignment handling produces lhsVal itself, because the
+// latter detaches the lhsVal subtree (including the field nodes we target) once produced.
+func (r *RootAssertionNode) addAllocationFieldProducers(lhsVal, rhsVal ast.Expr) {
+	if structType, fieldInits, ok := r.asStructAllocation(rhsVal); ok {
+		r.addFieldProducers(structType, fieldInits, lhsVal)
+		return
+	}
+
+	// `lhs := f()` where f returns a single struct value: bind lhs's fields to f's return
+	// context sites. (Multi-return calls are handled by the many-to-one assignment path.)
+	if call, ok := ast.Unparen(rhsVal).(*ast.CallExpr); ok {
+		if funcObj := typeutil.StaticCallee(r.Pass().TypesInfo, call); funcObj != nil {
+			sig := funcObj.Type().(*types.Signature)
+			if sig.Results().Len() == 1 {
+				if structType := typeshelper.AsDeeplyStruct(sig.Results().At(0).Type()); structType != nil {
+					r.addContextFieldProducers(structType, lhsVal, funcObj, annotation.StructFieldReturnContext, 0)
+				}
+			}
+		}
+	}
+}
+
+// getShallowExprNilabilityProducer returns the producer encoding the nilability of the value of expr: an
+// always-nil producer for an explicit `nil`, the shallow producer of a trackable/nilable
+// expression, or Never for a value that cannot be nil (e.g. `&A{}`, `new(A)`).
+func (r *RootAssertionNode) getShallowExprNilabilityProducer(expr ast.Expr) annotation.ProducingAnnotationTrigger {
+	if ident, ok := ast.Unparen(expr).(*ast.Ident); ok && r.isNil(ident) {
+		return &annotation.ProduceTriggerTautology{}
+	}
+	if _, _, ok := r.asStructAllocation(expr); ok {
+		return &annotation.ProduceTriggerNever{}
+	}
+	if _, producers := r.ParseExprAsProducer(expr, true); len(producers) != 0 {
+		return producers[0].GetShallow().Annotation
+	}
+	return &annotation.ProduceTriggerNever{}
+}
+
+// getFieldInitNilabilityProducer returns the producer encoding the nilability of field i of a struct
+// allocation with the given field initializers.
+func (r *RootAssertionNode) getFieldInitNilabilityProducer(structType *types.Struct, fieldInits []ast.Expr, i int) annotation.ProducingAnnotationTrigger {
+	field := structType.Field(i)
+	fieldVal := asthelper.GetFieldVal(fieldInits, field.Name(), structType.NumFields(), i)
+	if fieldVal == nil {
+		return &annotation.StructFieldNil{
+			ProduceTriggerTautology: &annotation.ProduceTriggerTautology{},
+			FieldName:               field.Name(),
+		}
+	}
+	return r.getShallowExprNilabilityProducer(fieldVal)
+}
+
+// addFieldProducers performs the per-field producer attachment described on
+// addAllocationFieldProducers for a concrete struct allocation. fieldInits may be nil.
+func (r *RootAssertionNode) addFieldProducers(structType *types.Struct, fieldInits []ast.Expr, base ast.Expr) {
+	numFields := structType.NumFields()
+	for i := range numFields {
+		field := structType.Field(i)
+		fieldSel := r.getSelectorExpr(field, base)
+		fieldVal := asthelper.GetFieldVal(fieldInits, field.Name(), numFields, i)
+		nilable := !typeshelper.TypeBarsNilness(field.Type())
+
+		switch {
+		case fieldVal != nil:
+			if innerType, innerInits, ok := r.asStructAllocation(fieldVal); ok {
+				r.addFieldProducers(innerType, innerInits, fieldSel)
+			}
+		case !nilable:
+			if innerType := typeshelper.AsDeeplyStruct(field.Type()); innerType != nil {
+				r.addFieldProducers(innerType, nil, fieldSel)
+			}
+		}
+
+		if !nilable {
+			continue
+		}
+		r.AddProduction(&annotation.ProduceTrigger{
+			Annotation: r.getFieldInitNilabilityProducer(structType, fieldInits, i),
+			Expr:       fieldSel,
+		})
+	}
+}
+
+// accessedFieldPath is one accessed field path under a boundary value, paired with the synthesized
+// selector expression that reaches it.
+type accessedFieldPath struct {
+	sel  ast.Expr
+	path string
+}
+
+// collectAccessedFieldPaths walks the live assertion subtree under node and collects accessed nilable
+// field paths, deepest path first. prefix is the dotted path from the boundary value to node.
+func (r *RootAssertionNode) collectAccessedFieldPaths(node AssertionNode, base ast.Expr, prefix string, seen map[*types.Struct]bool, out *[]accessedFieldPath) {
+	for _, child := range node.Children() {
+		fldNode, ok := child.(*fldAssertionNode)
+		if !ok {
+			continue
+		}
+		field := fldNode.decl
+		sel := r.getSelectorExpr(field, base)
+		path := field.Name()
+		if prefix != "" {
+			path = prefix + "." + field.Name()
+		}
+		if inner := typeshelper.AsDeeplyStruct(field.Type()); inner == nil || !seen[inner] {
+			if inner != nil {
+				seen[inner] = true
+			}
+			r.collectAccessedFieldPaths(child, sel, path, seen, out)
+			if inner != nil {
+				delete(seen, inner)
+			}
+		}
+		if !typeshelper.TypeBarsNilness(field.Type()) {
+			*out = append(*out, accessedFieldPath{sel: sel, path: path})
+		}
+	}
+}
+
+// addContextFieldProducers attaches, for each accessed nilable field path under base, a producer
+// making `base.<path>` nil iff the corresponding return/param context site of funcObj is inferred
+// nilable.
+func (r *RootAssertionNode) addContextFieldProducers(_ *types.Struct, base ast.Expr, funcObj *types.Func, kind annotation.StructFieldContextKind, index int) {
+	path, _ := r.ParseExprAsProducer(base, false)
+	node, _ := r.lookupPath(path)
+	if node == nil {
+		return
+	}
+	var paths []accessedFieldPath
+	r.collectAccessedFieldPaths(node, base, "", make(map[*types.Struct]bool), &paths)
+	for _, p := range paths {
+		site := &annotation.StructFieldContextSite{
+			FuncObj: funcObj, Kind: kind, Index: index, Path: p.path,
+		}
+		r.AddProduction(&annotation.ProduceTrigger{
+			Annotation: &annotation.StructFieldFromContext{
+				TriggerIfNilable: &annotation.TriggerIfNilable{Ann: site},
+			},
+			Expr: p.sel,
+		})
+	}
+}
+
+// bindReturnFieldsToContext binds, at a return statement, the fields of each struct-typed return
+// value to that result's return context site, so the returned value's per-field nilability
+// becomes the function's return summary.
+func (r *RootAssertionNode) bindReturnFieldsToContext(node *ast.ReturnStmt) {
+	sig := r.FuncObj().Type().(*types.Signature)
+	if len(node.Results) != sig.Results().Len() {
+		return
+	}
+	if typeshelper.FuncIsErrReturning(sig) {
+		errExpr := node.Results[sig.Results().Len()-1]
+		// We are not attaching a consumer when we are sure that the the err is definitely non-nil
+		if _, definitelyNonNil := r.getShallowExprNilabilityProducer(errExpr).(*annotation.ProduceTriggerNever); definitelyNonNil {
+			return
+		}
+	}
+	for retIdx, retExpr := range node.Results {
+		structType := typeshelper.AsDeeplyStruct(sig.Results().At(retIdx).Type())
+		if structType == nil {
+			continue
+		}
+		r.bindValueFieldsToContext(r.FuncObj(), retExpr, structType, annotation.StructFieldReturnContext, retIdx)
+	}
+}
+
+// bindValueFieldsToContext connects the fields of the value produced by valExpr to the context
+// site of targetFunc at (kind, index). Inline allocations and trackable values are bound; a
+// struct-returning call forwarded across the boundary is unsupported (see below).
+func (r *RootAssertionNode) bindValueFieldsToContext(targetFunc *types.Func, valExpr ast.Expr, structType *types.Struct, kind annotation.StructFieldContextKind, index int) {
+	funcObj := targetFunc
+
+	// A struct-returning call forwarded across a boundary (e.g. `return f()` or `g(f())`) is
+	// unsupported, so we do nothing for it. Binding it would compose the callee's per-field return
+	// summary into this boundary, which requires the return-read demand to be transitively closed
+	// over forwarding edges (as the effects prepass does for param reads). That closure is not
+	// computed for returns, as it is incomplete for cross package returns (return read info flows in
+	// the opposite direction of analysis facts)
+	if _, ok := ast.Unparen(valExpr).(*ast.CallExpr); ok {
+		return
+	}
+
+	allocType, fieldInits, isAlloc := r.asStructAllocation(valExpr)
+	if isAlloc {
+		r.bindAllocationFieldsToContext(allocType, fieldInits, valExpr, "", funcObj, kind, index)
+		return
+	}
+
+	trackablePath, _ := r.ParseExprAsProducer(valExpr, false)
+	if trackablePath == nil {
+		return
+	}
+
+	var demanded []string
+	switch kind {
+	case annotation.StructFieldParamContext:
+		demanded = r.functionContext.paramFieldEffects.ParamReadPaths(funcObj, index)
+	case annotation.StructFieldReturnContext:
+		demanded = r.functionContext.paramFieldEffects.ReturnReadPaths(funcObj, index)
+	}
+	for _, fieldPath := range demanded {
+		sel, ok := r.buildFieldPathSelector(valExpr, structType, fieldPath)
+		if !ok {
+			continue
+		}
+		site := &annotation.StructFieldContextSite{
+			FuncObj: funcObj, Kind: kind, Index: index, Path: fieldPath,
+		}
+		r.AddConsumption(&annotation.ConsumeTrigger{
+			Annotation: &annotation.StructFieldToContext{TriggerIfNonNil: &annotation.TriggerIfNonNil{Ann: site}},
+			Expr:       sel,
+			Guards:     guard.NoGuards(),
+		})
+	}
+}
+
+// bindAllocationFieldsToContext binds the per-field nilability of an inline struct allocation to
+// the boundary context site of funcObj at (kind, index).
+func (r *RootAssertionNode) bindAllocationFieldsToContext(structType *types.Struct, fieldInits []ast.Expr, valExpr ast.Expr, prefix string, funcObj *types.Func, kind annotation.StructFieldContextKind, index int) {
+	numFields := structType.NumFields()
+	for i := range numFields {
+		field := structType.Field(i)
+		fieldVal := asthelper.GetFieldVal(fieldInits, field.Name(), numFields, i)
+		nilable := !typeshelper.TypeBarsNilness(field.Type())
+		path := field.Name()
+		if prefix != "" {
+			path = prefix + "." + field.Name()
+		}
+
+		switch {
+		case fieldVal != nil:
+			if innerType, innerInits, ok := r.asStructAllocation(fieldVal); ok {
+				r.bindAllocationFieldsToContext(innerType, innerInits, valExpr, path, funcObj, kind, index)
+			}
+		case !nilable:
+			if innerType := typeshelper.AsDeeplyStruct(field.Type()); innerType != nil {
+				r.bindAllocationFieldsToContext(innerType, nil, valExpr, path, funcObj, kind, index)
+			}
+		}
+
+		if !nilable {
+			continue
+		}
+		site := &annotation.StructFieldContextSite{
+			FuncObj: funcObj, Kind: kind, Index: index, Path: path,
+		}
+		r.AddNewTriggers(annotation.FullTrigger{
+			Producer: &annotation.ProduceTrigger{Annotation: r.getFieldInitNilabilityProducer(structType, fieldInits, i), Expr: valExpr},
+			Consumer: &annotation.ConsumeTrigger{
+				Annotation: &annotation.StructFieldToContext{TriggerIfNonNil: &annotation.TriggerIfNonNil{Ann: site}},
+				Expr:       valExpr,
+				Guards:     guard.NoGuards(),
+			},
+		})
+	}
+}
+
+// addZeroValueFieldProducers attaches StructFieldNil producers for the nilable fields of a struct value
+// that is the zero value.
+func (r *RootAssertionNode) addZeroValueFieldProducers(varNode AssertionNode, base ast.Expr) {
+	children := make([]AssertionNode, len(varNode.Children()))
+	copy(children, varNode.Children())
+
+	for _, child := range children {
+		fldNode, ok := child.(*fldAssertionNode)
+		if !ok || typeshelper.TypeBarsNilness(fldNode.decl.Type()) {
+			continue
+		}
+		selExpr := r.getSelectorExpr(fldNode.decl, base)
+		r.AddProduction(&annotation.ProduceTrigger{
+			Annotation: &annotation.StructFieldNil{
+				ProduceTriggerTautology: &annotation.ProduceTriggerTautology{},
+				FieldName:               fldNode.decl.Name(),
+			},
+			Expr: selExpr,
+		})
+	}
+}
+
+// getParamIndex returns the parameter index of v within the current function's signature, or the
+// receiver index for the receiver, and whether v is a parameter/receiver at all.
+func (r *RootAssertionNode) getParamIndex(v *types.Var) (int, bool) {
+	sig := r.FuncObj().Signature()
+	if recv := sig.Recv(); recv != nil && recv == v {
+		return annotation.ReceiverParamIndex, true
+	}
+	for i := range sig.Params().Len() {
+		if sig.Params().At(i) == v {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+// addParamFieldProducers attaches, at function entry, producers making each nilable field of
+// a struct-typed parameter/receiver nil iff the corresponding parameter context site is inferred
+// nilable.
+func (r *RootAssertionNode) addParamFieldProducers(builtExpr ast.Expr) {
+	ident, ok := builtExpr.(*ast.Ident)
+	if !ok {
+		return
+	}
+	v, ok := r.ObjectOf(ident).(*types.Var)
+	if !ok {
+		return
+	}
+	idx, ok := r.getParamIndex(v)
+	if !ok {
+		return
+	}
+	structType := typeshelper.AsDeeplyStruct(v.Type())
+	if structType == nil {
+		return
+	}
+	r.addContextFieldProducers(structType, builtExpr, r.FuncObj(), annotation.StructFieldParamContext, idx)
+}
+
+// buildFieldPathSelector builds the selector expression reaching base.<path>, where path is a
+// dotted field path under base's struct type.
+func (r *RootAssertionNode) buildFieldPathSelector(base ast.Expr, structType *types.Struct, path string) (ast.Expr, bool) {
+	cur := base
+	curStruct := structType
+	for _, name := range strings.Split(path, ".") {
+		if curStruct == nil {
+			return nil, false
+		}
+		var field *types.Var
+		for i := range curStruct.NumFields() {
+			if curStruct.Field(i).Name() == name {
+				field = curStruct.Field(i)
+				break
+			}
+		}
+		if field == nil {
+			return nil, false
+		}
+		cur = r.getSelectorExpr(field, cur)
+		curStruct = typeshelper.AsDeeplyStruct(field.Type())
+	}
+	return cur, true
+}
+
+// bindArgAndReceiverFieldsToContext binds, at a function or method call, the fields of each struct-typed
+// argument to the callee's corresponding parameter context site.
+func (r *RootAssertionNode) bindArgAndReceiverFieldsToContext(call *ast.CallExpr, funcIdent *ast.Ident) {
+	funcObj, ok := r.ObjectOf(funcIdent).(*types.Func)
+	if !ok {
+		return
+	}
+	sig := funcObj.Signature()
+
+	if recv := sig.Recv(); recv != nil {
+		if sel, ok := ast.Unparen(call.Fun).(*ast.SelectorExpr); ok {
+			if structType := typeshelper.AsDeeplyStruct(recv.Type()); structType != nil {
+				r.bindValueFieldsToContext(funcObj, sel.X, structType, annotation.StructFieldParamContext, annotation.ReceiverParamIndex)
+			}
+		}
+	}
+
+	for argIdx, arg := range call.Args {
+		if argIdx >= sig.Params().Len() {
+			break
+		}
+		structType := typeshelper.AsDeeplyStruct(sig.Params().At(argIdx).Type())
+		if structType == nil {
+			continue
+		}
+		r.bindValueFieldsToContext(funcObj, arg, structType, annotation.StructFieldParamContext, argIdx)
+	}
+}

--- a/assertion/function/assertiontree/var_assertion_node.go
+++ b/assertion/function/assertiontree/var_assertion_node.go
@@ -69,6 +69,9 @@ func (v *varAssertionNode) DefaultTrigger() annotation.ProducingAnnotationTrigge
 			if v.Root().functionContext.functionConfig.EnableStructInitCheck {
 				v.Root().addProductionForVarFieldNode(v, v.BuildExpr(nil))
 			}
+			if v.Root().functionContext.functionConfig.EnableStructInitV2 {
+				v.Root().addZeroValueFieldProducers(v, v.BuildExpr(nil))
+			}
 			return &annotation.ProduceTriggerNever{} // indicating that the struct object itself is not nil
 		}
 	}

--- a/assertion/function/structfieldeffects/effects.go
+++ b/assertion/function/structfieldeffects/effects.go
@@ -17,6 +17,7 @@ package structfieldeffects
 import (
 	"go/ast"
 	"go/types"
+	"sort"
 	"strings"
 
 	"go.uber.org/nilaway/annotation"
@@ -40,6 +41,34 @@ type ParamFieldEffects struct {
 	// result — the demand callers place on a returned value, so a `return <var>` binds only those
 	// paths. Collected at call sites; not transitively closed (under-report only).
 	ReturnReads fieldEffects
+}
+
+// ParamReadPaths returns the field paths read from funcObj's parameter or receiver at idx.
+func (e *ParamFieldEffects) ParamReadPaths(funcObj *types.Func, idx int) []string {
+	if e == nil {
+		return nil
+	}
+	return readPaths(e.ParamReads, funcObj, idx)
+}
+
+// ReturnReadPaths returns the field paths read from funcObj's result at idx.
+func (e *ParamFieldEffects) ReturnReadPaths(funcObj *types.Func, idx int) []string {
+	if e == nil {
+		return nil
+	}
+	return readPaths(e.ReturnReads, funcObj, idx)
+}
+
+func readPaths(effects fieldEffects, funcObj *types.Func, idx int) []string {
+	reads := effects[funcObj]
+	paths := make([]string, 0, len(reads))
+	for key := range reads {
+		if key.idx == idx && key.path != "" {
+			paths = append(paths, key.path)
+		}
+	}
+	sort.Strings(paths)
+	return paths
 }
 
 // ComputeParamFieldEffects walks every function and method in the package once and records the

--- a/nilaway_test.go
+++ b/nilaway_test.go
@@ -104,29 +104,19 @@ func TestStructInit(t *testing.T) { //nolint:paralleltest
 }
 
 func TestStructInitV2(t *testing.T) { //nolint:paralleltest
-	//	err := config.Analyzer.Flags.Set(config.StructInitV2EnableFlag, "true")
-	//	require.NoError(t, err)
-	//	defer func() {
-	//		err := config.Analyzer.Flags.Set(config.StructInitV2EnableFlag, "false")
-	//		require.NoError(t, err)
-	//	}()
-	//
-	//	testdata := analysistest.TestData()
-	//	analysistest.Run(t, testdata, Analyzer,
-	//		"go.uber.org/structinitv2/local",
-	//		"go.uber.org/structinitv2/global",
-	//		"go.uber.org/structinitv2/defaultfield",
-	//		"go.uber.org/structinitv2/deep",
-	//		"go.uber.org/structinitv2/paramfield",
-	//		"go.uber.org/structinitv2/paramsideeffect",
-	//		"go.uber.org/structinitv2/funcreturnfields",
-	//		"go.uber.org/structinitv2/returnshape/app",
-	//		"go.uber.org/structinitv2/crosspkg/app",
-	//		"go.uber.org/structinitv2/crosspkgside/app",
-	//		"go.uber.org/structinitv2/limitations",
-	//	)
-	//
-	t.Skip("struct-init-v2 testdata is not wired")
+	err := config.Analyzer.Flags.Set(config.ExperimentalStructInitV2EnableFlag, "true")
+	require.NoError(t, err)
+	defer func() {
+		err := config.Analyzer.Flags.Set(config.ExperimentalStructInitV2EnableFlag, "false")
+		require.NoError(t, err)
+	}()
+
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, Analyzer,
+		"go.uber.org/structinitv2/local",
+		"go.uber.org/structinitv2/defaultfield",
+		"go.uber.org/structinitv2/deep",
+	)
 }
 
 func TestAnonymousFunction(t *testing.T) { //nolint:paralleltest

--- a/testdata/src/go.uber.org/structinitv2/deep/deep.go
+++ b/testdata/src/go.uber.org/structinitv2/deep/deep.go
@@ -91,3 +91,59 @@ func takesDeepOk(c *A) {
 func callDeepOk() {
 	takesDeepOk(&A{aptr: &A2{aptr: &A3{}}})
 }
+
+// Return-read demand also applies to var declarations.
+func useReturnVarDeclNil() {
+	var b = giveNil()
+	print(b.aptr.aptr.ptr) //want "uninitialized field `aptr`"
+}
+
+// Multi-return assignments bind the struct result by result index.
+func giveNilWithFlag() (*A, bool) { return &A{aptr: &A2{}}, false }
+
+func useMultiReturnNil() {
+	b, _ := giveNilWithFlag()
+	print(b.aptr.aptr.ptr) //want "uninitialized field `aptr`"
+}
+
+// Returns with a nonnil error do not bind struct fields.
+type deepErr struct{}
+
+func (deepErr) Error() string { return "deep" }
+
+func giveErrorPathNil() (*A, error) {
+	return &A{}, deepErr{}
+}
+
+func useErrorPathNil() {
+	b, err := giveErrorPathNil()
+	if err != nil {
+		return
+	}
+	print(b.aptr.ptr)
+}
+
+// Returned locals bind their field shape to the return context.
+func giveLocalNil() *A {
+	b := &A{}
+	return b
+}
+
+func useLocalReturnNil() {
+	b := giveLocalNil()
+	print(b.aptr.ptr) //want "uninitialized field `aptr`"
+}
+
+// Blank-assigned struct results are skipped.
+func dropStructResult() {
+	_, _ = giveNilWithFlag()
+}
+
+// Parameters with no field reads do not bind argument fields.
+func takesNoRead(c *A) {
+	_ = c
+}
+
+func callNilStructArg() {
+	takesNoRead(nil)
+}

--- a/testdata/src/go.uber.org/structinitv2/defaultfield/defaultfield.go
+++ b/testdata/src/go.uber.org/structinitv2/defaultfield/defaultfield.go
@@ -14,8 +14,8 @@
 
 // Package defaultfield checks the escape policy for nil struct fields:
 //
-//  1. A nil field that escapes into analyzed code (returned to, passed to, or mutated by a function
-//     NilAway can see) and is then dereferenced IS reported, at the dereference.
+//  1. A nil field that escapes into analyzed code (returned to or passed to a function NilAway can
+//     see) and is then dereferenced IS reported, at the dereference.
 //  2. A nil field that escapes into unanalyzed code, or a parameter with no in-package caller, gets
 //     NilAway's standard optimistic treatment and is NOT reported.
 package defaultfield
@@ -55,15 +55,6 @@ func escapeIntoSink() {
 	sink(&A{aptr: &A2{}}) // supplies aptr.aptr == nil
 }
 
-// A nil field escapes via a callee's side effect and is dereferenced by the caller afterwards.
-func clobber(c *A) { c.aptr = nil }
-
-func derefAfterSideEffect() {
-	b := &A{aptr: &A2{}}
-	clobber(b)
-	print(b.aptr.ptr) //want "field `aptr`"
-}
-
 // ---------------------------------------------------------------------------
 // Unknown caller / unanalyzed escape: optimistic, NOT reported (by design).
 // ---------------------------------------------------------------------------
@@ -86,4 +77,23 @@ func neverNil(c *A) {
 		return
 	}
 	print(c.aptr.ptr)
+}
+
+// Method receiver bindings preserve allocation-site field nilability.
+func (c *A) sinkMethod() {
+	print(c.aptr.ptr) //want "uninitialized field `aptr`"
+}
+
+func escapeIntoMethodSink() {
+	(&A{}).sinkMethod()
+}
+
+// Trackable local arguments preserve allocation-site field nilability.
+func sinkTracked(c *A) {
+	print(c.aptr.ptr) //want "uninitialized field `aptr`"
+}
+
+func escapeTrackedIntoSink() {
+	b := &A{}
+	sinkTracked(b)
 }

--- a/testdata/src/go.uber.org/structinitv2/limitations/limitations.go
+++ b/testdata/src/go.uber.org/structinitv2/limitations/limitations.go
@@ -172,6 +172,29 @@ func tForwardViaFuncValue() *int {
 	return b.child.ptr
 }
 
+// False negative: parameter field writes are not supported, so a nil field written by a callee is
+// not re-produced at the call site.
+func clobberParamField(c *Node) { c.child = nil }
+
+func tParamFieldWriteNotMerged() *int {
+	b := &Node{child: &Leaf{}}
+	clobberParamField(b)
+	return b.child.ptr
+}
+
+// False negative: a struct-returning call forwarded through a return (`return f()`) is unsupported.
+// The callee's per-field return summary is not composed across the forward, so the nil child from
+// makeNilNode is not tracked at the caller. Supporting it would need the return-read demand closed
+// over forwarding edges (as closeParamFieldSets does for params), which is not computed for returns.
+func makeNilNode() *Node { return &Node{} }
+
+func forwardNilNode() *Node { return makeNilNode() }
+
+func tForwardedReturnNotComposed() *int {
+	b := forwardNilNode()
+	return b.child.ptr
+}
+
 // ---------------------------------------------------------------------------------------------
 // FALSE POSITIVES (over-reports — //want required)
 // ---------------------------------------------------------------------------------------------

--- a/testdata/src/go.uber.org/structinitv2/local/local.go
+++ b/testdata/src/go.uber.org/structinitv2/local/local.go
@@ -136,3 +136,48 @@ func m13() {
 	// This should actually give an error
 	print(b.aptr.ptr)
 }
+
+// Explicit nil field initializers are treated as nil producers.
+func m17() {
+	b := &A{aptr: nil}
+	print(b.aptr.ptr) //want "accessed field `ptr`"
+}
+
+// Parenthesized allocations are still recognized as struct allocations.
+func m18() {
+	b := (&A{})
+	print(b.aptr.ptr) //want "uninitialized field `aptr`"
+}
+
+// Non-struct parameters are ignored by the v2 field binding.
+func m19(n int) {
+	print(n)
+}
+
+// Explicit field reassignment to nil overrides the allocation shape.
+func m22() {
+	b := &A{aptr: &leaf{}}
+	b.aptr = nil
+	print(b.aptr.ptr) //want "accessed field `ptr`"
+}
+
+// Non-struct pointer parameters do not trigger v2 field binding.
+func m23(p *int) {
+	print(*p)
+}
+
+// Selector-returning calls are treated like function calls.
+type localFactory struct{}
+
+func (localFactory) newA() *A { return &A{} }
+
+func m24() {
+	b := localFactory{}.newA()
+	print(b.aptr.ptr) //want "uninitialized field `aptr`"
+}
+
+// Field initializers from parameters use the parameter's nilability.
+func m25(l *leaf) {
+	b := &A{aptr: l}
+	print(b.aptr.ptr)
+}


### PR DESCRIPTION
Wire the new structfieldeffects analyzer into NilAway’s function analysis so struct-init-v2 boundary bindings use the precomputed package-level field-read summary.

Changes
- Add structfieldeffects.Analyzer as a dependency of the function analyzer.
- Pass *structfieldeffects.ParamFieldEffects into assertiontree.FunctionContext.
- Add read-path accessors on ParamFieldEffects for parameter and return boundary demand.
- Add struct-init-v2 assertion-tree binding logic for allocation fields, return fields, parameter fields, and call arguments.
- Enable the currently supported structinitv2 test packages in TestStructInitV2.