### PR TITLE
refactor(struct-init-v2): organize field effect collection

### DIFF
--- a/assertion/function/analyzer.go
+++ b/assertion/function/analyzer.go
@@ -109,7 +109,7 @@ func run(p *analysis.Pass) ([]annotation.FullTrigger, error) {
 	ctrlflowResult := pass.ResultOf[ctrlflow.Analyzer].(*ctrlflow.CFGs)
 	anonymousFuncResult := pass.ResultOf[anonymousfunc.Analyzer].(*analysishelper.Result[map[*ast.FuncLit]*anonymousfunc.FuncLitInfo])
 	contractsResult := pass.ResultOf[functioncontracts.Analyzer].(*analysishelper.Result[functioncontracts.Map])
-	structFieldEffectsResult := pass.ResultOf[structfieldeffects.Analyzer].(*analysishelper.Result[*structfieldeffects.ParamFieldEffects])
+	structFieldEffectsResult := pass.ResultOf[structfieldeffects.Analyzer].(*analysishelper.Result[*structfieldeffects.BoundaryFieldEffects])
 	if err := errors.Join(anonymousFuncResult.Err, contractsResult.Err, structFieldEffectsResult.Err); err != nil {
 		return nil, err
 	}
@@ -124,7 +124,7 @@ func run(p *analysis.Pass) ([]annotation.FullTrigger, error) {
 
 	// Field paths needed for the boundary bindings, precomputed by the struct field effects
 	// analyzer (empty when the analysis is disabled).
-	paramFieldEffects := structFieldEffectsResult.Res
+	boundaryFieldEffects := structFieldEffectsResult.Res
 
 	// Set up variables for synchronization and communication.
 	ctx, cancel := context.WithCancel(context.Background())
@@ -206,7 +206,7 @@ func run(p *analysis.Pass) ([]annotation.FullTrigger, error) {
 
 			// Now, analyze the function declarations concurrently.
 			funcContext := assertiontree.NewFunctionContext(
-				pass, funcDecl, funcLit, functionConfig, funcLitMap, pkgFakeIdentMap, funcContracts, paramFieldEffects)
+				pass, funcDecl, funcLit, functionConfig, funcLitMap, pkgFakeIdentMap, funcContracts, boundaryFieldEffects)
 			idx := funcIndex
 			wg.Go(func() { analyzeFunc(ctx, pass, funcDecl, funcContext, graph, idx, funcChan) })
 			funcIndex++

--- a/assertion/function/assertiontree/function_context.go
+++ b/assertion/function/assertiontree/function_context.go
@@ -65,11 +65,11 @@ type FunctionContext struct {
 	// funcContracts stores the function contracts of all the functions.
 	funcContracts functioncontracts.Map
 
-	// paramFieldEffects is the package-level boundary summary computed by the struct field effects
+	// boundaryFieldEffects is the package-level boundary summary computed by the struct field effects
 	// analyzer. Read-only here and always non-nil (empty when the analysis is disabled): the boundary
 	// field binding consults the read-path accessors to bind only the field paths a boundary actually
 	// dereferences rather than the full type.
-	paramFieldEffects *structfieldeffects.ParamFieldEffects
+	boundaryFieldEffects *structfieldeffects.BoundaryFieldEffects
 
 	// declaringIdentCache stores declaring identifiers by object.
 	declaringIdentCache map[types.Object]*ast.Ident
@@ -94,12 +94,12 @@ func NewFunctionContext(
 	funcLitMap map[*ast.FuncLit]*anonymousfunc.FuncLitInfo,
 	pkgFakeIdentMap map[*ast.Ident]types.Object,
 	funcContracts functioncontracts.Map,
-	effects *structfieldeffects.ParamFieldEffects,
+	effects *structfieldeffects.BoundaryFieldEffects,
 ) FunctionContext {
 	// Keep effects non-nil so the boundary lookups never need a nil guard; an empty summary
 	// (nil inner maps) reads back as "no effects", which is correct when the analysis is disabled.
 	if effects == nil {
-		effects = &structfieldeffects.ParamFieldEffects{}
+		effects = &structfieldeffects.BoundaryFieldEffects{}
 	}
 	return FunctionContext{
 		pass:                    pass,
@@ -111,7 +111,7 @@ func NewFunctionContext(
 		funcLitMap:              funcLitMap,
 		pkgFakeIdentMap:         pkgFakeIdentMap,
 		funcContracts:           funcContracts,
-		paramFieldEffects:       effects,
+		boundaryFieldEffects:    effects,
 		declaringIdentCache:     make(map[types.Object]*ast.Ident),
 	}
 }

--- a/assertion/function/assertiontree/structinitv2.go
+++ b/assertion/function/assertiontree/structinitv2.go
@@ -265,9 +265,9 @@ func (r *RootAssertionNode) bindValueFieldsToContext(targetFunc *types.Func, val
 	var demanded []string
 	switch kind {
 	case annotation.StructFieldParamContext:
-		demanded = r.functionContext.paramFieldEffects.ParamReadPaths(funcObj, index)
+		demanded = r.functionContext.boundaryFieldEffects.ParamReadPaths(funcObj, index)
 	case annotation.StructFieldReturnContext:
-		demanded = r.functionContext.paramFieldEffects.ReturnReadPaths(funcObj, index)
+		demanded = r.functionContext.boundaryFieldEffects.ReturnReadPaths(funcObj, index)
 	}
 	for _, fieldPath := range demanded {
 		sel, ok := r.buildFieldPathSelector(valExpr, structType, fieldPath)
@@ -443,7 +443,7 @@ func (r *RootAssertionNode) bindArgAndReceiverFieldsToContext(call *ast.CallExpr
 func (r *RootAssertionNode) addCallParamOutFieldProducers(call *ast.CallExpr, funcObj *types.Func) {
 	sig := funcObj.Signature()
 	produce := func(arg ast.Expr, structType *types.Struct, index int) {
-		paths := r.functionContext.paramFieldEffects.ParamWritePaths(funcObj, index)
+		paths := r.functionContext.boundaryFieldEffects.ParamWritePaths(funcObj, index)
 		// AddProduction detaches a matched subtree, so nested paths must be produced first.
 		sort.SliceStable(paths, func(i, j int) bool {
 			return strings.Count(paths[i], ".") > strings.Count(paths[j], ".")
@@ -505,7 +505,7 @@ func (r *RootAssertionNode) bindForwardedParamOut(call *ast.CallExpr, callee *ty
 		if !ok {
 			return
 		}
-		for _, calleePath := range r.functionContext.paramFieldEffects.ParamWritePaths(callee, calleeIndex) {
+		for _, calleePath := range r.functionContext.boundaryFieldEffects.ParamWritePaths(callee, calleeIndex) {
 			fieldPath := calleePath
 			if prefix != "" {
 				fieldPath = prefix + "." + fieldPath
@@ -561,7 +561,7 @@ func (r *RootAssertionNode) bindParamFieldWriteToContext(lhs, rhs ast.Expr) {
 	if !ok {
 		return
 	}
-	for _, path := range r.functionContext.paramFieldEffects.ParamWritePaths(r.FuncObj(), index) {
+	for _, path := range r.functionContext.boundaryFieldEffects.ParamWritePaths(r.FuncObj(), index) {
 		if path != fieldPath {
 			continue
 		}

--- a/assertion/function/structfieldeffects/analyzer.go
+++ b/assertion/function/structfieldeffects/analyzer.go
@@ -33,31 +33,30 @@ import (
 const _doc = "Compute the per-package struct-field boundary summary: the field paths each function " +
 	"writes or reads on its parameters and the result fields its callers consume."
 
-// Analyzer computes the package-level ParamFieldEffects boundary summary.
+// Analyzer computes the package-level BoundaryFieldEffects summary.
 var Analyzer = &analysis.Analyzer{
 	Name:       "nilaway_struct_field_effects_analyzer",
 	Doc:        _doc,
 	Run:        analysishelper.WrapRun(run),
-	ResultType: reflect.TypeOf((*analysishelper.Result[*ParamFieldEffects])(nil)),
-	FactTypes:  []analysis.Fact{new(ParamFieldEffectsPackageFact)},
+	ResultType: reflect.TypeOf((*analysishelper.Result[*BoundaryFieldEffects])(nil)),
+	FactTypes:  []analysis.Fact{new(BoundaryFieldEffectsPackageFact)},
 	Requires:   []*analysis.Analyzer{config.Analyzer},
 }
 
-func run(p *analysis.Pass) (*ParamFieldEffects, error) {
+func run(p *analysis.Pass) (*BoundaryFieldEffects, error) {
 	pass := analysishelper.NewEnhancedPass(p)
 	conf := pass.ResultOf[config.Analyzer].(*config.Config)
 	if !conf.ExperimentalStructInitV2Enable || !conf.IsPkgInScope(pass.Pkg) {
-		return &ParamFieldEffects{}, nil
+		return &BoundaryFieldEffects{}, nil
 	}
 
-	packageSummary, forwardingEdges, callees := computeParamFieldEffects(pass)
-	if err := importUsedParamEffects(pass, packageSummary, callees); err != nil {
+	collected := computeBoundaryFieldEffects(pass)
+	if err := importUsedParamEffects(pass, collected.summary, collected.callees); err != nil {
 		return nil, err
 	}
 
-	closeParamFieldSets(packageSummary.ParamWrites, forwardingEdges)
-	closeParamFieldSets(packageSummary.ParamReads, forwardingEdges)
-	fact := &ParamFieldEffectsPackageFact{}
+	packageSummary := collected.close()
+	fact := &BoundaryFieldEffectsPackageFact{}
 	encoder := &objectpath.Encoder{}
 	funcs := make(map[*types.Func]bool, len(packageSummary.ParamReads)+len(packageSummary.ParamWrites))
 	for funcObj := range packageSummary.ParamReads {
@@ -81,7 +80,7 @@ func run(p *analysis.Pass) (*ParamFieldEffects, error) {
 		if err != nil {
 			return nil, fmt.Errorf("create object path for exported function %s: %w", funcObj, err)
 		}
-		fact.Functions = append(fact.Functions, FunctionParamFieldEffects{
+		fact.Functions = append(fact.Functions, FunctionFieldEffects{
 			FunctionObjectPath: path,
 			ParamReads:         reads,
 			ParamWrites:        writes,
@@ -90,7 +89,7 @@ func run(p *analysis.Pass) (*ParamFieldEffects, error) {
 	if len(fact.Functions) > 0 {
 		// Functions were collected by ranging a map. Sorting makes the serialized fact
 		// deterministic and maintains the ordering required by BinarySearchFunc on import.
-		slices.SortFunc(fact.Functions, func(left, right FunctionParamFieldEffects) int {
+		slices.SortFunc(fact.Functions, func(left, right FunctionFieldEffects) int {
 			return cmp.Compare(left.FunctionObjectPath, right.FunctionObjectPath)
 		})
 		pass.ExportPackageFact(fact)
@@ -99,7 +98,7 @@ func run(p *analysis.Pass) (*ParamFieldEffects, error) {
 	return packageSummary, nil
 }
 
-func importUsedParamEffects(pass *analysishelper.EnhancedPass, effects *ParamFieldEffects, callees map[*types.Func]bool) error {
+func importUsedParamEffects(pass *analysishelper.EnhancedPass, effects *BoundaryFieldEffects, callees map[*types.Func]bool) error {
 	calleesByPackage := make(map[*types.Package][]*types.Func)
 	for callee := range callees {
 		if callee.Pkg() != nil && callee.Pkg() != pass.Pkg {
@@ -114,7 +113,7 @@ func importUsedParamEffects(pass *analysishelper.EnhancedPass, effects *ParamFie
 
 	encoder := &objectpath.Encoder{}
 	for _, pkg := range packages {
-		var fact ParamFieldEffectsPackageFact
+		var fact BoundaryFieldEffectsPackageFact
 		if !pass.ImportPackageFact(pkg, &fact) {
 			continue
 		}
@@ -123,7 +122,7 @@ func importUsedParamEffects(pass *analysishelper.EnhancedPass, effects *ParamFie
 			if err != nil {
 				return fmt.Errorf("create object path for imported function %s: %w", callee, err)
 			}
-			index, found := slices.BinarySearchFunc(fact.Functions, path, func(entry FunctionParamFieldEffects, path objectpath.Path) int {
+			index, found := slices.BinarySearchFunc(fact.Functions, path, func(entry FunctionFieldEffects, path objectpath.Path) int {
 				return cmp.Compare(entry.FunctionObjectPath, path)
 			})
 			if found {

--- a/assertion/function/structfieldeffects/effects.go
+++ b/assertion/function/structfieldeffects/effects.go
@@ -27,11 +27,11 @@ import (
 	"golang.org/x/tools/go/types/typeutil"
 )
 
-// ParamFieldEffects is the package-level boundary summary. Every effect set is keyed by
+// BoundaryFieldEffects is the package-level boundary summary. Every effect set is keyed by
 // *types.Func, then by IndexedFieldPath.
 // The read sets bound the field binding at boundaries so it enumerates only the
 // field paths a boundary actually dereferences, never the full type graph.
-type ParamFieldEffects struct {
+type BoundaryFieldEffects struct {
 	// ParamReads records (param idx, field path) pairs a function dereferences of that parameter —
 	// the demand a callee places on its caller's argument. Transitively closed over forwarding edges
 	// (a pure forwarder inherits its forwardees' reads), so a caller binds exactly the field paths
@@ -47,7 +47,7 @@ type ParamFieldEffects struct {
 }
 
 // ParamReadPaths returns the field paths read from funcObj's parameter or receiver at idx.
-func (e *ParamFieldEffects) ParamReadPaths(funcObj *types.Func, idx int) []string {
+func (e *BoundaryFieldEffects) ParamReadPaths(funcObj *types.Func, idx int) []string {
 	if e == nil {
 		return nil
 	}
@@ -55,7 +55,7 @@ func (e *ParamFieldEffects) ParamReadPaths(funcObj *types.Func, idx int) []strin
 }
 
 // ReturnReadPaths returns the field paths read from funcObj's result at idx.
-func (e *ParamFieldEffects) ReturnReadPaths(funcObj *types.Func, idx int) []string {
+func (e *BoundaryFieldEffects) ReturnReadPaths(funcObj *types.Func, idx int) []string {
 	if e == nil {
 		return nil
 	}
@@ -63,7 +63,7 @@ func (e *ParamFieldEffects) ReturnReadPaths(funcObj *types.Func, idx int) []stri
 }
 
 // ParamWritePaths returns the field paths written through funcObj's parameter or receiver at idx.
-func (e *ParamFieldEffects) ParamWritePaths(funcObj *types.Func, idx int) []string {
+func (e *BoundaryFieldEffects) ParamWritePaths(funcObj *types.Func, idx int) []string {
 	if e == nil {
 		return nil
 	}
@@ -84,8 +84,28 @@ func fieldPathsForIndex(effects fieldEffects, funcObj *types.Func, idx int) []st
 	return paths
 }
 
-// computeParamFieldEffects walks every function and method in the package once and records the
-// unclosed boundary summary as ParamFieldEffects, plus forwarding edges for closure.
+// collectedFieldEffects owns the unclosed package summary and the forwarding state needed to close
+// it after imported effects have been seeded.
+type collectedFieldEffects struct {
+	summary              *BoundaryFieldEffects
+	paramForwardingEdges map[*types.Func][]paramFieldForwardEdge
+	callees              map[*types.Func]bool
+}
+
+func newCollectedFieldEffects() *collectedFieldEffects {
+	return &collectedFieldEffects{
+		summary: &BoundaryFieldEffects{
+			ParamReads:  make(fieldEffects),
+			ReturnReads: make(fieldEffects),
+			ParamWrites: make(fieldEffects),
+		},
+		paramForwardingEdges: make(map[*types.Func][]paramFieldForwardEdge),
+		callees:              make(map[*types.Func]bool),
+	}
+}
+
+// computeBoundaryFieldEffects collects the unclosed boundary summary and forwarding state for every
+// function and method in the package.
 //
 // Reads are gathered from selector bases — to evaluate `base.Sel`, base must be non-nil, so the
 // field path of base is a read of whatever boundary value it roots at (a parameter → ParamReads,
@@ -93,58 +113,68 @@ func fieldPathsForIndex(effects fieldEffects, funcObj *types.Func, idx int) []st
 // every prefix of a deep access is recorded. Writes are gathered from assignment LHS field chains
 // rooted at a parameter or receiver. Every static call also records an arg→param forwarding
 // edge (which caller parameter, possibly at a nested field prefix, is passed as which callee
-// parameter). The analyzer later runs closeParamFieldSets over those edges so forwarders inherit
-// their forwardees' param reads and writes. Static callees are returned so the analyzer imports
-// only facts needed by calls in this package.
+// parameter). Static callees are retained so the analyzer imports only facts needed by calls in this
+// package before closing the collection.
 //
 // Unresolvable (interface/func-value) callees are treated as mutating/dereferencing nothing
 // (under-report only).
-func computeParamFieldEffects(pass *analysishelper.EnhancedPass) (*ParamFieldEffects, map[*types.Func][]paramFieldForwardEdge, map[*types.Func]bool) {
-	reads := make(fieldEffects)
-	returnReads := make(fieldEffects)
-	writes := make(fieldEffects)
-	edges := make(map[*types.Func][]paramFieldForwardEdge)
-	callees := make(map[*types.Func]bool)
+func computeBoundaryFieldEffects(pass *analysishelper.EnhancedPass) *collectedFieldEffects {
+	collected := newCollectedFieldEffects()
 	for _, file := range pass.Files {
 		for _, decl := range file.Decls {
 			fd, ok := decl.(*ast.FuncDecl)
 			if !ok || fd.Body == nil {
 				continue
 			}
-			funcObj, ok := pass.TypesInfo.ObjectOf(fd.Name).(*types.Func)
-			if !ok {
-				continue
-			}
-			sig, ok := funcObj.Type().(*types.Signature)
-			if !ok {
-				continue
-			}
-			paramIdx := make(map[*types.Var]int)
-			if recv := sig.Recv(); recv != nil {
-				paramIdx[recv] = annotation.ReceiverParamIndex
-			}
-			for i := range sig.Params().Len() {
-				paramIdx[sig.Params().At(i)] = i
-			}
-			// Locals bound directly to a struct-returning call, so a later dereference of the local's
-			// fields can be attributed to that callee's result (the return-read demand).
-			resultVars := collectStructResultVars(pass, fd.Body)
-			ast.Inspect(fd.Body, func(n ast.Node) bool {
-				switch n := n.(type) {
-				case *ast.AssignStmt:
-					collectParamFieldWrites(pass, n, paramIdx, funcObj, writes)
-				case *ast.CallExpr:
-					if callee := collectParamForwardEdges(pass, n, paramIdx, funcObj, edges); callee != nil {
-						callees[callee] = true
-					}
-				case *ast.SelectorExpr:
-					collectFieldReadDemand(pass, n, paramIdx, resultVars, funcObj, reads, returnReads)
-				}
-				return true
-			})
+			collected.collectFunction(pass, fd)
 		}
 	}
-	return &ParamFieldEffects{ParamReads: reads, ReturnReads: returnReads, ParamWrites: writes}, edges, callees
+	return collected
+}
+
+func (c *collectedFieldEffects) collectFunction(pass *analysishelper.EnhancedPass, fd *ast.FuncDecl) {
+	funcObj, ok := pass.TypesInfo.ObjectOf(fd.Name).(*types.Func)
+	if !ok {
+		return
+	}
+	sig, ok := funcObj.Type().(*types.Signature)
+	if !ok {
+		return
+	}
+
+	paramIdx := make(map[*types.Var]int)
+	if recv := sig.Recv(); recv != nil {
+		paramIdx[recv] = annotation.ReceiverParamIndex
+	}
+	for i := range sig.Params().Len() {
+		paramIdx[sig.Params().At(i)] = i
+	}
+
+	// Locals bound directly to a struct-returning call, so a later dereference of the local's fields
+	// can be attributed to that callee's result (the return-read demand).
+	resultVars := collectStructResultVars(pass, fd.Body)
+	ast.Inspect(fd.Body, func(n ast.Node) bool {
+		switch n := n.(type) {
+		case *ast.AssignStmt:
+			collectParamFieldWrites(pass, n, paramIdx, funcObj, c.summary.ParamWrites)
+		case *ast.CallExpr:
+			if callee := collectParamForwardEdges(pass, n, paramIdx, funcObj, c.paramForwardingEdges); callee != nil {
+				c.callees[callee] = true
+			}
+		case *ast.SelectorExpr:
+			collectFieldReadDemand(
+				pass, n, paramIdx, resultVars, funcObj,
+				c.summary.ParamReads, c.summary.ReturnReads,
+			)
+		}
+		return true
+	})
+}
+
+func (c *collectedFieldEffects) close() *BoundaryFieldEffects {
+	closeParamFieldSets(c.summary.ParamWrites, c.paramForwardingEdges)
+	closeParamFieldSets(c.summary.ParamReads, c.paramForwardingEdges)
+	return c.summary
 }
 
 // seedImportedParamEffects merges an imported callee's parameter effects before closure runs.
@@ -318,7 +348,7 @@ func collectParamFieldWrites(pass *analysishelper.EnhancedPass, assign *ast.Assi
 		if _, ok := param.Type().Underlying().(*types.Pointer); !ok {
 			continue
 		}
-		if !fieldPathIsAcyclic(funcObj, idx, path) {
+		if !paramFieldPathIsAcyclic(funcObj, idx, path) {
 			continue
 		}
 		writes.add(funcObj, IndexedFieldPath{Idx: idx, Path: path})
@@ -417,7 +447,7 @@ func closeParamFieldSets(fields fieldEffects, edges map[*types.Func][]paramField
 				path := joinFieldPath(e.callerPrefix, ck.Path)
 				// Skip recursive field paths; otherwise forwarding can keep growing paths like
 				// inner.f, inner.inner.f, ...
-				if !fieldPathIsAcyclic(f, e.callerParamIdx, path) {
+				if !paramFieldPathIsAcyclic(f, e.callerParamIdx, path) {
 					continue
 				}
 				if fields.add(f, IndexedFieldPath{Idx: e.callerParamIdx, Path: path}) {
@@ -445,32 +475,33 @@ func joinFieldPath(prefix, sub string) string {
 	return prefix + "." + sub
 }
 
-// fieldPathIsAcyclic reports whether path can be followed without re-entering a struct type already
-// seen on the chain. Recursive paths are skipped so the forwarding fixpoint stays finite.
-func fieldPathIsAcyclic(fn *types.Func, paramIdx int, path string) bool {
+func paramFieldPathIsAcyclic(fn *types.Func, paramIdx int, path string) bool {
 	sig := fn.Signature()
-	var paramType types.Type
 	if paramIdx == annotation.ReceiverParamIndex {
 		if sig.Recv() == nil {
 			return false
 		}
-		paramType = sig.Recv().Type()
-	} else {
-		if paramIdx < 0 || paramIdx >= sig.Params().Len() {
-			return false
-		}
-		paramType = sig.Params().At(paramIdx).Type()
+		return fieldPathIsAcyclic(sig.Recv().Type(), path)
 	}
+	if paramIdx < 0 || paramIdx >= sig.Params().Len() {
+		return false
+	}
+	return fieldPathIsAcyclic(sig.Params().At(paramIdx).Type(), path)
+}
+
+// fieldPathIsAcyclic reports whether path can be followed without re-entering a struct type already
+// seen on the chain. Recursive paths are skipped so forwarding fixpoints remain finite.
+func fieldPathIsAcyclic(boundaryType types.Type, path string) bool {
 	// AsDeeplyStruct unwraps at most one pointer, but forwarded field paths can be rooted at
-	// parameters with multiple pointer layers.
+	// boundary values with multiple pointer layers.
 	for {
-		ptr, ok := paramType.Underlying().(*types.Pointer)
+		ptr, ok := boundaryType.Underlying().(*types.Pointer)
 		if !ok {
 			break
 		}
-		paramType = ptr.Elem()
+		boundaryType = ptr.Elem()
 	}
-	st := typeshelper.AsDeeplyStruct(paramType)
+	st := typeshelper.AsDeeplyStruct(boundaryType)
 	if st == nil {
 		return false
 	}

--- a/assertion/function/structfieldeffects/effects_test.go
+++ b/assertion/function/structfieldeffects/effects_test.go
@@ -33,7 +33,7 @@ import (
 // with no effects carries an empty comment.
 const _expectEffectsPrefix = "expect_effects:"
 
-func TestComputeParamFieldEffects(t *testing.T) {
+func TestComputeBoundaryFieldEffects(t *testing.T) {
 	t.Parallel()
 	err := config.Analyzer.Flags.Set(config.ExperimentalStructInitV2EnableFlag, "true")
 	require.NoError(t, err)
@@ -46,7 +46,7 @@ func TestComputeParamFieldEffects(t *testing.T) {
 	r := analysistest.Run(t, testdata, Analyzer, "go.uber.org/paramfieldeffects")
 	require.Len(t, r, 1)
 	pass := r[0].Pass
-	result := r[0].Result.(*analysishelper.Result[*ParamFieldEffects])
+	result := r[0].Result.(*analysishelper.Result[*BoundaryFieldEffects])
 	require.NoError(t, result.Err)
 	effects := result.Res
 

--- a/assertion/function/structfieldeffects/fact.go
+++ b/assertion/function/structfieldeffects/fact.go
@@ -16,16 +16,16 @@ package structfieldeffects
 
 import "golang.org/x/tools/go/types/objectpath"
 
-// ParamFieldEffectsPackageFact is the exported parameter field-effect summary for one package.
-type ParamFieldEffectsPackageFact struct {
-	Functions []FunctionParamFieldEffects
+// BoundaryFieldEffectsPackageFact is the exported boundary field-effect summary for one package.
+type BoundaryFieldEffectsPackageFact struct {
+	Functions []FunctionFieldEffects
 }
 
 // AFact enables use of the facts passing mechanism in Go's analysis framework.
-func (*ParamFieldEffectsPackageFact) AFact() {}
+func (*BoundaryFieldEffectsPackageFact) AFact() {}
 
-// FunctionParamFieldEffects is a function's parameter field-effect summary within a package fact.
-type FunctionParamFieldEffects struct {
+// FunctionFieldEffects is a function's field-effect summary within a package fact.
+type FunctionFieldEffects struct {
 	FunctionObjectPath objectpath.Path
 	ParamReads         []IndexedFieldPath
 	ParamWrites        []IndexedFieldPath

--- a/assertion/function/structfieldeffects/fact_test.go
+++ b/assertion/function/structfieldeffects/fact_test.go
@@ -41,7 +41,7 @@ func TestFact(t *testing.T) { //nolint:paralleltest
 	require.Len(t, results, 2)
 	for _, result := range results {
 		pass := result.Pass
-		effects := result.Result.(*analysishelper.Result[*ParamFieldEffects])
+		effects := result.Result.(*analysishelper.Result[*BoundaryFieldEffects])
 		require.NoError(t, effects.Err)
 
 		localReads := make(fieldEffects)
@@ -61,7 +61,7 @@ func TestFact(t *testing.T) { //nolint:paralleltest
 	}
 }
 
-func TestParamFieldEffectsPackageFactCodec(t *testing.T) {
+func TestBoundaryFieldEffectsPackageFactCodec(t *testing.T) {
 	t.Parallel()
 
 	fact := newFact(100)
@@ -74,7 +74,7 @@ func TestParamFieldEffectsPackageFactCodec(t *testing.T) {
 		require.Less(t, len(encoded), 15_000,
 			"encoded facts contribute to artifact size; increase this cap only with justification")
 
-		var decoded ParamFieldEffectsPackageFact
+		var decoded BoundaryFieldEffectsPackageFact
 		require.NoError(t, gob.NewDecoder(bytes.NewReader(encoded)).Decode(&decoded))
 		require.Equal(t, fact, &decoded)
 
@@ -85,8 +85,8 @@ func TestParamFieldEffectsPackageFactCodec(t *testing.T) {
 	}
 }
 
-// BenchmarkParamFieldEffectsPackageFactCodec measures one complete fact in a fresh gob stream.
-func BenchmarkParamFieldEffectsPackageFactCodec(b *testing.B) {
+// BenchmarkBoundaryFieldEffectsPackageFactCodec measures one complete fact in a fresh gob stream.
+func BenchmarkBoundaryFieldEffectsPackageFactCodec(b *testing.B) {
 	for _, functionCount := range []int{1, 10, 100} {
 		fact := newFact(functionCount)
 		b.Run(fmt.Sprintf("encode/%d-functions", functionCount), func(b *testing.B) {
@@ -115,7 +115,7 @@ func BenchmarkParamFieldEffectsPackageFactCodec(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
 			for b.Loop() {
-				var decoded ParamFieldEffectsPackageFact
+				var decoded BoundaryFieldEffectsPackageFact
 				if err := gob.NewDecoder(bytes.NewReader(encoded.Bytes())).Decode(&decoded); err != nil {
 					b.Fatal(err)
 				}
@@ -159,10 +159,10 @@ func expectedParamEffects(t *testing.T, pass *analysis.Pass, wantKind string) ma
 	return want
 }
 
-func newFact(functionCount int) *ParamFieldEffectsPackageFact {
-	functions := make([]FunctionParamFieldEffects, functionCount)
+func newFact(functionCount int) *BoundaryFieldEffectsPackageFact {
+	functions := make([]FunctionFieldEffects, functionCount)
 	for i := range functions {
-		functions[i] = FunctionParamFieldEffects{
+		functions[i] = FunctionFieldEffects{
 			FunctionObjectPath: objectpath.Path(fmt.Sprintf("Function%03d", i)),
 			ParamReads: []IndexedFieldPath{
 				{Idx: -1, Path: "Receiver"},
@@ -178,5 +178,5 @@ func newFact(functionCount int) *ParamFieldEffectsPackageFact {
 			},
 		}
 	}
-	return &ParamFieldEffectsPackageFact{Functions: functions}
+	return &BoundaryFieldEffectsPackageFact{Functions: functions}
 }

--- a/assertion/function/structfieldeffects/testdata/src/go.uber.org/paramfieldeffects/main.go
+++ b/assertion/function/structfieldeffects/testdata/src/go.uber.org/paramfieldeffects/main.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package paramfieldeffects is the fixture for the ComputeParamFieldEffects boundary-summary test.
+// Package paramfieldeffects is the fixture for the boundary field-effects test.
 package paramfieldeffects
 
 type Leaf struct {


### PR DESCRIPTION
Refactor struct-field effect collection for struct-init v2.

- Rename `ParamFieldEffects` to `BoundaryFieldEffects`, since the summary covers both parameter and return boundary field paths.
- Group the unclosed summary, forwarding edges, and callees in `collectedFieldEffects`.
- Move forwarding closure into the collection result after imported effects are seeded.
- Generalize recursive-path validation from parameter types to boundary types.
- Rename package facts and test/benchmark coverage to match the boundary terminology.