### PR TITLE
Cache declaring identifiers in assertion trees

### DIFF
--- a/assertion/function/assertiontree/function_context.go
+++ b/assertion/function/assertiontree/function_context.go
@@ -70,6 +70,9 @@ type FunctionContext struct {
 	// field binding consults the read-path accessors to bind only the field paths a boundary actually
 	// dereferences rather than the full type.
 	paramFieldEffects *structfieldeffects.ParamFieldEffects
+
+	// declaringIdentCache stores declaring identifiers by object.
+	declaringIdentCache map[types.Object]*ast.Ident
 }
 
 // FunctionConfig is meant to hold all the user set configuration for analyzing a function
@@ -109,6 +112,7 @@ func NewFunctionContext(
 		pkgFakeIdentMap:         pkgFakeIdentMap,
 		funcContracts:           funcContracts,
 		paramFieldEffects:       effects,
+		declaringIdentCache:     make(map[types.Object]*ast.Ident),
 	}
 }
 

--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -132,7 +132,16 @@ func (r *RootAssertionNode) GetTriggers() []annotation.FullTrigger {
 
 // GetDeclaringIdent finds the identifier that serves as the declaration of the passed object
 func (r *RootAssertionNode) GetDeclaringIdent(obj types.Object) *ast.Ident {
+	if ident, ok := r.functionContext.declaringIdentCache[obj]; ok {
+		return ident
+	}
 
+	ident := r.computeDeclaringIdent(obj)
+	r.functionContext.declaringIdentCache[obj] = ident
+	return ident
+}
+
+func (r *RootAssertionNode) computeDeclaringIdent(obj types.Object) *ast.Ident {
 	if path, ok := GetDeclaringPath(r.Pass(), obj.Pos(), obj.Pos()); ok && len(path) > 0 {
 		if ident, ok := path[0].(*ast.Ident); ok && ident.Name == obj.Name() {
 			return ident


### PR DESCRIPTION
## Summary
Cache declaring identifiers by `types.Object` in each function context, avoiding repeated AST walks through `PathEnclosingInterval` during assertion-tree backpropagation.

On full stdlib, median wall time improves by **3.2% with experimental struct initialization v2 disabled** and **9.3% with experimental struct initialization v2 enabled**, with diagnostics unchanged.

## Method
- Workload: the project's golden-test stdlib command:
  `nilaway -include-errors-in-files / -json -pretty-print=false -group-error-messages=true std`
- Experimental struct initialization v2 mode adds `-experimental-struct-init-v2=true`.
- Hardware: Apple Silicon, 16 logical CPUs, Go 1.26.3.
- One warm-up plus eight measured iterations per variant and mode, interleaved with alternating base/fix execution order to reduce thermal and background-process bias.

## Correctness
- Identical diagnostic counts with and without this change
- `make test` and `make lint` pass.

## Experimental struct initialization v2 disabled

| metric | base median | fix median | delta |
|--------|------------:|-----------:|------:|
| real (wall) | 14.59 s | 14.13 s | **-3.2%** |
| user (CPU) | 169.55 s | 164.37 s | **-3.1%** |
| sys (CPU) | 10.35 s | 10.73 s | +3.7% |

## Experimental struct initialization v2 enabled

| metric | base median | fix median | delta |
|--------|------------:|-----------:|------:|
| real (wall) | 19.08 s | 17.32 s | **-9.3%** |
| user (CPU) | 216.83 s | 195.80 s | **-9.7%** |
| sys (CPU) | 11.66 s | 11.17 s | -4.2% |

CPU-time distributions still do not overlap: base user time was 212.42-224.88 s versus 189.45-198.44 s with the cache.
