### PR TITLE
feat(struct-init-v2): collect parameter field writes

### DIFF
--- a/assertion/function/structfieldeffects/analyzer.go
+++ b/assertion/function/structfieldeffects/analyzer.go
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 // Package structfieldeffects implements a sub-analyzer that computes the package-level struct-field
-// boundary summary: the field paths each function reads of its parameters and of the results its
-// callers consume.
+// boundary summary: the field paths each function writes or reads on its parameters and the result
+// fields its callers consume.
 package structfieldeffects
 
 import (
@@ -31,7 +31,7 @@ import (
 )
 
 const _doc = "Compute the per-package struct-field boundary summary: the field paths each function " +
-	"reads of its parameters and of the results its callers consume."
+	"writes or reads on its parameters and the result fields its callers consume."
 
 // Analyzer computes the package-level ParamFieldEffects boundary summary.
 var Analyzer = &analysis.Analyzer{
@@ -55,6 +55,7 @@ func run(p *analysis.Pass) (*ParamFieldEffects, error) {
 		return nil, err
 	}
 
+	closeParamFieldSets(packageSummary.ParamWrites, forwardingEdges)
 	closeParamFieldSets(packageSummary.ParamReads, forwardingEdges)
 	fact := &ParamFieldReadsPackageFact{}
 	encoder := &objectpath.Encoder{}

--- a/assertion/function/structfieldeffects/effects.go
+++ b/assertion/function/structfieldeffects/effects.go
@@ -41,6 +41,9 @@ type ParamFieldEffects struct {
 	// result — the demand callers place on a returned value, so a `return <var>` binds only those
 	// paths. Collected at call sites; not transitively closed (under-report only).
 	ReturnReads fieldEffects
+	// ParamWrites records (param idx, field path) pairs a function assigns through a parameter or
+	// receiver. Transitively closed over forwarding edges.
+	ParamWrites fieldEffects
 }
 
 // ParamReadPaths returns the field paths read from funcObj's parameter or receiver at idx.
@@ -79,17 +82,19 @@ func readPaths(effects fieldEffects, funcObj *types.Func, idx int) []string {
 // Reads are gathered from selector bases — to evaluate `base.Sel`, base must be non-nil, so the
 // field path of base is a read of whatever boundary value it roots at (a parameter → ParamReads,
 // or a struct-returning-call result local → ReturnReads). ast.Inspect visits nested selectors, so
-// every prefix of a deep access is recorded. Every static call also records an arg→param forwarding
+// every prefix of a deep access is recorded. Writes are gathered from assignment LHS field chains
+// rooted at a parameter or receiver. Every static call also records an arg→param forwarding
 // edge (which caller parameter, possibly at a nested field prefix, is passed as which callee
 // parameter). The analyzer later runs closeParamFieldSets over those edges so forwarders inherit
-// their forwardees' param reads. Static callees are returned so the analyzer imports only facts
-// needed by calls in this package.
+// their forwardees' param reads and writes. Static callees are returned so the analyzer imports
+// only facts needed by calls in this package.
 //
 // Unresolvable (interface/func-value) callees are treated as mutating/dereferencing nothing
 // (under-report only).
 func computeParamFieldEffects(pass *analysishelper.EnhancedPass) (*ParamFieldEffects, map[*types.Func][]paramFieldForwardEdge, map[*types.Func]bool) {
 	reads := make(fieldEffects)
 	returnReads := make(fieldEffects)
+	writes := make(fieldEffects)
 	edges := make(map[*types.Func][]paramFieldForwardEdge)
 	callees := make(map[*types.Func]bool)
 	for _, file := range pass.Files {
@@ -118,6 +123,8 @@ func computeParamFieldEffects(pass *analysishelper.EnhancedPass) (*ParamFieldEff
 			resultVars := collectStructResultVars(pass, fd.Body)
 			ast.Inspect(fd.Body, func(n ast.Node) bool {
 				switch n := n.(type) {
+				case *ast.AssignStmt:
+					collectParamFieldWrites(pass, n, paramIdx, funcObj, writes)
 				case *ast.CallExpr:
 					if callee := collectParamForwardEdges(pass, n, paramIdx, funcObj, edges); callee != nil {
 						callees[callee] = true
@@ -129,7 +136,7 @@ func computeParamFieldEffects(pass *analysishelper.EnhancedPass) (*ParamFieldEff
 			})
 		}
 	}
-	return &ParamFieldEffects{ParamReads: reads, ReturnReads: returnReads}, edges, callees
+	return &ParamFieldEffects{ParamReads: reads, ReturnReads: returnReads, ParamWrites: writes}, edges, callees
 }
 
 // seedImportedParamReads merges an imported callee's parameter-read fact before closure runs.
@@ -170,7 +177,7 @@ type IndexedFieldPath struct {
 	Path string
 }
 
-// fieldEffects maps each function to the set of boundary field paths it reads.
+// fieldEffects maps each function to a set of boundary field paths.
 type fieldEffects map[*types.Func]map[IndexedFieldPath]bool
 
 // add records key for funcObj, allocating the inner set on first use. It reports whether the key
@@ -272,6 +279,41 @@ func collectFieldReadDemand(pass *analysishelper.EnhancedPass, sel *ast.Selector
 	}
 	if src, ok := resultVars[v]; ok {
 		returnReads.add(src.callee, IndexedFieldPath{Idx: src.idx, Path: prefix})
+	}
+}
+
+// collectParamFieldWrites records nilable fields assigned through a pointer parameter or receiver.
+// The full path is retained for deep and explicit-deref writes. Recursive paths are skipped so the
+// forwarding closure remains finite.
+func collectParamFieldWrites(pass *analysishelper.EnhancedPass, assign *ast.AssignStmt, paramIdx map[*types.Var]int, funcObj *types.Func, writes fieldEffects) {
+	for _, lhs := range assign.Lhs {
+		sel, ok := ast.Unparen(lhs).(*ast.SelectorExpr)
+		if !ok {
+			continue
+		}
+		field, ok := pass.TypesInfo.ObjectOf(sel.Sel).(*types.Var)
+		if !ok || typeshelper.TypeBarsNilness(field.Type()) {
+			continue
+		}
+		base, path := asthelper.SplitFieldChain(lhs)
+		if base == nil || path == "" {
+			continue
+		}
+		param, ok := pass.TypesInfo.ObjectOf(base).(*types.Var)
+		if !ok {
+			continue
+		}
+		idx, ok := paramIdx[param]
+		if !ok {
+			continue
+		}
+		if _, ok := param.Type().Underlying().(*types.Pointer); !ok {
+			continue
+		}
+		if !fieldPathIsAcyclic(funcObj, idx, path) {
+			continue
+		}
+		writes.add(funcObj, IndexedFieldPath{Idx: idx, Path: path})
 	}
 }
 

--- a/assertion/function/structfieldeffects/effects_test.go
+++ b/assertion/function/structfieldeffects/effects_test.go
@@ -28,11 +28,10 @@ import (
 	"golang.org/x/tools/go/analysis/analysistest"
 )
 
-// _expectReadsPrefix precedes a fixture function's expected boundary reads. Each trailing token is
-// "<kind>:<idx>:<path>": kind is "param_reads" (ParamReads) or "return_reads" (ReturnReads), idx is
-// the boundary index (-1 for a receiver, per annotation.ReceiverParamIndex), and path is the dotted
-// field path. A function with no reads carries an empty "// expect_reads:" comment.
-const _expectReadsPrefix = "expect_reads:"
+// _expectEffectsPrefix precedes a fixture function's expected boundary effects. Each trailing token
+// is "<kind>:<idx>:<path>", where kind identifies Writes, ParamReads, or ReturnReads. A function
+// with no effects carries an empty comment.
+const _expectEffectsPrefix = "expect_effects:"
 
 func TestComputeParamFieldEffects(t *testing.T) {
 	t.Parallel()
@@ -51,44 +50,47 @@ func TestComputeParamFieldEffects(t *testing.T) {
 	require.NoError(t, result.Err)
 	effects := result.Res
 
-	// Read the expected boundary reads straight from the fixture comments, splitting them into the
-	// param and return effect sets keyed by the annotated function.
+	// Read the expected boundary effects from fixture comments and split them by effect kind.
 	wantParam := make(map[*types.Func][]IndexedFieldPath)
 	wantReturn := make(map[*types.Func][]IndexedFieldPath)
-	for node, tokens := range nilawaytest.FindExpectedValues(pass, _expectReadsPrefix) {
+	wantWrites := make(map[*types.Func][]IndexedFieldPath)
+	for node, tokens := range nilawaytest.FindExpectedValues(pass, _expectEffectsPrefix) {
 		fd, ok := node.(*ast.FuncDecl)
 		require.True(t, ok)
 		funcObj, ok := pass.TypesInfo.ObjectOf(fd.Name).(*types.Func)
 		require.True(t, ok)
 		for _, token := range tokens {
-			kind, key := parseExpectedRead(t, token)
+			kind, key := parseExpectedEffect(t, token)
 			switch kind {
+			case "writes":
+				wantWrites[funcObj] = append(wantWrites[funcObj], key)
 			case "param_reads":
 				wantParam[funcObj] = append(wantParam[funcObj], key)
 			case "return_reads":
 				wantReturn[funcObj] = append(wantReturn[funcObj], key)
 			default:
-				t.Fatalf("unknown read kind %q in token %q", kind, token)
+				t.Fatalf("unknown effect kind %q in token %q", kind, token)
 			}
 		}
 	}
 
-	requireReads(t, effects.ParamReads, wantParam)
-	requireReads(t, effects.ReturnReads, wantReturn)
+	requireEffects(t, effects.ParamReads, wantParam)
+	requireEffects(t, effects.ReturnReads, wantReturn)
+	requireEffects(t, effects.ParamWrites, wantWrites)
 }
 
-// parseExpectedRead splits a "<kind>:<idx>:<path>" expect_reads token into its kind and boundary key.
-func parseExpectedRead(t *testing.T, token string) (string, IndexedFieldPath) {
+// parseExpectedEffect splits a "<kind>:<idx>:<path>" expect_effects token into its kind and boundary key.
+func parseExpectedEffect(t *testing.T, token string) (string, IndexedFieldPath) {
 	parts := strings.SplitN(token, ":", 3)
-	require.Lenf(t, parts, 3, "malformed expect_reads token %q", token)
+	require.Lenf(t, parts, 3, "malformed expect_effects token %q", token)
 	idx, err := strconv.Atoi(parts[1])
-	require.NoErrorf(t, err, "malformed index in expect_reads token %q", token)
+	require.NoErrorf(t, err, "malformed index in expect_effects token %q", token)
 	return parts[0], IndexedFieldPath{Idx: idx, Path: parts[2]}
 }
 
-// requireReads asserts the computed effect set matches want for every function in either map, so
-// both missing and unexpected reads fail the test.
-func requireReads(t *testing.T, got fieldEffects, want map[*types.Func][]IndexedFieldPath) {
+// requireEffects asserts the computed effect set matches want for every function in either map. so
+// both missing and unexpected effects fail the test.
+func requireEffects(t *testing.T, got fieldEffects, want map[*types.Func][]IndexedFieldPath) {
 	funcs := make(map[*types.Func]bool)
 	for funcObj := range got {
 		funcs[funcObj] = true
@@ -101,6 +103,6 @@ func requireReads(t *testing.T, got fieldEffects, want map[*types.Func][]Indexed
 		for key := range got[funcObj] {
 			gotKeys = append(gotKeys, key)
 		}
-		require.ElementsMatchf(t, want[funcObj], gotKeys, "reads mismatch for %s", funcObj.Name())
+		require.ElementsMatchf(t, want[funcObj], gotKeys, "effects mismatch for %s", funcObj.Name())
 	}
 }

--- a/assertion/function/structfieldeffects/fact_test.go
+++ b/assertion/function/structfieldeffects/fact_test.go
@@ -50,7 +50,7 @@ func TestFact(t *testing.T) { //nolint:paralleltest
 				localReads[funcObj] = reads
 			}
 		}
-		requireReads(t, localReads, expectedParamReads(t, pass))
+		requireEffects(t, localReads, expectedParamReads(t, pass))
 	}
 }
 
@@ -129,13 +129,13 @@ func expectedParamReads(t *testing.T, pass *analysis.Pass) map[*types.Func][]Ind
 	t.Helper()
 
 	want := make(map[*types.Func][]IndexedFieldPath)
-	for node, tokens := range nilawaytest.FindExpectedValues(pass, _expectReadsPrefix) {
+	for node, tokens := range nilawaytest.FindExpectedValues(pass, _expectEffectsPrefix) {
 		funcDecl, ok := node.(*ast.FuncDecl)
 		require.True(t, ok)
 		funcObj, ok := pass.TypesInfo.ObjectOf(funcDecl.Name).(*types.Func)
 		require.True(t, ok)
 		for _, token := range tokens {
-			kind, key := parseExpectedRead(t, token)
+			kind, key := parseExpectedEffect(t, token)
 			require.Equal(t, "param_reads", kind)
 			want[funcObj] = append(want[funcObj], key)
 		}

--- a/assertion/function/structfieldeffects/testdata/src/go.uber.org/paramfieldeffects/factexport/downstream/downstream.go
+++ b/assertion/function/structfieldeffects/testdata/src/go.uber.org/paramfieldeffects/factexport/downstream/downstream.go
@@ -2,7 +2,7 @@ package downstream // want package:".*"
 
 import "go.uber.org/paramfieldeffects/factexport/upstream"
 
-func Forward(o *upstream.Outer) { // expect_reads: param_reads:0:Mid param_reads:0:Mid.Child
+func Forward(o *upstream.Outer) { // expect_effects: param_reads:0:Mid param_reads:0:Mid.Child
 	upstream.ExportedRead(o)
 }
 

--- a/assertion/function/structfieldeffects/testdata/src/go.uber.org/paramfieldeffects/factexport/upstream/upstream.go
+++ b/assertion/function/structfieldeffects/testdata/src/go.uber.org/paramfieldeffects/factexport/upstream/upstream.go
@@ -14,11 +14,11 @@ type Outer struct {
 
 // Ordinary field-access analysis requires o to be non-nil. These field-read effects additionally
 // require Mid and Mid.Child to be non-nil; Ptr itself may be nil because it is not dereferenced.
-func ExportedRead(o *Outer) { // expect_reads: param_reads:0:Mid param_reads:0:Mid.Child
+func ExportedRead(o *Outer) { // expect_effects: param_reads:0:Mid param_reads:0:Mid.Child
 	_ = o.Mid.Child.Ptr
 }
 
-func ReadOneLevelDeep(o *Outer) { // expect_reads:
+func ReadOneLevelDeep(o *Outer) { // expect_effects:
 	_ = o.Mid
 }
 
@@ -28,6 +28,6 @@ func ExportedNoRead(o *Outer) {
 	_ = o
 }
 
-func unexportedRead(o *Outer) { // expect_reads: param_reads:0:Mid param_reads:0:Mid.Child
+func unexportedRead(o *Outer) { // expect_effects: param_reads:0:Mid param_reads:0:Mid.Child
 	_ = o.Mid.Child.Ptr
 }

--- a/assertion/function/structfieldeffects/testdata/src/go.uber.org/paramfieldeffects/main.go
+++ b/assertion/function/structfieldeffects/testdata/src/go.uber.org/paramfieldeffects/main.go
@@ -24,7 +24,8 @@ type Node struct {
 }
 
 type Outer struct {
-	Mid *Node
+	Mid   *Node
+	Count int
 }
 
 type Wrap struct {
@@ -38,27 +39,27 @@ type Rec struct {
 
 // directRead dereferences two nested field prefixes of its parameter: reaching o.Mid.Child.Ptr
 // requires o.Mid and o.Mid.Child to be non-nil, so both paths are param reads.
-func directRead(o *Outer) { // expect_reads: param_reads:0:Mid param_reads:0:Mid.Child
+func directRead(o *Outer) { // expect_effects: param_reads:0:Mid param_reads:0:Mid.Child
 	_ = o.Mid.Child.Ptr
 }
 
 // forwarder passes its parameter straight through, so the closure copies directRead's reads verbatim.
-func forwarder(o *Outer) { // expect_reads: param_reads:0:Mid param_reads:0:Mid.Child
+func forwarder(o *Outer) { // expect_effects: param_reads:0:Mid param_reads:0:Mid.Child
 	directRead(o)
 }
 
 // forwardField forwards a nested field of its parameter, so the inherited reads gain the "Inner" prefix.
-func forwardField(w *Wrap) { // expect_reads: param_reads:0:Inner.Mid param_reads:0:Inner.Mid.Child
+func forwardField(w *Wrap) { // expect_effects: param_reads:0:Inner.Mid param_reads:0:Inner.Mid.Child
 	directRead(w.Inner)
 }
 
 // recvRead exercises the receiver boundary index (ReceiverParamIndex).
-func (o *Outer) recvRead() { // expect_reads: param_reads:-1:Mid param_reads:-1:Mid.Child
+func (o *Outer) recvRead() { // expect_effects: param_reads:-1:Mid param_reads:-1:Mid.Child
 	_ = o.Mid.Child.Ptr
 }
 
 // makeOuter is a struct-returning constructor; a caller's deref of its result becomes a return read.
-func makeOuter() *Outer { // expect_reads: return_reads:0:Mid return_reads:0:Mid.Child
+func makeOuter() *Outer { // expect_effects: return_reads:0:Mid return_reads:0:Mid.Child
 	return &Outer{}
 }
 
@@ -69,11 +70,52 @@ func consumeReturn() {
 }
 
 // recRead directly dereferences a self-recursive field chain; direct reads keep the exact paths.
-func recRead(r *Rec) { // expect_reads: param_reads:0:Self param_reads:0:Self.Self
+func recRead(r *Rec) { // expect_effects: param_reads:0:Self param_reads:0:Self.Self
 	_ = r.Self.Self.Ptr
 }
 
 // recForward forwards a self-recursive field, so the closure must stop the path from growing.
-func recForward(r *Rec) { // expect_reads:
+func recForward(r *Rec) { // expect_effects:
 	recRead(r.Self)
+}
+
+func directWrite(o *Outer) { // expect_effects: writes:0:Mid
+	o.Mid = &Node{}
+}
+
+func deepWrite(o *Outer) { // expect_effects: writes:0:Mid.Child param_reads:0:Mid
+	o.Mid.Child = nil
+}
+
+func (o *Outer) receiverWrite() { // expect_effects: writes:-1:Mid
+	o.Mid = &Node{}
+}
+
+func forwardWrite(o *Outer) { // expect_effects: writes:0:Mid.Child
+	writeChild(o.Mid)
+}
+
+func forwardWriteAgain(w *Wrap) { // expect_effects: writes:0:Inner.Mid.Child
+	forwardWrite(w.Inner)
+}
+
+func writeChild(n *Node) { // expect_effects: writes:0:Child
+	n.Child = nil
+}
+
+func ignoredNonNilableWrite(o *Outer) { // expect_effects:
+	o.Count = 1
+}
+
+func ignoredLocalWrite() { // expect_effects:
+	o := &Outer{}
+	o.Mid = nil
+}
+
+func ignoredValueParamWrite(o Outer) { // expect_effects:
+	o.Mid = nil
+}
+
+func ignoredRecursiveWrite(r *Rec) { // expect_effects: param_reads:0:Self
+	r.Self.Ptr = nil
 }


### PR DESCRIPTION
Collect nilable struct-field writes through pointer parameters and receivers in structfieldeffects.
- Add ParamWrites to the package boundary summary.
- Propagate writes through parameter-forwarding calls, including nested field paths.
- Exclude non-nilable fields, local/value-parameter writes, and recursive paths.