### PR TITLE
feat(struct-init-v2): refactor SplitFieldChain to support StarExpr

### DIFF
--- a/assertion/function/structfieldeffects/effects.go
+++ b/assertion/function/structfieldeffects/effects.go
@@ -453,6 +453,15 @@ func fieldPathIsAcyclic(fn *types.Func, paramIdx int, path string) bool {
 		}
 		paramType = sig.Params().At(paramIdx).Type()
 	}
+	// AsDeeplyStruct unwraps at most one pointer, but forwarded field paths can be rooted at
+	// parameters with multiple pointer layers.
+	for {
+		ptr, ok := paramType.Underlying().(*types.Pointer)
+		if !ok {
+			break
+		}
+		paramType = ptr.Elem()
+	}
 	st := typeshelper.AsDeeplyStruct(paramType)
 	if st == nil {
 		return false

--- a/assertion/function/structfieldeffects/testdata/src/go.uber.org/paramfieldeffects/main.go
+++ b/assertion/function/structfieldeffects/testdata/src/go.uber.org/paramfieldeffects/main.go
@@ -43,9 +43,25 @@ func directRead(o *Outer) { // expect_effects: param_reads:0:Mid param_reads:0:M
 	_ = o.Mid.Child.Ptr
 }
 
+func explicitDerefRead(o *Outer) { // expect_effects: param_reads:0:Mid param_reads:0:Mid.Child
+	_ = (*o).Mid.Child.Ptr
+}
+
+func intermediateDerefRead(o *Outer) { // expect_effects: param_reads:0:Mid param_reads:0:Mid.Child
+	_ = (*o.Mid).Child.Ptr
+}
+
+func doublePointerRead(o **Outer) { // expect_effects: param_reads:0:Mid param_reads:0:Mid.Child
+	_ = (*o).Mid.Child.Ptr
+}
+
 // forwarder passes its parameter straight through, so the closure copies directRead's reads verbatim.
 func forwarder(o *Outer) { // expect_effects: param_reads:0:Mid param_reads:0:Mid.Child
 	directRead(o)
+}
+
+func forwardDerefPointerRead(o **Outer) { // expect_effects: param_reads:0:Mid param_reads:0:Mid.Child
+	directRead(*o)
 }
 
 // forwardField forwards a nested field of its parameter, so the inherited reads gain the "Inner" prefix.
@@ -95,6 +111,10 @@ func forwardWrite(o *Outer) { // expect_effects: writes:0:Mid.Child
 	writeChild(o.Mid)
 }
 
+func forwardDerefPointerWrite(o **Outer) { // expect_effects: writes:0:Mid
+	directWrite(*o)
+}
+
 func forwardWriteAgain(w *Wrap) { // expect_effects: writes:0:Inner.Mid.Child
 	forwardWrite(w.Inner)
 }
@@ -118,4 +138,12 @@ func ignoredValueParamWrite(o Outer) { // expect_effects:
 
 func ignoredRecursiveWrite(r *Rec) { // expect_effects: param_reads:0:Self
 	r.Self.Ptr = nil
+}
+
+func explicitDerefWrite(o *Outer) { // expect_effects: writes:0:Mid
+	(*o).Mid = nil
+}
+
+func explicitDoublePointerWrite(o **Outer) { // expect_effects: writes:0:Mid
+	(*o).Mid = nil
 }

--- a/util/asthelper/asthelper.go
+++ b/util/asthelper/asthelper.go
@@ -187,9 +187,9 @@ func IsFieldSelectorChain(expr ast.Expr) bool {
 }
 
 // SplitFieldChain decomposes a field-chain expression into its base identifier and the dotted
-// field prefix from that base: `x` -> (x, ""), `x.a` -> (x, "a"), `x.a.b` -> (x, "a.b"). It
-// returns (nil, "") for anything whose innermost base is not a bare identifier, such as `(*x).a`
-// or `f().a`.
+// field prefix from that base: `x` -> (x, ""), `x.a` -> (x, "a"), `x.a.b` -> (x, "a.b"). Pointer
+// dereferences are transparent, so `(*x).a` -> (x, "a") and `*x` -> (x, ""). It returns (nil, "")
+// for anything whose innermost base is not a bare identifier, such as `f().a`.
 func SplitFieldChain(expr ast.Expr) (*ast.Ident, string) {
 	expr = ast.Unparen(expr)
 	var parts []string
@@ -205,6 +205,8 @@ func SplitFieldChain(expr ast.Expr) (*ast.Ident, string) {
 			return e, strings.Join(parts, ".")
 		case *ast.SelectorExpr:
 			parts = append(parts, e.Sel.Name)
+			expr = ast.Unparen(e.X)
+		case *ast.StarExpr:
 			expr = ast.Unparen(e.X)
 		default:
 			return nil, ""

--- a/util/asthelper/asthelper_test.go
+++ b/util/asthelper/asthelper_test.go
@@ -116,7 +116,9 @@ func TestSplitFieldChain(t *testing.T) {
 		{name: "SingleSelector", expr: "x.a", wantBase: "x", wantPrefix: "a"},
 		{name: "NestedSelector", expr: "x.a.b", wantBase: "x", wantPrefix: "a.b"},
 		{name: "ParenthesizedSelector", expr: "(x.a).b", wantBase: "x", wantPrefix: "a.b"},
-		{name: "PointerBase", expr: "(*x).a", wantBase: "", wantPrefix: ""},
+		{name: "PointerBase", expr: "(*x).a", wantBase: "x", wantPrefix: "a"},
+		{name: "PointerBaseNested", expr: "(*x).a.b", wantBase: "x", wantPrefix: "a.b"},
+		{name: "TopLevelDeref", expr: "*x", wantBase: "x", wantPrefix: ""},
 		{name: "CallBase", expr: "f().a", wantBase: "", wantPrefix: ""},
 	}
 


### PR DESCRIPTION
Support parameter field-effect analysis for reads and writes containing explicit pointer dereferences.

Changes
- Treat ast.StarExpr as transparent when splitting field chains.
- Resolve multi-pointer parameter types during field-path cycle validation.
- Add tests for direct, intermediate, double-pointer, and forwarded dereference effects.