### PR TITLE
feat(struct-init-v2): propagate parameter field side effects

### DIFF
--- a/accumulation/analyzer.go
+++ b/accumulation/analyzer.go
@@ -131,10 +131,22 @@ func run(p *analysis.Pass) (result interface{}, _ error) {
 		// TODO: This is a suppression added for handling of struct field assignments. We plan to add
 		//  object sensitivity to NilAway in the future, which will allow us to be more precise in struct fields'
 		//  handling. Remove this suppression once we have the object sensitivity implemented (issue #339).
-		for _, t := range assertionsResult.Res {
+		for i := range assertionsResult.Res {
+			t := &assertionsResult.Res[i]
 			if _, ok := t.Consumer.Annotation.(*annotation.FldAssign); ok {
-				// update its producer to be non-nil
-				t.Producer.Annotation = &annotation.ProduceTriggerNever{}
+				if conf.ExperimentalStructInitV2Enable {
+					// The legacy FldAssign suppression changes its producer's annotation to Never. A
+					// producer can be shared by multiple full triggers; under ExperimentalStructInitV2Enable ,
+					// a param-out consumer for the same field write can share it. Mutating that producer would silence the
+					// param-out consumer too, so give only the FldAssign trigger a Never producer.
+					// Once ExperimentalStructInitV2Enable is complete, FldAssign and this block should be removed.
+					t.Producer = &annotation.ProduceTrigger{
+						Annotation: &annotation.ProduceTriggerNever{},
+						Expr:       t.Producer.Expr,
+					}
+				} else {
+					t.Producer.Annotation = &annotation.ProduceTriggerNever{}
+				}
 			}
 		}
 

--- a/annotation/structinitv2.go
+++ b/annotation/structinitv2.go
@@ -68,6 +68,9 @@ const (
 	// StructFieldParamContext is the nilability of a field of a function's parameter/receiver,
 	// as observed on entry to the function (the value passed in by the caller).
 	StructFieldParamContext
+	// StructFieldParamOutContext is the nilability of a parameter or receiver field after the
+	// function has assigned it.
+	StructFieldParamOutContext
 )
 
 func (k StructFieldContextKind) string() string {
@@ -82,7 +85,7 @@ func (k StructFieldContextKind) string() string {
 // boundaryDesc renders the boundary descriptor used in diagnostics, e.g. "param 0 of `f`",
 // "result 0 of `g`", or "method receiver of `m`" (when the param index is the receiver index).
 func boundaryDesc(kind StructFieldContextKind, index int, funcName string) string {
-	if kind == StructFieldParamContext && index == ReceiverParamIndex {
+	if kind != StructFieldReturnContext && index == ReceiverParamIndex {
 		return fmt.Sprintf("method receiver of `%s`", funcName)
 	}
 	return fmt.Sprintf("%s %d of `%s`", kind.string(), index, funcName)

--- a/assertion/function/assertiontree/backprop.go
+++ b/assertion/function/assertiontree/backprop.go
@@ -774,6 +774,9 @@ buildShadowMask:
 	// Phase 2
 	for i := range rhs {
 		lhsVal, rhsVal := lhs[i], rhs[i]
+		if rootNode.functionContext.functionConfig.EnableStructInitV2 {
+			rootNode.bindParamFieldWriteToContext(lhsVal, rhsVal)
+		}
 		// Check whether a consumption trigger needs to be added for a field assignment here
 		consumeTrigger, err := exprAsAssignmentConsumer(rootNode, lhsVal, rhsVal)
 		if err != nil {

--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -751,7 +751,13 @@ func (r *RootAssertionNode) AddComputation(expr ast.Expr) {
 			}
 
 			if r.functionContext.functionConfig.EnableStructInitV2 {
-				r.bindArgAndReceiverFieldsToContext(expr, fun)
+				funcObj := r.ObjectOf(fun).(*types.Func)
+				// First, let post-call field reads use the callee's param-out summary.
+				r.addCallParamOutFieldProducers(expr, funcObj)
+				// Then, if this function forwards its own parameter, make that summary its own output.
+				r.bindForwardedParamOut(expr, funcObj)
+				// Finally, bind the arguments' incoming fields to the callee's param-in summary.
+				r.bindArgAndReceiverFieldsToContext(expr, funcObj)
 			}
 		} else {
 			// here we have found either a builtin function like make or new,

--- a/assertion/function/assertiontree/structinitv2.go
+++ b/assertion/function/assertiontree/structinitv2.go
@@ -18,6 +18,7 @@ import (
 	"go/ast"
 	"go/token"
 	"go/types"
+	"sort"
 	"strings"
 
 	"go.uber.org/nilaway/annotation"
@@ -412,11 +413,7 @@ func (r *RootAssertionNode) buildFieldPathSelector(base ast.Expr, structType *ty
 
 // bindArgAndReceiverFieldsToContext binds, at a function or method call, the fields of each struct-typed
 // argument to the callee's corresponding parameter context site.
-func (r *RootAssertionNode) bindArgAndReceiverFieldsToContext(call *ast.CallExpr, funcIdent *ast.Ident) {
-	funcObj, ok := r.ObjectOf(funcIdent).(*types.Func)
-	if !ok {
-		return
-	}
+func (r *RootAssertionNode) bindArgAndReceiverFieldsToContext(call *ast.CallExpr, funcObj *types.Func) {
 	sig := funcObj.Signature()
 
 	if recv := sig.Recv(); recv != nil {
@@ -436,5 +433,165 @@ func (r *RootAssertionNode) bindArgAndReceiverFieldsToContext(call *ast.CallExpr
 			continue
 		}
 		r.bindValueFieldsToContext(funcObj, arg, structType, annotation.StructFieldParamContext, argIdx)
+	}
+}
+
+// addCallParamOutFieldProducers attaches a callee's post-call field state to its concrete arguments
+// and receiver. For `f(x)`, if f's parameter 0 may write `b.c`, it produces
+// `x.b.c <- PARAM_OUT(f, 0, "b.c")`. A post-call dereference of x.b.c then consumes f's output
+// summary, while fields absent from the write set retain their pre-call producers.
+func (r *RootAssertionNode) addCallParamOutFieldProducers(call *ast.CallExpr, funcObj *types.Func) {
+	sig := funcObj.Signature()
+	produce := func(arg ast.Expr, structType *types.Struct, index int) {
+		paths := r.functionContext.paramFieldEffects.ParamWritePaths(funcObj, index)
+		// AddProduction detaches a matched subtree, so nested paths must be produced first.
+		sort.SliceStable(paths, func(i, j int) bool {
+			return strings.Count(paths[i], ".") > strings.Count(paths[j], ".")
+		})
+		for _, fieldPath := range paths {
+			fieldExpr, ok := r.buildFieldPathSelector(arg, structType, fieldPath)
+			if !ok {
+				continue
+			}
+			site := &annotation.StructFieldContextSite{
+				FuncObj: funcObj,
+				Kind:    annotation.StructFieldParamOutContext,
+				Index:   index,
+				Path:    fieldPath,
+			}
+			r.AddProduction(&annotation.ProduceTrigger{
+				Annotation: &annotation.StructFieldFromContext{
+					TriggerIfNilable: &annotation.TriggerIfNilable{Ann: site},
+				},
+				Expr: fieldExpr,
+			})
+		}
+	}
+
+	if recv := sig.Recv(); recv != nil {
+		if sel, ok := ast.Unparen(call.Fun).(*ast.SelectorExpr); ok {
+			if structType := typeshelper.AsDeeplyStruct(recv.Type()); structType != nil {
+				produce(sel.X, structType, annotation.ReceiverParamIndex)
+			}
+		}
+	}
+	for index, arg := range call.Args {
+		if index >= sig.Params().Len() {
+			break
+		}
+		if structType := typeshelper.AsDeeplyStruct(sig.Params().At(index).Type()); structType != nil {
+			produce(arg, structType, index)
+		}
+	}
+}
+
+// bindForwardedParamOut connects a callee's output summary to a forwarder's output summary. For
+// `func g(p *A) { f(p) }`, when f's parameter 0 may write b.c, it adds
+// `PARAM_OUT(f, 0, "b.c") -> PARAM_OUT(g, 0, "b.c")`. A field prefix is retained, so passing
+// p.inner to f instead targets `PARAM_OUT(g, 0, "inner.b.c")`. The write summary is already closed
+// over these edges; this supplies each inherited path's context value.
+func (r *RootAssertionNode) bindForwardedParamOut(call *ast.CallExpr, callee *types.Func) {
+	sig := callee.Signature()
+	link := func(calleeIndex int, arg ast.Expr) {
+		base, prefix := asthelper.SplitFieldChain(arg)
+		if base == nil {
+			return
+		}
+		param, ok := r.ObjectOf(base).(*types.Var)
+		if !ok {
+			return
+		}
+		callerIndex, ok := r.getParamIndex(param)
+		if !ok {
+			return
+		}
+		for _, calleePath := range r.functionContext.paramFieldEffects.ParamWritePaths(callee, calleeIndex) {
+			fieldPath := calleePath
+			if prefix != "" {
+				fieldPath = prefix + "." + fieldPath
+			}
+			source := &annotation.StructFieldContextSite{
+				FuncObj: callee, Kind: annotation.StructFieldParamOutContext, Index: calleeIndex, Path: calleePath,
+			}
+			destination := &annotation.StructFieldContextSite{
+				FuncObj: r.FuncObj(), Kind: annotation.StructFieldParamOutContext, Index: callerIndex, Path: fieldPath,
+			}
+			r.AddNewTriggers(annotation.FullTrigger{
+				Producer: &annotation.ProduceTrigger{
+					Annotation: &annotation.StructFieldFromContext{TriggerIfNilable: &annotation.TriggerIfNilable{Ann: source}},
+					Expr:       arg,
+				},
+				Consumer: &annotation.ConsumeTrigger{
+					Annotation: &annotation.StructFieldToContext{TriggerIfNonNil: &annotation.TriggerIfNonNil{Ann: destination}},
+					Expr:       arg,
+					Guards:     guard.NoGuards(),
+				},
+			})
+		}
+	}
+
+	if recv := sig.Recv(); recv != nil {
+		if sel, ok := ast.Unparen(call.Fun).(*ast.SelectorExpr); ok {
+			link(annotation.ReceiverParamIndex, sel.X)
+		}
+	}
+	for index, arg := range call.Args {
+		if index >= sig.Params().Len() {
+			break
+		}
+		link(index, arg)
+	}
+}
+
+// bindParamFieldWriteToContext records a direct parameter or receiver field write as the callee's
+// post-call output. For `func f(p *A) { p.b.c = value }`, it connects
+// `value -> PARAM_OUT(f, 0, "b.c")`. For a local value, the consumer is attached to the local so
+// ordinary intraprocedural flow supplies the context. The write-summary check excludes local field
+// assignments from this boundary.
+func (r *RootAssertionNode) bindParamFieldWriteToContext(lhs, rhs ast.Expr) {
+	base, fieldPath := asthelper.SplitFieldChain(lhs)
+	if base == nil || fieldPath == "" {
+		return
+	}
+	param, ok := r.ObjectOf(base).(*types.Var)
+	if !ok {
+		return
+	}
+	index, ok := r.getParamIndex(param)
+	if !ok {
+		return
+	}
+	for _, path := range r.functionContext.paramFieldEffects.ParamWritePaths(r.FuncObj(), index) {
+		if path != fieldPath {
+			continue
+		}
+		site := &annotation.StructFieldContextSite{
+			FuncObj: r.FuncObj(),
+			Kind:    annotation.StructFieldParamOutContext,
+			Index:   index,
+			Path:    fieldPath,
+		}
+		consumer := &annotation.ConsumeTrigger{
+			Annotation: &annotation.StructFieldToContext{TriggerIfNonNil: &annotation.TriggerIfNonNil{Ann: site}},
+			Expr:       lhs,
+			Guards:     guard.NoGuards(),
+		}
+		if ident, ok := ast.Unparen(rhs).(*ast.Ident); ok {
+			if v, ok := r.ObjectOf(ident).(*types.Var); ok {
+				if _, isParam := r.getParamIndex(v); !isParam && !annotation.VarIsGlobal(v) {
+					consumer.Expr = rhs
+					r.AddConsumption(consumer)
+					return
+				}
+			}
+		}
+		r.AddNewTriggers(annotation.FullTrigger{
+			Producer: &annotation.ProduceTrigger{
+				Annotation: r.getShallowExprNilabilityProducer(rhs),
+				Expr:       rhs,
+			},
+			Consumer: consumer,
+		})
+		return
 	}
 }

--- a/assertion/function/structfieldeffects/effects.go
+++ b/assertion/function/structfieldeffects/effects.go
@@ -51,7 +51,7 @@ func (e *ParamFieldEffects) ParamReadPaths(funcObj *types.Func, idx int) []strin
 	if e == nil {
 		return nil
 	}
-	return readPaths(e.ParamReads, funcObj, idx)
+	return fieldPathsForIndex(e.ParamReads, funcObj, idx)
 }
 
 // ReturnReadPaths returns the field paths read from funcObj's result at idx.
@@ -59,13 +59,21 @@ func (e *ParamFieldEffects) ReturnReadPaths(funcObj *types.Func, idx int) []stri
 	if e == nil {
 		return nil
 	}
-	return readPaths(e.ReturnReads, funcObj, idx)
+	return fieldPathsForIndex(e.ReturnReads, funcObj, idx)
 }
 
-func readPaths(effects fieldEffects, funcObj *types.Func, idx int) []string {
-	reads := effects[funcObj]
-	paths := make([]string, 0, len(reads))
-	for key := range reads {
+// ParamWritePaths returns the field paths written through funcObj's parameter or receiver at idx.
+func (e *ParamFieldEffects) ParamWritePaths(funcObj *types.Func, idx int) []string {
+	if e == nil {
+		return nil
+	}
+	return fieldPathsForIndex(e.ParamWrites, funcObj, idx)
+}
+
+func fieldPathsForIndex(effects fieldEffects, funcObj *types.Func, idx int) []string {
+	fields := effects[funcObj]
+	paths := make([]string, 0, len(fields))
+	for key := range fields {
 		if key.Idx == idx && key.Path != "" {
 			paths = append(paths, key.Path)
 		}

--- a/assertion/function/structfieldeffects/effects.go
+++ b/assertion/function/structfieldeffects/effects.go
@@ -453,6 +453,15 @@ func fieldPathIsAcyclic(fn *types.Func, paramIdx int, path string) bool {
 		}
 		paramType = sig.Params().At(paramIdx).Type()
 	}
+	// AsDeeplyStruct unwraps at most one pointer, but forwarded field paths can be rooted at
+	// parameters with multiple pointer layers.
+	for {
+		ptr, ok := paramType.Underlying().(*types.Pointer)
+		if !ok {
+			break
+		}
+		paramType = ptr.Elem()
+	}
 	st := typeshelper.AsDeeplyStruct(paramType)
 	if st == nil {
 		return false

--- a/assertion/function/structfieldeffects/testdata/src/go.uber.org/paramfieldeffects/main.go
+++ b/assertion/function/structfieldeffects/testdata/src/go.uber.org/paramfieldeffects/main.go
@@ -43,9 +43,25 @@ func directRead(o *Outer) { // expect_effects: param_reads:0:Mid param_reads:0:M
 	_ = o.Mid.Child.Ptr
 }
 
+func explicitDerefRead(o *Outer) { // expect_effects: param_reads:0:Mid param_reads:0:Mid.Child
+	_ = (*o).Mid.Child.Ptr
+}
+
+func intermediateDerefRead(o *Outer) { // expect_effects: param_reads:0:Mid param_reads:0:Mid.Child
+	_ = (*o.Mid).Child.Ptr
+}
+
+func doublePointerRead(o **Outer) { // expect_effects: param_reads:0:Mid param_reads:0:Mid.Child
+	_ = (*o).Mid.Child.Ptr
+}
+
 // forwarder passes its parameter straight through, so the closure copies directRead's reads verbatim.
 func forwarder(o *Outer) { // expect_effects: param_reads:0:Mid param_reads:0:Mid.Child
 	directRead(o)
+}
+
+func forwardDerefPointerRead(o **Outer) { // expect_effects: param_reads:0:Mid param_reads:0:Mid.Child
+	directRead(*o)
 }
 
 // forwardField forwards a nested field of its parameter, so the inherited reads gain the "Inner" prefix.
@@ -95,6 +111,10 @@ func forwardWrite(o *Outer) { // expect_effects: writes:0:Mid.Child
 	writeChild(o.Mid)
 }
 
+func forwardDerefPointerWrite(o **Outer) { // expect_effects: writes:0:Mid
+	directWrite(*o)
+}
+
 func forwardWriteAgain(w *Wrap) { // expect_effects: writes:0:Inner.Mid.Child
 	forwardWrite(w.Inner)
 }
@@ -118,4 +138,12 @@ func ignoredValueParamWrite(o Outer) { // expect_effects:
 
 func ignoredRecursiveWrite(r *Rec) { // expect_effects: param_reads:0:Self
 	r.Self.Ptr = nil
+}
+
+func explicitDerefWrite(o *Outer) { // expect_effects: writes:0:Mid
+	(*o).Mid = nil
+}
+
+func explicitDoublePointerWrite(o **Outer) { // expect_effects: writes:0:Mid
+	(*o).Mid = nil
 }

--- a/nilaway_test.go
+++ b/nilaway_test.go
@@ -117,6 +117,7 @@ func TestStructInitV2(t *testing.T) { //nolint:paralleltest
 		"go.uber.org/structinitv2/defaultfield",
 		"go.uber.org/structinitv2/deep",
 		"go.uber.org/structinitv2/crosspkg/app",
+		"go.uber.org/structinitv2/paramsideeffect",
 	)
 }
 

--- a/testdata/src/go.uber.org/structinitv2/defaultfield/defaultfield.go
+++ b/testdata/src/go.uber.org/structinitv2/defaultfield/defaultfield.go
@@ -55,6 +55,15 @@ func escapeIntoSink() {
 	sink(&A{aptr: &A2{}}) // supplies aptr.aptr == nil
 }
 
+// A nil field escapes via a callee's side effect and is dereferenced by the caller afterwards.
+func clobber(c *A) { c.aptr = nil }
+
+func derefAfterSideEffect() {
+	b := &A{aptr: &A2{}}
+	clobber(b)
+	print(b.aptr.ptr) //want "field `aptr`"
+}
+
 // ---------------------------------------------------------------------------
 // Unknown caller / unanalyzed escape: optimistic, NOT reported (by design).
 // ---------------------------------------------------------------------------

--- a/testdata/src/go.uber.org/structinitv2/limitations/limitations.go
+++ b/testdata/src/go.uber.org/structinitv2/limitations/limitations.go
@@ -172,16 +172,6 @@ func tForwardViaFuncValue() *int {
 	return b.child.ptr
 }
 
-// False negative: parameter field writes are not supported, so a nil field written by a callee is
-// not re-produced at the call site.
-func clobberParamField(c *Node) { c.child = nil }
-
-func tParamFieldWriteNotMerged() *int {
-	b := &Node{child: &Leaf{}}
-	clobberParamField(b)
-	return b.child.ptr
-}
-
 // False negative: a struct-returning call forwarded through a return (`return f()`) is unsupported.
 // The callee's per-field return summary is not composed across the forward, so the nil child from
 // makeNilNode is not tracked at the caller. Supporting it would need the return-read demand closed
@@ -193,6 +183,25 @@ func forwardNilNode() *Node { return makeNilNode() }
 func tForwardedReturnNotComposed() *int {
 	b := forwardNilNode()
 	return b.child.ptr
+}
+
+// False negative: a struct-returning call used directly as an argument is not composed into the
+// parameter boundary. Return-effects support must bind makeNilNodeForParam's field summary to n.
+func makeNilNodeForParam() *Node { return &Node{} }
+
+func readReturnedParam(n *Node) *int { return n.child.ptr }
+
+func tReturnedCallAsParam() *int {
+	return readReturnedParam(makeNilNodeForParam())
+}
+
+// False negative: the same missing return-to-boundary composition applies to a method receiver.
+func makeNilNodeForReceiver() *Node { return &Node{} }
+
+func (n *Node) readReturnedReceiver() *int { return n.child.ptr }
+
+func tReturnedCallAsReceiver() *int {
+	return makeNilNodeForReceiver().readReturnedReceiver()
 }
 
 // ---------------------------------------------------------------------------------------------

--- a/testdata/src/go.uber.org/structinitv2/paramfield/paramfield.go
+++ b/testdata/src/go.uber.org/structinitv2/paramfield/paramfield.go
@@ -90,19 +90,6 @@ func f14(c *A) {
 	print(c.aptr.ptr) //want "field `aptr` of param 0 of `f14`"
 }
 
-// Positive example with direct composite as parameter
-func giveA15() *A {
-	return &A{}
-}
-
-func callF15() {
-	f15(giveA15())
-}
-
-func f15(c *A) {
-	print(c.aptr.ptr) //want "field `aptr` of param 0 of `f15`"
-}
-
 // Negative example with direct composite as parameter
 
 func callF16() {

--- a/testdata/src/go.uber.org/structinitv2/paramfield/receiverfield.go
+++ b/testdata/src/go.uber.org/structinitv2/paramfield/receiverfield.go
@@ -50,19 +50,6 @@ func (c A) f24() {
 	print(c.aptr.ptr) //want "field `aptr` of method receiver of `f24`"
 }
 
-// Positive example with direct composite as parameter
-func giveA25() *A {
-	return &A{}
-}
-
-func callF25() {
-	giveA25().f25()
-}
-
-func (c *A) f25() {
-	print(c.aptr.ptr) //want "field `aptr` of method receiver of `f25`"
-}
-
 // Negative example with direct composite as parameter
 
 func callF26() {

--- a/util/asthelper/asthelper.go
+++ b/util/asthelper/asthelper.go
@@ -187,9 +187,9 @@ func IsFieldSelectorChain(expr ast.Expr) bool {
 }
 
 // SplitFieldChain decomposes a field-chain expression into its base identifier and the dotted
-// field prefix from that base: `x` -> (x, ""), `x.a` -> (x, "a"), `x.a.b` -> (x, "a.b"). It
-// returns (nil, "") for anything whose innermost base is not a bare identifier, such as `(*x).a`
-// or `f().a`.
+// field prefix from that base: `x` -> (x, ""), `x.a` -> (x, "a"), `x.a.b` -> (x, "a.b"). Pointer
+// dereferences are transparent, so `(*x).a` -> (x, "a") and `*x` -> (x, ""). It returns (nil, "")
+// for anything whose innermost base is not a bare identifier, such as `f().a`.
 func SplitFieldChain(expr ast.Expr) (*ast.Ident, string) {
 	expr = ast.Unparen(expr)
 	var parts []string
@@ -205,6 +205,8 @@ func SplitFieldChain(expr ast.Expr) (*ast.Ident, string) {
 			return e, strings.Join(parts, ".")
 		case *ast.SelectorExpr:
 			parts = append(parts, e.Sel.Name)
+			expr = ast.Unparen(e.X)
+		case *ast.StarExpr:
 			expr = ast.Unparen(e.X)
 		default:
 			return nil, ""

--- a/util/asthelper/asthelper_test.go
+++ b/util/asthelper/asthelper_test.go
@@ -116,7 +116,9 @@ func TestSplitFieldChain(t *testing.T) {
 		{name: "SingleSelector", expr: "x.a", wantBase: "x", wantPrefix: "a"},
 		{name: "NestedSelector", expr: "x.a.b", wantBase: "x", wantPrefix: "a.b"},
 		{name: "ParenthesizedSelector", expr: "(x.a).b", wantBase: "x", wantPrefix: "a.b"},
-		{name: "PointerBase", expr: "(*x).a", wantBase: "", wantPrefix: ""},
+		{name: "PointerBase", expr: "(*x).a", wantBase: "x", wantPrefix: "a"},
+		{name: "PointerBaseNested", expr: "(*x).a.b", wantBase: "x", wantPrefix: "a.b"},
+		{name: "TopLevelDeref", expr: "*x", wantBase: "x", wantPrefix: ""},
 		{name: "CallBase", expr: "f().a", wantBase: "", wantPrefix: ""},
 	}
 


### PR DESCRIPTION
Track field writes through function parameters and receivers so callers observe the field’s post-call nilability.

Changes
- Add parameter-output field contexts for direct and transitive writes.
- Reproduce written fields at call sites while preserving unaffected fields.
- Track forwarded writes through nested calls, receivers, and field paths.
- Enable parameter side-effect tests and document unsupported call-result composition.