### PR TITLE
Fix field assignment suppression outside struct-init v2

### DIFF
--- a/accumulation/analyzer.go
+++ b/accumulation/analyzer.go
@@ -134,18 +134,11 @@ func run(p *analysis.Pass) (result interface{}, _ error) {
 		for i := range assertionsResult.Res {
 			t := &assertionsResult.Res[i]
 			if _, ok := t.Consumer.Annotation.(*annotation.FldAssign); ok {
-				if conf.ExperimentalStructInitV2Enable {
-					// The legacy FldAssign suppression changes its producer's annotation to Never. A
-					// producer can be shared by multiple full triggers; under ExperimentalStructInitV2Enable ,
-					// a param-out consumer for the same field write can share it. Mutating that producer would silence the
-					// param-out consumer too, so give only the FldAssign trigger a Never producer.
-					// Once ExperimentalStructInitV2Enable is complete, FldAssign and this block should be removed.
-					t.Producer = &annotation.ProduceTrigger{
-						Annotation: &annotation.ProduceTriggerNever{},
-						Expr:       t.Producer.Expr,
-					}
-				} else {
-					t.Producer.Annotation = &annotation.ProduceTriggerNever{}
+				// Create a fresh producer for this consumer so the shared producer is not
+				// mutated.
+				t.Producer = &annotation.ProduceTrigger{
+					Annotation: &annotation.ProduceTriggerNever{},
+					Expr:       t.Producer.Expr,
 				}
 			}
 		}

--- a/testdata/src/go.uber.org/receivers/inference/receivers-with-inference.go
+++ b/testdata/src/go.uber.org/receivers/inference/receivers-with-inference.go
@@ -186,9 +186,7 @@ func testBlankAndNonPointerReceiversForLibraryMethods() {
 	var e E
 	var err2 error
 	e.errField = err2
-	// TODO: Error should be reported on the line below. It is currently not reported because of the suppression of
-	//  struct field assignment logic that we added until we add object sensitivity for precise handling (issue #339).
-	print(e.errField.Error()) // "unassigned variable"
+	print(e.errField.Error()) //want "unassigned variable"
 
 	e.errField = &myErr{}
 	print(e.errField.Error()) // safe


### PR DESCRIPTION
### Summary
- Avoid mutating a producer shared by field-assignment triggers
- Apply the fix outside experimental struct-init v2 and cover the restored receiver diagnostic
