### PR TITLE
feat(struct-init-v2): propagate parameter field writes across packages

### DIFF
--- a/assertion/function/structfieldeffects/analyzer.go
+++ b/assertion/function/structfieldeffects/analyzer.go
@@ -39,7 +39,7 @@ var Analyzer = &analysis.Analyzer{
 	Doc:        _doc,
 	Run:        analysishelper.WrapRun(run),
 	ResultType: reflect.TypeOf((*analysishelper.Result[*ParamFieldEffects])(nil)),
-	FactTypes:  []analysis.Fact{new(ParamFieldReadsPackageFact)},
+	FactTypes:  []analysis.Fact{new(ParamFieldEffectsPackageFact)},
 	Requires:   []*analysis.Analyzer{config.Analyzer},
 }
 
@@ -51,34 +51,46 @@ func run(p *analysis.Pass) (*ParamFieldEffects, error) {
 	}
 
 	packageSummary, forwardingEdges, callees := computeParamFieldEffects(pass)
-	if err := importUsedParamReads(pass, packageSummary.ParamReads, callees); err != nil {
+	if err := importUsedParamEffects(pass, packageSummary, callees); err != nil {
 		return nil, err
 	}
 
 	closeParamFieldSets(packageSummary.ParamWrites, forwardingEdges)
 	closeParamFieldSets(packageSummary.ParamReads, forwardingEdges)
-	fact := &ParamFieldReadsPackageFact{}
+	fact := &ParamFieldEffectsPackageFact{}
 	encoder := &objectpath.Encoder{}
+	funcs := make(map[*types.Func]bool, len(packageSummary.ParamReads)+len(packageSummary.ParamWrites))
 	for funcObj := range packageSummary.ParamReads {
+		funcs[funcObj] = true
+	}
+	for funcObj := range packageSummary.ParamWrites {
+		funcs[funcObj] = true
+	}
+	for funcObj := range funcs {
 		if funcObj.Pkg() != pass.Pkg || !funcObj.Exported() {
 			continue
 		}
-		// Export only parameter reads. Return reads remain local because callers infer them
+		// Return reads remain local because callers infer them
 		// from their dereferences of results, opposite the direction of fact propagation.
 		reads := packageSummary.ParamReads.sortedPaths(funcObj)
-		if len(reads) == 0 {
+		writes := packageSummary.ParamWrites.sortedPaths(funcObj)
+		if len(reads) == 0 && len(writes) == 0 {
 			continue
 		}
 		path, err := encoder.For(funcObj)
 		if err != nil {
 			return nil, fmt.Errorf("create object path for exported function %s: %w", funcObj, err)
 		}
-		fact.Functions = append(fact.Functions, FunctionParamFieldReads{FunctionObjectPath: path, ParamReads: reads})
+		fact.Functions = append(fact.Functions, FunctionParamFieldEffects{
+			FunctionObjectPath: path,
+			ParamReads:         reads,
+			ParamWrites:        writes,
+		})
 	}
 	if len(fact.Functions) > 0 {
 		// Functions were collected by ranging a map. Sorting makes the serialized fact
 		// deterministic and maintains the ordering required by BinarySearchFunc on import.
-		slices.SortFunc(fact.Functions, func(left, right FunctionParamFieldReads) int {
+		slices.SortFunc(fact.Functions, func(left, right FunctionParamFieldEffects) int {
 			return cmp.Compare(left.FunctionObjectPath, right.FunctionObjectPath)
 		})
 		pass.ExportPackageFact(fact)
@@ -87,7 +99,7 @@ func run(p *analysis.Pass) (*ParamFieldEffects, error) {
 	return packageSummary, nil
 }
 
-func importUsedParamReads(pass *analysishelper.EnhancedPass, paramReads fieldEffects, callees map[*types.Func]bool) error {
+func importUsedParamEffects(pass *analysishelper.EnhancedPass, effects *ParamFieldEffects, callees map[*types.Func]bool) error {
 	calleesByPackage := make(map[*types.Package][]*types.Func)
 	for callee := range callees {
 		if callee.Pkg() != nil && callee.Pkg() != pass.Pkg {
@@ -102,7 +114,7 @@ func importUsedParamReads(pass *analysishelper.EnhancedPass, paramReads fieldEff
 
 	encoder := &objectpath.Encoder{}
 	for _, pkg := range packages {
-		var fact ParamFieldReadsPackageFact
+		var fact ParamFieldEffectsPackageFact
 		if !pass.ImportPackageFact(pkg, &fact) {
 			continue
 		}
@@ -111,11 +123,12 @@ func importUsedParamReads(pass *analysishelper.EnhancedPass, paramReads fieldEff
 			if err != nil {
 				return fmt.Errorf("create object path for imported function %s: %w", callee, err)
 			}
-			index, found := slices.BinarySearchFunc(fact.Functions, path, func(entry FunctionParamFieldReads, path objectpath.Path) int {
+			index, found := slices.BinarySearchFunc(fact.Functions, path, func(entry FunctionParamFieldEffects, path objectpath.Path) int {
 				return cmp.Compare(entry.FunctionObjectPath, path)
 			})
 			if found {
-				seedImportedParamReads(paramReads, callee, fact.Functions[index].ParamReads)
+				seedImportedParamEffects(effects.ParamReads, callee, fact.Functions[index].ParamReads)
+				seedImportedParamEffects(effects.ParamWrites, callee, fact.Functions[index].ParamWrites)
 			}
 		}
 	}

--- a/assertion/function/structfieldeffects/effects.go
+++ b/assertion/function/structfieldeffects/effects.go
@@ -147,13 +147,13 @@ func computeParamFieldEffects(pass *analysishelper.EnhancedPass) (*ParamFieldEff
 	return &ParamFieldEffects{ParamReads: reads, ReturnReads: returnReads, ParamWrites: writes}, edges, callees
 }
 
-// seedImportedParamReads merges an imported callee's parameter-read fact before closure runs.
-func seedImportedParamReads(paramReads fieldEffects, funcObj *types.Func, reads []IndexedFieldPath) {
-	for _, read := range reads {
-		if read.Path == "" {
+// seedImportedParamEffects merges an imported callee's parameter effects before closure runs.
+func seedImportedParamEffects(effects fieldEffects, funcObj *types.Func, paths []IndexedFieldPath) {
+	for _, path := range paths {
+		if path.Path == "" {
 			continue
 		}
-		paramReads.add(funcObj, read)
+		effects.add(funcObj, path)
 	}
 }
 

--- a/assertion/function/structfieldeffects/effects_test.go
+++ b/assertion/function/structfieldeffects/effects_test.go
@@ -62,7 +62,7 @@ func TestComputeParamFieldEffects(t *testing.T) {
 		for _, token := range tokens {
 			kind, key := parseExpectedEffect(t, token)
 			switch kind {
-			case "writes":
+			case "param_writes":
 				wantWrites[funcObj] = append(wantWrites[funcObj], key)
 			case "param_reads":
 				wantParam[funcObj] = append(wantParam[funcObj], key)

--- a/assertion/function/structfieldeffects/fact.go
+++ b/assertion/function/structfieldeffects/fact.go
@@ -16,16 +16,17 @@ package structfieldeffects
 
 import "golang.org/x/tools/go/types/objectpath"
 
-// ParamFieldReadsPackageFact is the exported parameter field-read summary for one package.
-type ParamFieldReadsPackageFact struct {
-	Functions []FunctionParamFieldReads
+// ParamFieldEffectsPackageFact is the exported parameter field-effect summary for one package.
+type ParamFieldEffectsPackageFact struct {
+	Functions []FunctionParamFieldEffects
 }
 
 // AFact enables use of the facts passing mechanism in Go's analysis framework.
-func (*ParamFieldReadsPackageFact) AFact() {}
+func (*ParamFieldEffectsPackageFact) AFact() {}
 
-// FunctionParamFieldReads is a function's parameter field-read summary within a package fact.
-type FunctionParamFieldReads struct {
+// FunctionParamFieldEffects is a function's parameter field-effect summary within a package fact.
+type FunctionParamFieldEffects struct {
 	FunctionObjectPath objectpath.Path
 	ParamReads         []IndexedFieldPath
+	ParamWrites        []IndexedFieldPath
 }

--- a/assertion/function/structfieldeffects/fact_test.go
+++ b/assertion/function/structfieldeffects/fact_test.go
@@ -45,16 +45,23 @@ func TestFact(t *testing.T) { //nolint:paralleltest
 		require.NoError(t, effects.Err)
 
 		localReads := make(fieldEffects)
+		localWrites := make(fieldEffects)
 		for funcObj, reads := range effects.Res.ParamReads {
 			if funcObj.Pkg() == pass.Pkg {
 				localReads[funcObj] = reads
 			}
 		}
+		for funcObj, writes := range effects.Res.ParamWrites {
+			if funcObj.Pkg() == pass.Pkg {
+				localWrites[funcObj] = writes
+			}
+		}
 		requireEffects(t, localReads, expectedParamReads(t, pass))
+		requireEffects(t, localWrites, expectedParamWrites(t, pass))
 	}
 }
 
-func TestParamFieldReadsPackageFactCodec(t *testing.T) {
+func TestParamFieldEffectsPackageFactCodec(t *testing.T) {
 	t.Parallel()
 
 	fact := newFact(100)
@@ -64,10 +71,10 @@ func TestParamFieldReadsPackageFactCodec(t *testing.T) {
 		require.NoError(t, gob.NewEncoder(&buf).Encode(fact))
 		encoded := append([]byte(nil), buf.Bytes()...)
 		require.NotEmpty(t, encoded)
-		require.Less(t, len(encoded), 10_000,
+		require.Less(t, len(encoded), 15_000,
 			"encoded facts contribute to artifact size; increase this cap only with justification")
 
-		var decoded ParamFieldReadsPackageFact
+		var decoded ParamFieldEffectsPackageFact
 		require.NoError(t, gob.NewDecoder(bytes.NewReader(encoded)).Decode(&decoded))
 		require.Equal(t, fact, &decoded)
 
@@ -78,8 +85,8 @@ func TestParamFieldReadsPackageFactCodec(t *testing.T) {
 	}
 }
 
-// BenchmarkParamFieldReadsPackageFactCodec measures one complete fact in a fresh gob stream.
-func BenchmarkParamFieldReadsPackageFactCodec(b *testing.B) {
+// BenchmarkParamFieldEffectsPackageFactCodec measures one complete fact in a fresh gob stream.
+func BenchmarkParamFieldEffectsPackageFactCodec(b *testing.B) {
 	for _, functionCount := range []int{1, 10, 100} {
 		fact := newFact(functionCount)
 		b.Run(fmt.Sprintf("encode/%d-functions", functionCount), func(b *testing.B) {
@@ -108,7 +115,7 @@ func BenchmarkParamFieldReadsPackageFactCodec(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
 			for b.Loop() {
-				var decoded ParamFieldReadsPackageFact
+				var decoded ParamFieldEffectsPackageFact
 				if err := gob.NewDecoder(bytes.NewReader(encoded.Bytes())).Decode(&decoded); err != nil {
 					b.Fatal(err)
 				}
@@ -126,6 +133,14 @@ func enableStructInitV2(t *testing.T) {
 }
 
 func expectedParamReads(t *testing.T, pass *analysis.Pass) map[*types.Func][]IndexedFieldPath {
+	return expectedParamEffects(t, pass, "param_reads")
+}
+
+func expectedParamWrites(t *testing.T, pass *analysis.Pass) map[*types.Func][]IndexedFieldPath {
+	return expectedParamEffects(t, pass, "param_writes")
+}
+
+func expectedParamEffects(t *testing.T, pass *analysis.Pass, wantKind string) map[*types.Func][]IndexedFieldPath {
 	t.Helper()
 
 	want := make(map[*types.Func][]IndexedFieldPath)
@@ -136,17 +151,18 @@ func expectedParamReads(t *testing.T, pass *analysis.Pass) map[*types.Func][]Ind
 		require.True(t, ok)
 		for _, token := range tokens {
 			kind, key := parseExpectedEffect(t, token)
-			require.Equal(t, "param_reads", kind)
-			want[funcObj] = append(want[funcObj], key)
+			if kind == wantKind {
+				want[funcObj] = append(want[funcObj], key)
+			}
 		}
 	}
 	return want
 }
 
-func newFact(functionCount int) *ParamFieldReadsPackageFact {
-	functions := make([]FunctionParamFieldReads, functionCount)
+func newFact(functionCount int) *ParamFieldEffectsPackageFact {
+	functions := make([]FunctionParamFieldEffects, functionCount)
 	for i := range functions {
-		functions[i] = FunctionParamFieldReads{
+		functions[i] = FunctionParamFieldEffects{
 			FunctionObjectPath: objectpath.Path(fmt.Sprintf("Function%03d", i)),
 			ParamReads: []IndexedFieldPath{
 				{Idx: -1, Path: "Receiver"},
@@ -154,7 +170,13 @@ func newFact(functionCount int) *ParamFieldReadsPackageFact {
 				{Idx: 0, Path: "Child.Leaf"},
 				{Idx: 1, Path: fmt.Sprintf("Argument%d.Field", i)},
 			},
+			ParamWrites: []IndexedFieldPath{
+				{Idx: -1, Path: "Receiver.Child"},
+				{Idx: 0, Path: "Child"},
+				{Idx: 0, Path: "Child.Leaf"},
+				{Idx: 1, Path: fmt.Sprintf("Argument%d.Field", i)},
+			},
 		}
 	}
-	return &ParamFieldReadsPackageFact{Functions: functions}
+	return &ParamFieldEffectsPackageFact{Functions: functions}
 }

--- a/assertion/function/structfieldeffects/testdata/src/go.uber.org/paramfieldeffects/factexport/downstream/downstream.go
+++ b/assertion/function/structfieldeffects/testdata/src/go.uber.org/paramfieldeffects/factexport/downstream/downstream.go
@@ -13,3 +13,19 @@ func ForwardUnused(o *upstream.Outer) {
 func DirectCall() {
 	upstream.ExportedRead(&upstream.Outer{})
 }
+
+func ForwardWrite(o *upstream.Outer) { // expect_effects: param_writes:0:Mid
+	upstream.ExportedWrite(o)
+}
+
+func ForwardDeepWrite(o *upstream.Outer) { // expect_effects: param_reads:0:Mid param_writes:0:Mid.Child
+	upstream.ExportedDeepWrite(o)
+}
+
+func ForwardExportedForwardWrite(o *upstream.Outer) { // expect_effects: param_reads:0:Mid param_writes:0:Mid.Child
+	upstream.ExportedForwardWrite(o)
+}
+
+func ForwardWriteTwice(o *upstream.Outer) { // expect_effects: param_reads:0:Mid param_writes:0:Mid.Child
+	ForwardDeepWrite(o)
+}

--- a/assertion/function/structfieldeffects/testdata/src/go.uber.org/paramfieldeffects/factexport/upstream/upstream.go
+++ b/assertion/function/structfieldeffects/testdata/src/go.uber.org/paramfieldeffects/factexport/upstream/upstream.go
@@ -31,3 +31,15 @@ func ExportedNoRead(o *Outer) {
 func unexportedRead(o *Outer) { // expect_effects: param_reads:0:Mid param_reads:0:Mid.Child
 	_ = o.Mid.Child.Ptr
 }
+
+func ExportedWrite(o *Outer) { // expect_effects: param_writes:0:Mid
+	o.Mid = nil
+}
+
+func ExportedDeepWrite(o *Outer) { // expect_effects: param_reads:0:Mid param_writes:0:Mid.Child
+	o.Mid.Child = nil
+}
+
+func ExportedForwardWrite(o *Outer) { // expect_effects: param_reads:0:Mid param_writes:0:Mid.Child
+	ExportedDeepWrite(o)
+}

--- a/assertion/function/structfieldeffects/testdata/src/go.uber.org/paramfieldeffects/main.go
+++ b/assertion/function/structfieldeffects/testdata/src/go.uber.org/paramfieldeffects/main.go
@@ -95,31 +95,31 @@ func recForward(r *Rec) { // expect_effects:
 	recRead(r.Self)
 }
 
-func directWrite(o *Outer) { // expect_effects: writes:0:Mid
+func directWrite(o *Outer) { // expect_effects: param_writes:0:Mid
 	o.Mid = &Node{}
 }
 
-func deepWrite(o *Outer) { // expect_effects: writes:0:Mid.Child param_reads:0:Mid
+func deepWrite(o *Outer) { // expect_effects: param_writes:0:Mid.Child param_reads:0:Mid
 	o.Mid.Child = nil
 }
 
-func (o *Outer) receiverWrite() { // expect_effects: writes:-1:Mid
+func (o *Outer) receiverWrite() { // expect_effects: param_writes:-1:Mid
 	o.Mid = &Node{}
 }
 
-func forwardWrite(o *Outer) { // expect_effects: writes:0:Mid.Child
+func forwardWrite(o *Outer) { // expect_effects: param_writes:0:Mid.Child
 	writeChild(o.Mid)
 }
 
-func forwardDerefPointerWrite(o **Outer) { // expect_effects: writes:0:Mid
+func forwardDerefPointerWrite(o **Outer) { // expect_effects: param_writes:0:Mid
 	directWrite(*o)
 }
 
-func forwardWriteAgain(w *Wrap) { // expect_effects: writes:0:Inner.Mid.Child
+func forwardWriteAgain(w *Wrap) { // expect_effects: param_writes:0:Inner.Mid.Child
 	forwardWrite(w.Inner)
 }
 
-func writeChild(n *Node) { // expect_effects: writes:0:Child
+func writeChild(n *Node) { // expect_effects: param_writes:0:Child
 	n.Child = nil
 }
 
@@ -140,10 +140,10 @@ func ignoredRecursiveWrite(r *Rec) { // expect_effects: param_reads:0:Self
 	r.Self.Ptr = nil
 }
 
-func explicitDerefWrite(o *Outer) { // expect_effects: writes:0:Mid
+func explicitDerefWrite(o *Outer) { // expect_effects: param_writes:0:Mid
 	(*o).Mid = nil
 }
 
-func explicitDoublePointerWrite(o **Outer) { // expect_effects: writes:0:Mid
+func explicitDoublePointerWrite(o **Outer) { // expect_effects: param_writes:0:Mid
 	(*o).Mid = nil
 }

--- a/nilaway_test.go
+++ b/nilaway_test.go
@@ -117,6 +117,8 @@ func TestStructInitV2(t *testing.T) { //nolint:paralleltest
 		"go.uber.org/structinitv2/defaultfield",
 		"go.uber.org/structinitv2/deep",
 		"go.uber.org/structinitv2/crosspkg/app",
+		"go.uber.org/structinitv2/crosspkgside/app",
+		"go.uber.org/structinitv2/paramfield",
 		"go.uber.org/structinitv2/paramsideeffect",
 	)
 }


### PR DESCRIPTION
Propagate parameter-field write effects across package boundaries. This allows callers to observe direct, deep, and transitively forwarded mutations made by external callees.

Changes
- Extend the typed field-effects fact with parameter writes.
- Import read and write effects before transitive closure.
- Preserve deterministic fact serialization.
- Add cross-package write and forwarding coverage.
- Enable crosspkgside/app and paramfield tests.