### PR TITLE
feat(struct-init-v2): propagate field effects across packages

### DIFF
--- a/assertion/function/structfieldeffects/analyzer.go
+++ b/assertion/function/structfieldeffects/analyzer.go
@@ -18,11 +18,16 @@
 package structfieldeffects
 
 import (
+	"cmp"
+	"fmt"
+	"go/types"
 	"reflect"
+	"slices"
 
 	"go.uber.org/nilaway/config"
 	"go.uber.org/nilaway/util/analysishelper"
 	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/types/objectpath"
 )
 
 const _doc = "Compute the per-package struct-field boundary summary: the field paths each function " +
@@ -34,6 +39,7 @@ var Analyzer = &analysis.Analyzer{
 	Doc:        _doc,
 	Run:        analysishelper.WrapRun(run),
 	ResultType: reflect.TypeOf((*analysishelper.Result[*ParamFieldEffects])(nil)),
+	FactTypes:  []analysis.Fact{new(ParamFieldReadsPackageFact)},
 	Requires:   []*analysis.Analyzer{config.Analyzer},
 }
 
@@ -43,5 +49,74 @@ func run(p *analysis.Pass) (*ParamFieldEffects, error) {
 	if !conf.ExperimentalStructInitV2Enable || !conf.IsPkgInScope(pass.Pkg) {
 		return &ParamFieldEffects{}, nil
 	}
-	return ComputeParamFieldEffects(pass), nil
+
+	packageSummary, forwardingEdges, callees := computeParamFieldEffects(pass)
+	if err := importUsedParamReads(pass, packageSummary.ParamReads, callees); err != nil {
+		return nil, err
+	}
+
+	closeParamFieldSets(packageSummary.ParamReads, forwardingEdges)
+	fact := &ParamFieldReadsPackageFact{}
+	encoder := &objectpath.Encoder{}
+	for funcObj := range packageSummary.ParamReads {
+		if funcObj.Pkg() != pass.Pkg || !funcObj.Exported() {
+			continue
+		}
+		// Export only parameter reads. Return reads remain local because callers infer them
+		// from their dereferences of results, opposite the direction of fact propagation.
+		reads := packageSummary.ParamReads.sortedPaths(funcObj)
+		if len(reads) == 0 {
+			continue
+		}
+		path, err := encoder.For(funcObj)
+		if err != nil {
+			return nil, fmt.Errorf("create object path for exported function %s: %w", funcObj, err)
+		}
+		fact.Functions = append(fact.Functions, FunctionParamFieldReads{FunctionObjectPath: path, ParamReads: reads})
+	}
+	if len(fact.Functions) > 0 {
+		// Functions were collected by ranging a map. Sorting makes the serialized fact
+		// deterministic and maintains the ordering required by BinarySearchFunc on import.
+		slices.SortFunc(fact.Functions, func(left, right FunctionParamFieldReads) int {
+			return cmp.Compare(left.FunctionObjectPath, right.FunctionObjectPath)
+		})
+		pass.ExportPackageFact(fact)
+	}
+
+	return packageSummary, nil
+}
+
+func importUsedParamReads(pass *analysishelper.EnhancedPass, paramReads fieldEffects, callees map[*types.Func]bool) error {
+	calleesByPackage := make(map[*types.Package][]*types.Func)
+	for callee := range callees {
+		if callee.Pkg() != nil && callee.Pkg() != pass.Pkg {
+			calleesByPackage[callee.Pkg()] = append(calleesByPackage[callee.Pkg()], callee)
+		}
+	}
+
+	packages := make([]*types.Package, 0, len(calleesByPackage))
+	for pkg := range calleesByPackage {
+		packages = append(packages, pkg)
+	}
+
+	encoder := &objectpath.Encoder{}
+	for _, pkg := range packages {
+		var fact ParamFieldReadsPackageFact
+		if !pass.ImportPackageFact(pkg, &fact) {
+			continue
+		}
+		for _, callee := range calleesByPackage[pkg] {
+			path, err := encoder.For(callee)
+			if err != nil {
+				return fmt.Errorf("create object path for imported function %s: %w", callee, err)
+			}
+			index, found := slices.BinarySearchFunc(fact.Functions, path, func(entry FunctionParamFieldReads, path objectpath.Path) int {
+				return cmp.Compare(entry.FunctionObjectPath, path)
+			})
+			if found {
+				seedImportedParamReads(paramReads, callee, fact.Functions[index].ParamReads)
+			}
+		}
+	}
+	return nil
 }

--- a/assertion/function/structfieldeffects/effects.go
+++ b/assertion/function/structfieldeffects/effects.go
@@ -27,8 +27,8 @@ import (
 	"golang.org/x/tools/go/types/typeutil"
 )
 
-// ParamFieldEffects is the package-level boundary summary computed once per package by
-// ComputeParamFieldEffects. Every effect set is keyed by *types.Func, then by indexedFieldPath.
+// ParamFieldEffects is the package-level boundary summary. Every effect set is keyed by
+// *types.Func, then by IndexedFieldPath.
 // The read sets bound the field binding at boundaries so it enumerates only the
 // field paths a boundary actually dereferences, never the full type graph.
 type ParamFieldEffects struct {
@@ -63,33 +63,35 @@ func readPaths(effects fieldEffects, funcObj *types.Func, idx int) []string {
 	reads := effects[funcObj]
 	paths := make([]string, 0, len(reads))
 	for key := range reads {
-		if key.idx == idx && key.path != "" {
-			paths = append(paths, key.path)
+		if key.Idx == idx && key.Path != "" {
+			paths = append(paths, key.Path)
 		}
 	}
+
+	// Sort paths so diagnostics at the same source location have a deterministic order.
 	sort.Strings(paths)
 	return paths
 }
 
-// ComputeParamFieldEffects walks every function and method in the package once and records the
-// boundary summary as ParamFieldEffects: the param fields it dereferences and the result fields
-// its callers dereference. It is a read-only, package-level pre-pass (pure
-// syntax/type inspection, no backpropagation).
+// computeParamFieldEffects walks every function and method in the package once and records the
+// unclosed boundary summary as ParamFieldEffects, plus forwarding edges for closure.
 //
 // Reads are gathered from selector bases — to evaluate `base.Sel`, base must be non-nil, so the
 // field path of base is a read of whatever boundary value it roots at (a parameter → ParamReads,
 // or a struct-returning-call result local → ReturnReads). ast.Inspect visits nested selectors, so
 // every prefix of a deep access is recorded. Every static call also records an arg→param forwarding
 // edge (which caller parameter, possibly at a nested field prefix, is passed as which callee
-// parameter). closeParamFieldSets then runs a fixpoint over those edges so forwarders inherit their
-// forwardees' param reads.
+// parameter). The analyzer later runs closeParamFieldSets over those edges so forwarders inherit
+// their forwardees' param reads. Static callees are returned so the analyzer imports only facts
+// needed by calls in this package.
 //
-// Cross-package and unresolvable (interface/func-value) callees contribute no edge and are treated
-// as mutating/dereferencing nothing (under-report only).
-func ComputeParamFieldEffects(pass *analysishelper.EnhancedPass) *ParamFieldEffects {
+// Unresolvable (interface/func-value) callees are treated as mutating/dereferencing nothing
+// (under-report only).
+func computeParamFieldEffects(pass *analysishelper.EnhancedPass) (*ParamFieldEffects, map[*types.Func][]paramFieldForwardEdge, map[*types.Func]bool) {
 	reads := make(fieldEffects)
 	returnReads := make(fieldEffects)
 	edges := make(map[*types.Func][]paramFieldForwardEdge)
+	callees := make(map[*types.Func]bool)
 	for _, file := range pass.Files {
 		for _, decl := range file.Decls {
 			fd, ok := decl.(*ast.FuncDecl)
@@ -117,7 +119,9 @@ func ComputeParamFieldEffects(pass *analysishelper.EnhancedPass) *ParamFieldEffe
 			ast.Inspect(fd.Body, func(n ast.Node) bool {
 				switch n := n.(type) {
 				case *ast.CallExpr:
-					collectParamForwardEdges(pass, n, paramIdx, funcObj, edges)
+					if callee := collectParamForwardEdges(pass, n, paramIdx, funcObj, edges); callee != nil {
+						callees[callee] = true
+					}
 				case *ast.SelectorExpr:
 					collectFieldReadDemand(pass, n, paramIdx, resultVars, funcObj, reads, returnReads)
 				}
@@ -125,26 +129,55 @@ func ComputeParamFieldEffects(pass *analysishelper.EnhancedPass) *ParamFieldEffe
 			})
 		}
 	}
-	closeParamFieldSets(reads, edges)
-	return &ParamFieldEffects{ParamReads: reads, ReturnReads: returnReads}
+	return &ParamFieldEffects{ParamReads: reads, ReturnReads: returnReads}, edges, callees
 }
 
-// indexedFieldPath identifies a boundary value by parameter/result index and field path.
-// For example, in an access to `a.b.c` where `a` is the first parameter, {idx: 0,
-// path: "b"} represents the read demand on that parameter's `b` field.
-type indexedFieldPath struct {
-	idx  int
-	path string
+// seedImportedParamReads merges an imported callee's parameter-read fact before closure runs.
+func seedImportedParamReads(paramReads fieldEffects, funcObj *types.Func, reads []IndexedFieldPath) {
+	for _, read := range reads {
+		if read.Path == "" {
+			continue
+		}
+		paramReads.add(funcObj, read)
+	}
+}
+
+// sortedPaths returns funcObj's field paths in a deterministic order. The paths come from a
+// map-backed set and are serialized in an exported fact, so map iteration order must not
+// affect the encoded fact.
+func (e fieldEffects) sortedPaths(funcObj *types.Func) []IndexedFieldPath {
+	if len(e[funcObj]) == 0 {
+		return nil
+	}
+	paths := make([]IndexedFieldPath, 0, len(e[funcObj]))
+	for key := range e[funcObj] {
+		paths = append(paths, key)
+	}
+	sort.Slice(paths, func(i, j int) bool {
+		if paths[i].Idx != paths[j].Idx {
+			return paths[i].Idx < paths[j].Idx
+		}
+		return paths[i].Path < paths[j].Path
+	})
+	return paths
+}
+
+// IndexedFieldPath identifies a boundary value by parameter/result index and field path.
+// For example, in an access to `a.b.c` where `a` is the first parameter, {Idx: 0,
+// Path: "b"} represents the read demand on that parameter's `b` field.
+type IndexedFieldPath struct {
+	Idx  int
+	Path string
 }
 
 // fieldEffects maps each function to the set of boundary field paths it reads.
-type fieldEffects map[*types.Func]map[indexedFieldPath]bool
+type fieldEffects map[*types.Func]map[IndexedFieldPath]bool
 
 // add records key for funcObj, allocating the inner set on first use. It reports whether the key
 // was newly added.
-func (e fieldEffects) add(funcObj *types.Func, key indexedFieldPath) bool {
+func (e fieldEffects) add(funcObj *types.Func, key IndexedFieldPath) bool {
 	if e[funcObj] == nil {
-		e[funcObj] = make(map[indexedFieldPath]bool)
+		e[funcObj] = make(map[IndexedFieldPath]bool)
 	}
 	if e[funcObj][key] {
 		return false
@@ -234,26 +267,26 @@ func collectFieldReadDemand(pass *analysishelper.EnhancedPass, sel *ast.Selector
 		return
 	}
 	if idx, ok := paramIdx[v]; ok {
-		reads.add(funcObj, indexedFieldPath{idx: idx, path: prefix})
+		reads.add(funcObj, IndexedFieldPath{Idx: idx, Path: prefix})
 		return
 	}
 	if src, ok := resultVars[v]; ok {
-		returnReads.add(src.callee, indexedFieldPath{idx: src.idx, path: prefix})
+		returnReads.add(src.callee, IndexedFieldPath{Idx: src.idx, Path: prefix})
 	}
 }
 
-// collectParamForwardEdges records, for the forwarding phase of ComputeParamFieldEffects, an arg→param
+// collectParamForwardEdges records an arg→param
 // edge for each argument (and the receiver) of call that resolves — through a field chain — to a
-// parameter/receiver of funcObj (the function containing the call). Unresolvable or cross-package
-// callees contribute no edge.
-func collectParamForwardEdges(pass *analysishelper.EnhancedPass, call *ast.CallExpr, paramIdx map[*types.Var]int, funcObj *types.Func, edges map[*types.Func][]paramFieldForwardEdge) {
+// parameter/receiver of funcObj (the function containing the call). Unresolvable (interface/func-value)
+// callees contribute no edge or callee.
+func collectParamForwardEdges(pass *analysishelper.EnhancedPass, call *ast.CallExpr, paramIdx map[*types.Var]int, funcObj *types.Func, edges map[*types.Func][]paramFieldForwardEdge) *types.Func {
 	callee := typeutil.StaticCallee(pass.TypesInfo, call)
 	if callee == nil {
-		return
+		return nil
 	}
 	sig, ok := callee.Type().(*types.Signature)
 	if !ok {
-		return
+		return nil
 	}
 	record := func(calleeIdx int, arg ast.Expr) {
 		base, prefix := asthelper.SplitFieldChain(arg)
@@ -286,6 +319,7 @@ func collectParamForwardEdges(pass *analysishelper.EnhancedPass, call *ast.CallE
 		}
 		record(argIdx, arg)
 	}
+	return callee
 }
 
 // paramFieldForwardEdge records that the caller passes its own parameter/receiver (callerParamIdx) — possibly
@@ -327,16 +361,16 @@ func closeParamFieldSets(fields fieldEffects, edges map[*types.Func][]paramField
 		changed := false
 		for _, e := range edges[f] {
 			for ck := range fields[e.callee] {
-				if ck.idx != e.calleeParamIdx {
+				if ck.Idx != e.calleeParamIdx {
 					continue
 				}
-				path := joinFieldPath(e.callerPrefix, ck.path)
+				path := joinFieldPath(e.callerPrefix, ck.Path)
 				// Skip recursive field paths; otherwise forwarding can keep growing paths like
 				// inner.f, inner.inner.f, ...
 				if !fieldPathIsAcyclic(f, e.callerParamIdx, path) {
 					continue
 				}
-				if fields.add(f, indexedFieldPath{idx: e.callerParamIdx, path: path}) {
+				if fields.add(f, IndexedFieldPath{Idx: e.callerParamIdx, Path: path}) {
 					changed = true
 				}
 			}

--- a/assertion/function/structfieldeffects/effects_test.go
+++ b/assertion/function/structfieldeffects/effects_test.go
@@ -53,8 +53,8 @@ func TestComputeParamFieldEffects(t *testing.T) {
 
 	// Read the expected boundary reads straight from the fixture comments, splitting them into the
 	// param and return effect sets keyed by the annotated function.
-	wantParam := make(map[*types.Func][]indexedFieldPath)
-	wantReturn := make(map[*types.Func][]indexedFieldPath)
+	wantParam := make(map[*types.Func][]IndexedFieldPath)
+	wantReturn := make(map[*types.Func][]IndexedFieldPath)
 	for node, tokens := range nilawaytest.FindExpectedValues(pass, _expectReadsPrefix) {
 		fd, ok := node.(*ast.FuncDecl)
 		require.True(t, ok)
@@ -78,17 +78,17 @@ func TestComputeParamFieldEffects(t *testing.T) {
 }
 
 // parseExpectedRead splits a "<kind>:<idx>:<path>" expect_reads token into its kind and boundary key.
-func parseExpectedRead(t *testing.T, token string) (string, indexedFieldPath) {
+func parseExpectedRead(t *testing.T, token string) (string, IndexedFieldPath) {
 	parts := strings.SplitN(token, ":", 3)
 	require.Lenf(t, parts, 3, "malformed expect_reads token %q", token)
 	idx, err := strconv.Atoi(parts[1])
 	require.NoErrorf(t, err, "malformed index in expect_reads token %q", token)
-	return parts[0], indexedFieldPath{idx: idx, path: parts[2]}
+	return parts[0], IndexedFieldPath{Idx: idx, Path: parts[2]}
 }
 
 // requireReads asserts the computed effect set matches want for every function in either map, so
 // both missing and unexpected reads fail the test.
-func requireReads(t *testing.T, got fieldEffects, want map[*types.Func][]indexedFieldPath) {
+func requireReads(t *testing.T, got fieldEffects, want map[*types.Func][]IndexedFieldPath) {
 	funcs := make(map[*types.Func]bool)
 	for funcObj := range got {
 		funcs[funcObj] = true
@@ -97,7 +97,7 @@ func requireReads(t *testing.T, got fieldEffects, want map[*types.Func][]indexed
 		funcs[funcObj] = true
 	}
 	for funcObj := range funcs {
-		var gotKeys []indexedFieldPath
+		var gotKeys []IndexedFieldPath
 		for key := range got[funcObj] {
 			gotKeys = append(gotKeys, key)
 		}

--- a/assertion/function/structfieldeffects/fact.go
+++ b/assertion/function/structfieldeffects/fact.go
@@ -1,0 +1,31 @@
+//  Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package structfieldeffects
+
+import "golang.org/x/tools/go/types/objectpath"
+
+// ParamFieldReadsPackageFact is the exported parameter field-read summary for one package.
+type ParamFieldReadsPackageFact struct {
+	Functions []FunctionParamFieldReads
+}
+
+// AFact enables use of the facts passing mechanism in Go's analysis framework.
+func (*ParamFieldReadsPackageFact) AFact() {}
+
+// FunctionParamFieldReads is a function's parameter field-read summary within a package fact.
+type FunctionParamFieldReads struct {
+	FunctionObjectPath objectpath.Path
+	ParamReads         []IndexedFieldPath
+}

--- a/assertion/function/structfieldeffects/fact_test.go
+++ b/assertion/function/structfieldeffects/fact_test.go
@@ -1,0 +1,160 @@
+//  Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package structfieldeffects
+
+import (
+	"bytes"
+	"encoding/gob"
+	"fmt"
+	"go/ast"
+	"go/types"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/nilaway/config"
+	"go.uber.org/nilaway/nilawaytest"
+	"go.uber.org/nilaway/util/analysishelper"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/analysistest"
+	"golang.org/x/tools/go/types/objectpath"
+)
+
+func TestFact(t *testing.T) { //nolint:paralleltest
+	enableStructInitV2(t)
+
+	results := analysistest.Run(t, analysistest.TestData(), Analyzer,
+		"go.uber.org/paramfieldeffects/factexport/upstream",
+		"go.uber.org/paramfieldeffects/factexport/downstream",
+	)
+	require.Len(t, results, 2)
+	for _, result := range results {
+		pass := result.Pass
+		effects := result.Result.(*analysishelper.Result[*ParamFieldEffects])
+		require.NoError(t, effects.Err)
+
+		localReads := make(fieldEffects)
+		for funcObj, reads := range effects.Res.ParamReads {
+			if funcObj.Pkg() == pass.Pkg {
+				localReads[funcObj] = reads
+			}
+		}
+		requireReads(t, localReads, expectedParamReads(t, pass))
+	}
+}
+
+func TestParamFieldReadsPackageFactCodec(t *testing.T) {
+	t.Parallel()
+
+	fact := newFact(100)
+	var previous []byte
+	for range 10 {
+		var buf bytes.Buffer
+		require.NoError(t, gob.NewEncoder(&buf).Encode(fact))
+		encoded := append([]byte(nil), buf.Bytes()...)
+		require.NotEmpty(t, encoded)
+		require.Less(t, len(encoded), 10_000,
+			"encoded facts contribute to artifact size; increase this cap only with justification")
+
+		var decoded ParamFieldReadsPackageFact
+		require.NoError(t, gob.NewDecoder(bytes.NewReader(encoded)).Decode(&decoded))
+		require.Equal(t, fact, &decoded)
+
+		if previous != nil {
+			require.Equal(t, previous, encoded, "encoded fact must be deterministic")
+		}
+		previous = encoded
+	}
+}
+
+// BenchmarkParamFieldReadsPackageFactCodec measures one complete fact in a fresh gob stream.
+func BenchmarkParamFieldReadsPackageFactCodec(b *testing.B) {
+	for _, functionCount := range []int{1, 10, 100} {
+		fact := newFact(functionCount)
+		b.Run(fmt.Sprintf("encode/%d-functions", functionCount), func(b *testing.B) {
+			b.ReportAllocs()
+			var encodedBytes int
+			b.ResetTimer()
+			for b.Loop() {
+				var buf bytes.Buffer
+				if err := gob.NewEncoder(&buf).Encode(fact); err != nil {
+					b.Fatal(err)
+				}
+				if buf.Len() == 0 {
+					b.Fatal("encoded fact is empty")
+				}
+				encodedBytes = buf.Len()
+			}
+			b.ReportMetric(float64(encodedBytes), "encoded_bytes")
+		})
+
+		var encoded bytes.Buffer
+		if err := gob.NewEncoder(&encoded).Encode(fact); err != nil {
+			b.Fatal(err)
+		}
+
+		b.Run(fmt.Sprintf("decode/%d-functions", functionCount), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				var decoded ParamFieldReadsPackageFact
+				if err := gob.NewDecoder(bytes.NewReader(encoded.Bytes())).Decode(&decoded); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func enableStructInitV2(t *testing.T) {
+	t.Helper()
+	require.NoError(t, config.Analyzer.Flags.Set(config.ExperimentalStructInitV2EnableFlag, "true"))
+	t.Cleanup(func() {
+		require.NoError(t, config.Analyzer.Flags.Set(config.ExperimentalStructInitV2EnableFlag, "false"))
+	})
+}
+
+func expectedParamReads(t *testing.T, pass *analysis.Pass) map[*types.Func][]IndexedFieldPath {
+	t.Helper()
+
+	want := make(map[*types.Func][]IndexedFieldPath)
+	for node, tokens := range nilawaytest.FindExpectedValues(pass, _expectReadsPrefix) {
+		funcDecl, ok := node.(*ast.FuncDecl)
+		require.True(t, ok)
+		funcObj, ok := pass.TypesInfo.ObjectOf(funcDecl.Name).(*types.Func)
+		require.True(t, ok)
+		for _, token := range tokens {
+			kind, key := parseExpectedRead(t, token)
+			require.Equal(t, "param_reads", kind)
+			want[funcObj] = append(want[funcObj], key)
+		}
+	}
+	return want
+}
+
+func newFact(functionCount int) *ParamFieldReadsPackageFact {
+	functions := make([]FunctionParamFieldReads, functionCount)
+	for i := range functions {
+		functions[i] = FunctionParamFieldReads{
+			FunctionObjectPath: objectpath.Path(fmt.Sprintf("Function%03d", i)),
+			ParamReads: []IndexedFieldPath{
+				{Idx: -1, Path: "Receiver"},
+				{Idx: 0, Path: "Child"},
+				{Idx: 0, Path: "Child.Leaf"},
+				{Idx: 1, Path: fmt.Sprintf("Argument%d.Field", i)},
+			},
+		}
+	}
+	return &ParamFieldReadsPackageFact{Functions: functions}
+}

--- a/assertion/function/structfieldeffects/testdata/src/go.uber.org/paramfieldeffects/factexport/downstream/downstream.go
+++ b/assertion/function/structfieldeffects/testdata/src/go.uber.org/paramfieldeffects/factexport/downstream/downstream.go
@@ -1,0 +1,15 @@
+package downstream // want package:".*"
+
+import "go.uber.org/paramfieldeffects/factexport/upstream"
+
+func Forward(o *upstream.Outer) { // expect_reads: param_reads:0:Mid param_reads:0:Mid.Child
+	upstream.ExportedRead(o)
+}
+
+func ForwardUnused(o *upstream.Outer) {
+	upstream.UnusedRead(o)
+}
+
+func DirectCall() {
+	upstream.ExportedRead(&upstream.Outer{})
+}

--- a/assertion/function/structfieldeffects/testdata/src/go.uber.org/paramfieldeffects/factexport/upstream/upstream.go
+++ b/assertion/function/structfieldeffects/testdata/src/go.uber.org/paramfieldeffects/factexport/upstream/upstream.go
@@ -1,0 +1,33 @@
+package upstream // want package:".*"
+
+type Leaf struct {
+	Ptr *int
+}
+
+type Node struct {
+	Child *Leaf
+}
+
+type Outer struct {
+	Mid *Node
+}
+
+// Ordinary field-access analysis requires o to be non-nil. These field-read effects additionally
+// require Mid and Mid.Child to be non-nil; Ptr itself may be nil because it is not dereferenced.
+func ExportedRead(o *Outer) { // expect_reads: param_reads:0:Mid param_reads:0:Mid.Child
+	_ = o.Mid.Child.Ptr
+}
+
+func ReadOneLevelDeep(o *Outer) { // expect_reads:
+	_ = o.Mid
+}
+
+func UnusedRead(o *Outer) {}
+
+func ExportedNoRead(o *Outer) {
+	_ = o
+}
+
+func unexportedRead(o *Outer) { // expect_reads: param_reads:0:Mid param_reads:0:Mid.Child
+	_ = o.Mid.Child.Ptr
+}

--- a/nilaway_test.go
+++ b/nilaway_test.go
@@ -116,6 +116,7 @@ func TestStructInitV2(t *testing.T) { //nolint:paralleltest
 		"go.uber.org/structinitv2/local",
 		"go.uber.org/structinitv2/defaultfield",
 		"go.uber.org/structinitv2/deep",
+		"go.uber.org/structinitv2/crosspkg/app",
 	)
 }
 


### PR DESCRIPTION
Extend the structfieldeffects analyzer to export and import parameter field-read summaries across package boundaries, using Go's analysis Facts mechanism, so cross-package calls no longer under-report which fields a callee dereferences.

#### Changes
- Add `ParamFieldReadsPackageFact` (`assertion/function/structfieldeffects/fact.go`), a gob-encodable per-package fact holding each exported function's sorted parameter field-read paths.
- Export the fact from the analyzer for every exported function with a non-empty read set, keyed by objectpath of the function for stable cross-package lookup.
- Import facts for statically-resolvable cross-package callees before running `closeParamFieldSets`, seeding their param reads via the new `seedImportedParamReads`, so forwarding closure accounts for reads that happen in the callee's own package.
- Track callees encountered during `collectParamForwardEdges` so the analyzer only imports facts for packages actually called into.
- Export `indexedFieldPath` as `IndexedFieldPath` so it can be serialized as part of the fact.
- Add `fact_test.go` covering export, import, import-with-real serialization (via `analysistest`/`checker.Analyze`), and gob codec determinism, plus a codec benchmark.
- Add upstream/downstream testdata packages under `factexport/` exercising a cross-package forwarded read.
- Enable `go.uber.org/structinitv2/crosspkg/app` in `TestStructInitV2`.