### PR TITLE
feat(struct-init-v2): support generic static call field effects

### DIFF
--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -759,20 +759,19 @@ func (r *RootAssertionNode) AddComputation(expr ast.Expr) {
 				r.addConsumptionsForArgAndReceiverFields(expr, fun)
 			}
 
-			if r.functionContext.functionConfig.EnableStructInitV2 {
-				funcObj := r.ObjectOf(fun).(*types.Func)
-				// First, let post-call field reads use the callee's param-out summary.
-				r.addCallParamOutFieldProducers(expr, funcObj)
-				// Then, if this function forwards its own parameter, make that summary its own output.
-				r.bindForwardedParamOut(expr, funcObj)
-				// Finally, bind the arguments' incoming fields to the callee's param-in summary.
-				r.bindArgAndReceiverFieldsToContext(expr, funcObj)
-			}
 		} else {
 			// here we have found either a builtin function like make or new,
 			// or a typecast like int(x) - in either case (at least for now), do nothing to try
 			// to consume the arguments
 			consumeArg = consumeArgNoop
+		}
+
+		if r.functionContext.functionConfig.EnableStructInitV2 {
+			if target, ok := typeshelper.ResolveStaticCallTarget(r.Pass().TypesInfo, expr); ok {
+				r.addCallParamOutFieldProducers(expr, target)
+				r.bindForwardedParamOut(expr, target)
+				r.bindArgAndReceiverFieldsToContext(expr, target)
+			}
 		}
 
 		// when we reach this point, consumeArg will be set to a no-op exactly if we don't know

--- a/assertion/function/assertiontree/structinitv2.go
+++ b/assertion/function/assertiontree/structinitv2.go
@@ -25,7 +25,6 @@ import (
 	"go.uber.org/nilaway/guard"
 	"go.uber.org/nilaway/util/asthelper"
 	"go.uber.org/nilaway/util/typeshelper"
-	"golang.org/x/tools/go/types/typeutil"
 )
 
 // asStructAllocation inspects expr and, if it allocates a struct value, returns the (deeply
@@ -79,12 +78,9 @@ func (r *RootAssertionNode) addAllocationFieldProducers(lhsVal, rhsVal ast.Expr)
 	// `lhs := f()` where f returns a single struct value: bind lhs's fields to f's return
 	// context sites. (Multi-return calls are handled by the many-to-one assignment path.)
 	if call, ok := ast.Unparen(rhsVal).(*ast.CallExpr); ok {
-		if funcObj := typeutil.StaticCallee(r.Pass().TypesInfo, call); funcObj != nil {
-			sig := funcObj.Type().(*types.Signature)
-			if sig.Results().Len() == 1 {
-				if structType := typeshelper.AsDeeplyStruct(sig.Results().At(0).Type()); structType != nil {
-					r.addContextFieldProducers(structType, lhsVal, funcObj, annotation.StructFieldReturnContext, 0)
-				}
+		if target, ok := typeshelper.ResolveStaticCallTarget(r.Pass().TypesInfo, call); ok && target.Signature.Results().Len() == 1 {
+			if structType := typeshelper.AsDeeplyStruct(target.Signature.Results().At(0).Type()); structType != nil {
+				r.addContextFieldProducers(structType, lhsVal, target.Origin, annotation.StructFieldReturnContext, 0)
 			}
 		}
 	}
@@ -413,26 +409,24 @@ func (r *RootAssertionNode) buildFieldPathSelector(base ast.Expr, structType *ty
 
 // bindArgAndReceiverFieldsToContext binds, at a function or method call, the fields of each struct-typed
 // argument to the callee's corresponding parameter context site.
-func (r *RootAssertionNode) bindArgAndReceiverFieldsToContext(call *ast.CallExpr, funcObj *types.Func) {
-	sig := funcObj.Signature()
-
-	if recv := sig.Recv(); recv != nil {
+func (r *RootAssertionNode) bindArgAndReceiverFieldsToContext(call *ast.CallExpr, target typeshelper.StaticCallTarget) {
+	if recv := target.Signature.Recv(); recv != nil {
 		if sel, ok := ast.Unparen(call.Fun).(*ast.SelectorExpr); ok {
 			if structType := typeshelper.AsDeeplyStruct(recv.Type()); structType != nil {
-				r.bindValueFieldsToContext(funcObj, sel.X, structType, annotation.StructFieldParamContext, annotation.ReceiverParamIndex)
+				r.bindValueFieldsToContext(target.Origin, sel.X, structType, annotation.StructFieldParamContext, annotation.ReceiverParamIndex)
 			}
 		}
 	}
 
 	for argIdx, arg := range call.Args {
-		if argIdx >= sig.Params().Len() {
+		if argIdx >= target.Signature.Params().Len() {
 			break
 		}
-		structType := typeshelper.AsDeeplyStruct(sig.Params().At(argIdx).Type())
+		structType := typeshelper.AsDeeplyStruct(target.Signature.Params().At(argIdx).Type())
 		if structType == nil {
 			continue
 		}
-		r.bindValueFieldsToContext(funcObj, arg, structType, annotation.StructFieldParamContext, argIdx)
+		r.bindValueFieldsToContext(target.Origin, arg, structType, annotation.StructFieldParamContext, argIdx)
 	}
 }
 
@@ -440,10 +434,9 @@ func (r *RootAssertionNode) bindArgAndReceiverFieldsToContext(call *ast.CallExpr
 // and receiver. For `f(x)`, if f's parameter 0 may write `b.c`, it produces
 // `x.b.c <- PARAM_OUT(f, 0, "b.c")`. A post-call dereference of x.b.c then consumes f's output
 // summary, while fields absent from the write set retain their pre-call producers.
-func (r *RootAssertionNode) addCallParamOutFieldProducers(call *ast.CallExpr, funcObj *types.Func) {
-	sig := funcObj.Signature()
+func (r *RootAssertionNode) addCallParamOutFieldProducers(call *ast.CallExpr, target typeshelper.StaticCallTarget) {
 	produce := func(arg ast.Expr, structType *types.Struct, index int) {
-		paths := r.functionContext.boundaryFieldEffects.ParamWritePaths(funcObj, index)
+		paths := r.functionContext.boundaryFieldEffects.ParamWritePaths(target.Origin, index)
 		// AddProduction detaches a matched subtree, so nested paths must be produced first.
 		sort.SliceStable(paths, func(i, j int) bool {
 			return strings.Count(paths[i], ".") > strings.Count(paths[j], ".")
@@ -454,7 +447,7 @@ func (r *RootAssertionNode) addCallParamOutFieldProducers(call *ast.CallExpr, fu
 				continue
 			}
 			site := &annotation.StructFieldContextSite{
-				FuncObj: funcObj,
+				FuncObj: target.Origin,
 				Kind:    annotation.StructFieldParamOutContext,
 				Index:   index,
 				Path:    fieldPath,
@@ -468,7 +461,7 @@ func (r *RootAssertionNode) addCallParamOutFieldProducers(call *ast.CallExpr, fu
 		}
 	}
 
-	if recv := sig.Recv(); recv != nil {
+	if recv := target.Signature.Recv(); recv != nil {
 		if sel, ok := ast.Unparen(call.Fun).(*ast.SelectorExpr); ok {
 			if structType := typeshelper.AsDeeplyStruct(recv.Type()); structType != nil {
 				produce(sel.X, structType, annotation.ReceiverParamIndex)
@@ -476,10 +469,10 @@ func (r *RootAssertionNode) addCallParamOutFieldProducers(call *ast.CallExpr, fu
 		}
 	}
 	for index, arg := range call.Args {
-		if index >= sig.Params().Len() {
+		if index >= target.Signature.Params().Len() {
 			break
 		}
-		if structType := typeshelper.AsDeeplyStruct(sig.Params().At(index).Type()); structType != nil {
+		if structType := typeshelper.AsDeeplyStruct(target.Signature.Params().At(index).Type()); structType != nil {
 			produce(arg, structType, index)
 		}
 	}
@@ -490,8 +483,7 @@ func (r *RootAssertionNode) addCallParamOutFieldProducers(call *ast.CallExpr, fu
 // `PARAM_OUT(f, 0, "b.c") -> PARAM_OUT(g, 0, "b.c")`. A field prefix is retained, so passing
 // p.inner to f instead targets `PARAM_OUT(g, 0, "inner.b.c")`. The write summary is already closed
 // over these edges; this supplies each inherited path's context value.
-func (r *RootAssertionNode) bindForwardedParamOut(call *ast.CallExpr, callee *types.Func) {
-	sig := callee.Signature()
+func (r *RootAssertionNode) bindForwardedParamOut(call *ast.CallExpr, target typeshelper.StaticCallTarget) {
 	link := func(calleeIndex int, arg ast.Expr) {
 		base, prefix := asthelper.SplitFieldChain(arg)
 		if base == nil {
@@ -505,13 +497,13 @@ func (r *RootAssertionNode) bindForwardedParamOut(call *ast.CallExpr, callee *ty
 		if !ok {
 			return
 		}
-		for _, calleePath := range r.functionContext.boundaryFieldEffects.ParamWritePaths(callee, calleeIndex) {
+		for _, calleePath := range r.functionContext.boundaryFieldEffects.ParamWritePaths(target.Origin, calleeIndex) {
 			fieldPath := calleePath
 			if prefix != "" {
 				fieldPath = prefix + "." + fieldPath
 			}
 			source := &annotation.StructFieldContextSite{
-				FuncObj: callee, Kind: annotation.StructFieldParamOutContext, Index: calleeIndex, Path: calleePath,
+				FuncObj: target.Origin, Kind: annotation.StructFieldParamOutContext, Index: calleeIndex, Path: calleePath,
 			}
 			destination := &annotation.StructFieldContextSite{
 				FuncObj: r.FuncObj(), Kind: annotation.StructFieldParamOutContext, Index: callerIndex, Path: fieldPath,
@@ -530,13 +522,13 @@ func (r *RootAssertionNode) bindForwardedParamOut(call *ast.CallExpr, callee *ty
 		}
 	}
 
-	if recv := sig.Recv(); recv != nil {
+	if recv := target.Signature.Recv(); recv != nil {
 		if sel, ok := ast.Unparen(call.Fun).(*ast.SelectorExpr); ok {
 			link(annotation.ReceiverParamIndex, sel.X)
 		}
 	}
 	for index, arg := range call.Args {
-		if index >= sig.Params().Len() {
+		if index >= target.Signature.Params().Len() {
 			break
 		}
 		link(index, arg)

--- a/assertion/function/structfieldeffects/effects.go
+++ b/assertion/function/structfieldeffects/effects.go
@@ -25,11 +25,11 @@ import (
 	"go.uber.org/nilaway/util/analysishelper"
 	"go.uber.org/nilaway/util/asthelper"
 	"go.uber.org/nilaway/util/typeshelper"
-	"golang.org/x/tools/go/types/typeutil"
 )
 
-// BoundaryFieldEffects is the package-level boundary summary. Every effect set is keyed by
-// *types.Func, then by IndexedFieldPath.
+// BoundaryFieldEffects is the package-level boundary summary. Every effect set is keyed by a
+// function origin, then by IndexedFieldPath. Function declarations and StaticCallTarget both
+// provide that identity, including for instantiated generic calls.
 // The read sets bound the field binding at boundaries so it enumerates only the
 // field paths a boundary actually dereferences, never the full type graph.
 type BoundaryFieldEffects struct {
@@ -288,12 +288,11 @@ func collectStructResultVars(pass *analysishelper.EnhancedPass, body *ast.BlockS
 		if !ok {
 			return
 		}
-		callee := typeutil.StaticCallee(pass.TypesInfo, call)
-		if callee == nil {
+		target, ok := typeshelper.ResolveStaticCallTarget(pass.TypesInfo, call)
+		if !ok {
 			return
 		}
-		sig, ok := callee.Type().(*types.Signature)
-		if !ok || sig.Results().Len() != len(lhs) {
+		if target.Signature.Results().Len() != len(lhs) {
 			return
 		}
 		for i, l := range lhs {
@@ -305,11 +304,11 @@ func collectStructResultVars(pass *analysishelper.EnhancedPass, body *ast.BlockS
 			if !ok {
 				continue
 			}
-			if typeshelper.AsDeeplyStruct(sig.Results().At(i).Type()) == nil {
+			if typeshelper.AsDeeplyStruct(target.Signature.Results().At(i).Type()) == nil {
 				continue
 			}
 			if _, seen := out[v]; !seen {
-				out[v] = structResultSource{callee: callee, idx: i}
+				out[v] = structResultSource{callee: target.Origin, idx: i}
 			}
 		}
 	}
@@ -366,18 +365,17 @@ func collectConcreteReturnEffects(
 	edges map[*types.Func][]returnForwardEdge,
 ) {
 	sig := funcObj.Signature()
-	addEdge := func(callerResultIdx int, callee *types.Func, calleeResultIdx int) {
-		if callee == nil || callee.Pkg() != pass.Pkg {
+	addEdge := func(callerResultIdx int, target typeshelper.StaticCallTarget, calleeResultIdx int) {
+		if target.Origin == nil || target.Origin.Pkg() != pass.Pkg {
 			return
 		}
-		calleeSig, ok := callee.Type().(*types.Signature)
-		if !ok || calleeResultIdx < 0 || calleeResultIdx >= calleeSig.Results().Len() ||
-			typeshelper.AsDeeplyStruct(calleeSig.Results().At(calleeResultIdx).Type()) == nil {
+		if calleeResultIdx < 0 || calleeResultIdx >= target.Signature.Results().Len() ||
+			typeshelper.AsDeeplyStruct(target.Signature.Results().At(calleeResultIdx).Type()) == nil {
 			return
 		}
 		edges[funcObj] = append(edges[funcObj], returnForwardEdge{
 			callerResultIdx: callerResultIdx,
-			callee:          callee,
+			callee:          target.Origin,
 			calleeResultIdx: calleeResultIdx,
 		})
 	}
@@ -402,12 +400,9 @@ func collectConcreteReturnEffects(
 					continue
 				}
 				if call, ok := ast.Unparen(resultExpr).(*ast.CallExpr); ok {
-					callee := typeutil.StaticCallee(pass.TypesInfo, call)
-					if callee != nil {
-						calleeSig, _ := callee.Type().(*types.Signature)
-						if calleeSig != nil && calleeSig.Results().Len() == 1 {
-							addEdge(resultIdx, callee, 0)
-						}
+					target, ok := typeshelper.ResolveStaticCallTarget(pass.TypesInfo, call)
+					if ok && target.Signature.Results().Len() == 1 {
+						addEdge(resultIdx, target, 0)
 					}
 					continue
 				}
@@ -507,11 +502,7 @@ func collectParamFieldWrites(pass *analysishelper.EnhancedPass, assign *ast.Assi
 // parameter/receiver of funcObj (the function containing the call). Unresolvable (interface/func-value)
 // callees contribute no edge or callee.
 func collectParamForwardEdges(pass *analysishelper.EnhancedPass, call *ast.CallExpr, paramIdx map[*types.Var]int, funcObj *types.Func, edges map[*types.Func][]paramFieldForwardEdge) *types.Func {
-	callee := typeutil.StaticCallee(pass.TypesInfo, call)
-	if callee == nil {
-		return nil
-	}
-	sig, ok := callee.Type().(*types.Signature)
+	target, ok := typeshelper.ResolveStaticCallTarget(pass.TypesInfo, call)
 	if !ok {
 		return nil
 	}
@@ -531,22 +522,22 @@ func collectParamForwardEdges(pass *analysishelper.EnhancedPass, call *ast.CallE
 		edges[funcObj] = append(edges[funcObj], paramFieldForwardEdge{
 			callerParamIdx: callerIdx,
 			callerPrefix:   prefix,
-			callee:         callee,
+			callee:         target.Origin,
 			calleeParamIdx: calleeIdx,
 		})
 	}
-	if recv := sig.Recv(); recv != nil {
+	if recv := target.Signature.Recv(); recv != nil {
 		if sel, ok := ast.Unparen(call.Fun).(*ast.SelectorExpr); ok {
 			record(annotation.ReceiverParamIndex, sel.X)
 		}
 	}
 	for argIdx, arg := range call.Args {
-		if argIdx >= sig.Params().Len() {
+		if argIdx >= target.Signature.Params().Len() {
 			break
 		}
 		record(argIdx, arg)
 	}
-	return callee
+	return target.Origin
 }
 
 // paramFieldForwardEdge records that the caller passes its own parameter/receiver (callerParamIdx) — possibly

--- a/assertion/function/structfieldeffects/testdata/src/go.uber.org/paramfieldeffects/factexport/downstream/downstream.go
+++ b/assertion/function/structfieldeffects/testdata/src/go.uber.org/paramfieldeffects/factexport/downstream/downstream.go
@@ -29,3 +29,7 @@ func ForwardExportedForwardWrite(o *upstream.Outer) { // expect_effects: param_r
 func ForwardWriteTwice(o *upstream.Outer) { // expect_effects: param_reads:0:Mid param_writes:0:Mid.Child
 	ForwardDeepWrite(o)
 }
+
+func ForwardGenericWrite(o *upstream.Outer) { // expect_effects: param_writes:0:Mid
+	upstream.GenericExportedWrite[int](o)
+}

--- a/assertion/function/structfieldeffects/testdata/src/go.uber.org/paramfieldeffects/factexport/upstream/upstream.go
+++ b/assertion/function/structfieldeffects/testdata/src/go.uber.org/paramfieldeffects/factexport/upstream/upstream.go
@@ -43,3 +43,7 @@ func ExportedDeepWrite(o *Outer) { // expect_effects: param_reads:0:Mid param_wr
 func ExportedForwardWrite(o *Outer) { // expect_effects: param_reads:0:Mid param_writes:0:Mid.Child
 	ExportedDeepWrite(o)
 }
+
+func GenericExportedWrite[T any](o *Outer) { // expect_effects: param_writes:0:Mid
+	o.Mid = nil
+}

--- a/assertion/function/structfieldeffects/testdata/src/go.uber.org/returneffects/main.go
+++ b/assertion/function/structfieldeffects/testdata/src/go.uber.org/returneffects/main.go
@@ -75,6 +75,14 @@ func directForward() *Outer { // expect_effects: return_effects:0:Mid return_eff
 	return inlinePointer()
 }
 
+func genericConcrete[T any]() *Outer { // expect_effects: return_effects:0:Mid return_effects:0:Value.Child
+	return &Outer{}
+}
+
+func genericForward() *Outer { // expect_effects: return_effects:0:Mid return_effects:0:Value.Child
+	return genericConcrete[int]()
+}
+
 func pair() (*Outer, *Node) { // expect_effects: return_effects:1:Child
 	return safeOuter(), &Node{}
 }

--- a/testdata/src/go.uber.org/structinitv2/local/local.go
+++ b/testdata/src/go.uber.org/structinitv2/local/local.go
@@ -181,3 +181,40 @@ func m25(l *leaf) {
 	b := &A{aptr: l}
 	print(b.aptr.ptr)
 }
+
+func genericNewA[T any]() *A { return &A{} }
+
+func m26() {
+	b := genericNewA[int]()
+	print(b.aptr.ptr) //want "uninitialized field `aptr`"
+}
+
+type genericFactory[T any] struct{}
+
+func (genericFactory[T]) newA() *A { return &A{} }
+
+func m27() {
+	b := genericFactory[int]{}.newA()
+	print(b.aptr.ptr) //want "uninitialized field `aptr`"
+}
+
+// False negative: the call site knows genericIdentity returns *A, but the generic declaration
+// returns T. A per-field return summary cannot be formed from an unconstrained type parameter.
+func genericIdentity[T any](value T) T { return value }
+
+func m28() {
+	b := genericIdentity(&A{})
+	print(b.aptr.ptr)
+}
+
+// The same false negative applies to a generic method whose result is its receiver's type parameter.
+type genericBox[T any] struct {
+	value T
+}
+
+func (b genericBox[T]) valueOf() T { return b.value }
+
+func m29() {
+	b := genericBox[*A]{value: &A{}}.valueOf()
+	print(b.aptr.ptr)
+}

--- a/util/typeshelper/typeshelper.go
+++ b/util/typeshelper/typeshelper.go
@@ -17,10 +17,12 @@ package typeshelper
 
 import (
 	"fmt"
+	"go/ast"
 	"go/types"
 
 	"go.uber.org/nilaway/util/tokenhelper"
 	"golang.org/x/exp/typeparams"
+	"golang.org/x/tools/go/types/typeutil"
 )
 
 // ErrorType is the type of the builtin "error" interface.
@@ -46,6 +48,36 @@ var BuiltinAppend = types.Universe.Lookup("append")
 
 // BuiltinNew is the builtin "new" function object.
 var BuiltinNew = types.Universe.Lookup("new")
+
+// StaticCallTarget describes a statically resolved call. Origin identifies the declared function;
+// for a generic instantiation, it is the generic declaration. Signature describes this call's
+// parameter and result types after type arguments and method selection have been applied.
+type StaticCallTarget struct {
+	Origin    *types.Func
+	Signature *types.Signature
+}
+
+// ResolveStaticCallTarget returns the target of call when it has a statically resolved callee. For a
+// non-generic call, Origin identifies the declaration and Signature is its call signature. For a
+// generic instantiation, Origin still identifies the generic declaration while Signature includes
+// the type-argument substitutions.
+func ResolveStaticCallTarget(info *types.Info, call *ast.CallExpr) (StaticCallTarget, bool) {
+	callee := typeutil.StaticCallee(info, call)
+	if callee == nil {
+		return StaticCallTarget{}, false
+	}
+	target := StaticCallTarget{Origin: callee.Origin()}
+	target.Signature, _ = info.TypeOf(call.Fun).(*types.Signature)
+	if selector, isSelector := ast.Unparen(call.Fun).(*ast.SelectorExpr); isSelector {
+		if selection := info.Selections[selector]; selection != nil {
+			target.Signature, _ = selection.Type().(*types.Signature)
+		}
+	}
+	if target.Origin == nil || target.Signature == nil {
+		return StaticCallTarget{}, false
+	}
+	return target, true
+}
 
 // IsDeep checks if a type is an expression that admits deep nilability, such as maps, slices, arrays, etc.
 // Only consider pointers to deep types (e.g., `var x *[]int`) as deep type,

--- a/util/typeshelper/typeshelper_test.go
+++ b/util/typeshelper/typeshelper_test.go
@@ -111,6 +111,58 @@ func Generic[A ~[8]int, E ArrayConstraint, U ~[8]int | ~[16]int, X ~[8]int | ~[]
 	}
 }
 
+func TestResolveStaticCallTarget(t *testing.T) {
+	t.Parallel()
+
+	const src = `package testpkg
+
+type Result struct{}
+
+func Generic[T any](value T) T { return value }
+
+type Factory[T any] struct{}
+
+func (Factory[T]) New() *Result { return &Result{} }
+
+func use() {
+	Generic[Result](Result{})
+	Factory[int]{}.New()
+}
+`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "test.go", src, 0)
+	require.NoError(t, err)
+	info := &types.Info{
+		Types:      make(map[ast.Expr]types.TypeAndValue),
+		Uses:       make(map[*ast.Ident]types.Object),
+		Selections: make(map[*ast.SelectorExpr]*types.Selection),
+	}
+	pkg, err := (&types.Config{}).Check("testpkg", fset, []*ast.File{file}, info)
+	require.NoError(t, err)
+
+	var calls []*ast.CallExpr
+	ast.Inspect(file, func(node ast.Node) bool {
+		if call, ok := node.(*ast.CallExpr); ok {
+			calls = append(calls, call)
+		}
+		return true
+	})
+	require.Len(t, calls, 2)
+
+	generic, ok := ResolveStaticCallTarget(info, calls[0])
+	require.True(t, ok)
+	require.Equal(t, pkg.Scope().Lookup("Generic").(*types.Func), generic.Origin)
+	require.Equal(t, "testpkg.Result", generic.Signature.Params().At(0).Type().String())
+	require.Equal(t, "testpkg.Result", generic.Signature.Results().At(0).Type().String())
+
+	method, ok := ResolveStaticCallTarget(info, calls[1])
+	require.True(t, ok)
+	factory := pkg.Scope().Lookup("Factory").Type().(*types.Named)
+	newMethod, _, _ := types.LookupFieldOrMethod(factory, true, pkg, "New")
+	require.Equal(t, newMethod.(*types.Func), method.Origin)
+	require.Equal(t, "*testpkg.Result", method.Signature.Results().At(0).Type().String())
+}
+
 func TestIsIterType(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Enable field-effect bindings for statically resolved generic function and method calls.

- Add `typeshelper.StaticCallTarget`, separating a call's declared function origin from its instantiated call signature.
- Use the origin for field-effect/context-summary lookup and the instantiated signature for concrete argument, receiver, and result struct shapes.
- Handle direct generic calls such as `f[int]()` and instantiated generic methods.
- Add coverage for supported generic function and method returns.
- Document false-negative cases where a return shape depends on an unconstrained type parameter.
