### PR TITLE
feat(struct-init-v2): Support local variable return effects

### DIFF
--- a/assertion/function/structfieldeffects/effects.go
+++ b/assertion/function/structfieldeffects/effects.go
@@ -161,7 +161,7 @@ func (c *collectedFieldEffects) collectFunction(pass *analysishelper.EnhancedPas
 	// Locals bound directly to a struct-returning call, so a later dereference of the local's fields
 	// can be attributed to that callee's result (the return-read demand).
 	resultVars := collectStructResultVars(pass, fd.Body)
-	c.collectReturnEffects(pass, fd, funcObj)
+	c.collectReturnEffects(pass, fd, funcObj, resultVars)
 
 	ast.Inspect(fd.Body, func(n ast.Node) bool {
 		switch n := n.(type) {
@@ -182,9 +182,9 @@ func (c *collectedFieldEffects) collectFunction(pass *analysishelper.EnhancedPas
 }
 
 // collectReturnEffects records this function's concrete nil result fields and same-package return
-// forwarding edges. Only direct construction sites and direct same-package call returns are
-// recognized; returned locals are handled by a later revision.
-func (c *collectedFieldEffects) collectReturnEffects(pass *analysishelper.EnhancedPass, fd *ast.FuncDecl, funcObj *types.Func) {
+// forwarding edges. resultVars maps locals bound directly to struct-returning calls and is shared
+// with the later read-demand pass.
+func (c *collectedFieldEffects) collectReturnEffects(pass *analysishelper.EnhancedPass, fd *ast.FuncDecl, funcObj *types.Func, resultVars map[*types.Var]structResultSource) {
 	sig := funcObj.Signature()
 	// Fast path: no struct-shaped result can ever produce a concrete return effect or forwarding
 	// edge, so the body walk below would do nothing. Use the same predicate as
@@ -199,8 +199,10 @@ func (c *collectedFieldEffects) collectReturnEffects(pass *analysishelper.Enhanc
 	if !hasStructResult {
 		return
 	}
+	allocationVars := collectStructAllocationVars(pass, fd.Body)
+	stableVars := collectStableStructVars(pass, fd.Body, allocationVars, resultVars)
 	collectConcreteReturnEffects(
-		pass, fd.Body, funcObj,
+		pass, fd.Body, funcObj, allocationVars, resultVars, stableVars,
 		c.summary.ReturnEffects, c.returnForwardingEdges,
 	)
 }
@@ -269,7 +271,7 @@ func (e fieldEffects) add(funcObj *types.Func, key IndexedFieldPath) bool {
 // structResultSource identifies the struct-returning callee and result index a local variable was
 // assigned from, so dereferences of that local's fields can be attributed to the callee's return.
 type structResultSource struct {
-	callee *types.Func
+	callee typeshelper.StaticCallTarget
 	idx    int
 }
 
@@ -308,7 +310,7 @@ func collectStructResultVars(pass *analysishelper.EnhancedPass, body *ast.BlockS
 				continue
 			}
 			if _, seen := out[v]; !seen {
-				out[v] = structResultSource{callee: target.Origin, idx: i}
+				out[v] = structResultSource{callee: target, idx: i}
 			}
 		}
 	}
@@ -356,11 +358,115 @@ func staticStructAllocation(pass *analysishelper.EnhancedPass, expr ast.Expr) (s
 	return structAllocationSource{}, false
 }
 
+// collectStructAllocationVars records locals whose defining value is a concrete struct allocation.
+func collectStructAllocationVars(pass *analysishelper.EnhancedPass, body *ast.BlockStmt) map[*types.Var]structAllocationSource {
+	var out map[*types.Var]structAllocationSource
+	record := func(ident *ast.Ident, expr ast.Expr) {
+		v, ok := pass.TypesInfo.Defs[ident].(*types.Var)
+		if !ok {
+			return
+		}
+		source, ok := staticStructAllocation(pass, expr)
+		if ok {
+			if out == nil {
+				out = make(map[*types.Var]structAllocationSource)
+			}
+			out[v] = source
+		}
+	}
+	ast.Inspect(body, func(n ast.Node) bool {
+		switch n := n.(type) {
+		case *ast.AssignStmt:
+			if len(n.Lhs) != len(n.Rhs) {
+				return true
+			}
+			for i, lhs := range n.Lhs {
+				if ident, ok := ast.Unparen(lhs).(*ast.Ident); ok {
+					record(ident, n.Rhs[i])
+				}
+			}
+		case *ast.ValueSpec:
+			if len(n.Names) != len(n.Values) {
+				return true
+			}
+			for i, ident := range n.Names {
+				record(ident, n.Values[i])
+			}
+		case *ast.FuncLit:
+			return false
+		}
+		return true
+	})
+	return out
+}
+
+// collectStableStructVars returns candidate locals whose only uses are as bare operands of explicit
+// returns from the enclosing function. Starting from known-safe uses makes unfamiliar syntax
+// conservative by default: any reassignment, mutation, alias, observation, escape, or closure
+// capture is a non-return use and disqualifies the local.
+func collectStableStructVars(pass *analysishelper.EnhancedPass, body *ast.BlockStmt, allocationVars map[*types.Var]structAllocationSource, resultVars map[*types.Var]structResultSource) map[*types.Var]bool {
+	if len(allocationVars) == 0 && len(resultVars) == 0 {
+		return nil
+	}
+
+	candidates := make(map[*types.Var]bool, len(allocationVars)+len(resultVars))
+	for v := range allocationVars {
+		candidates[v] = true
+	}
+	for v := range resultVars {
+		candidates[v] = true
+	}
+
+	// Record exact identifier occurrences that are bare return operands. Returns inside closures do
+	// not return from the function being summarized, so they are not allowed uses.
+	allowedUses := make(map[*ast.Ident]bool)
+	ast.Inspect(body, func(n ast.Node) bool {
+		switch n := n.(type) {
+		case *ast.FuncLit:
+			return false
+		case *ast.ReturnStmt:
+			for _, result := range n.Results {
+				if ident, ok := ast.Unparen(result).(*ast.Ident); ok {
+					allowedUses[ident] = true
+				}
+			}
+		}
+		return true
+	})
+
+	// Only candidates that are actually returned start stable. The second walk intentionally enters
+	// closures so a captured candidate is seen as a disallowed use.
+	stable := make(map[*types.Var]bool)
+	for ident := range allowedUses {
+		if v, ok := pass.TypesInfo.Uses[ident].(*types.Var); ok && candidates[v] {
+			stable[v] = true
+		}
+	}
+
+	// Reject a candidate if any of its uses is not one of the exact return occurrences recorded
+	// above. Definitions are absent from TypesInfo.Uses, so they do not disqualify the candidate.
+	ast.Inspect(body, func(n ast.Node) bool {
+		ident, ok := n.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		v, ok := pass.TypesInfo.Uses[ident].(*types.Var)
+		if ok && candidates[v] && !allowedUses[ident] {
+			delete(stable, v)
+		}
+		return true
+	})
+	return stable
+}
+
 // collectConcreteReturnEffects records concrete nil result fields and same-package forwarding edges.
 func collectConcreteReturnEffects(
 	pass *analysishelper.EnhancedPass,
 	body *ast.BlockStmt,
 	funcObj *types.Func,
+	allocationVars map[*types.Var]structAllocationSource,
+	resultVars map[*types.Var]structResultSource,
+	stableVars map[*types.Var]bool,
 	effects fieldEffects,
 	edges map[*types.Func][]returnForwardEdge,
 ) {
@@ -405,6 +511,21 @@ func collectConcreteReturnEffects(
 						addEdge(resultIdx, target, 0)
 					}
 					continue
+				}
+				ident, ok := ast.Unparen(resultExpr).(*ast.Ident)
+				if !ok {
+					continue
+				}
+				v, ok := pass.TypesInfo.ObjectOf(ident).(*types.Var)
+				if !ok || !stableVars[v] {
+					continue
+				}
+				if source, ok := allocationVars[v]; ok {
+					enumerateConcreteReturnEffects(pass, funcObj, resultIdx, source.structType, source.fieldInits, "", effects)
+					continue
+				}
+				if source, ok := resultVars[v]; ok {
+					addEdge(resultIdx, source.callee, source.idx)
 				}
 			}
 			return false
@@ -458,7 +579,7 @@ func collectFieldReadDemand(pass *analysishelper.EnhancedPass, sel *ast.Selector
 		return
 	}
 	if src, ok := resultVars[v]; ok {
-		returnReads.add(src.callee, IndexedFieldPath{Idx: src.idx, Path: prefix})
+		returnReads.add(src.callee.Origin, IndexedFieldPath{Idx: src.idx, Path: prefix})
 	}
 }
 

--- a/assertion/function/structfieldeffects/testdata/src/go.uber.org/returneffects/main.go
+++ b/assertion/function/structfieldeffects/testdata/src/go.uber.org/returneffects/main.go
@@ -122,3 +122,154 @@ func multiResultWithNil() (Outer, error) { // expect_effects: return_effects:0:M
 func multiResultSpread() (Outer, error) { // expect_effects:
 	return multiResultWithNil()
 }
+
+func shortLocal() *Outer { // expect_effects: return_effects:0:Mid return_effects:0:Value.Child
+	x := &Outer{}
+	return x
+}
+
+func declaredLocal() *Outer { // expect_effects: return_effects:0:Mid.Child return_effects:0:Value.Child
+	var x = &Outer{Mid: &Node{}}
+	return x
+}
+
+func parenthesizedLocal() *Outer { // expect_effects: return_effects:0:Mid return_effects:0:Value.Child
+	x := &Outer{}
+	return (x)
+}
+
+func multipleLocalReturns(cond bool) *Outer { // expect_effects: return_effects:0:Mid return_effects:0:Value.Child
+	x := &Outer{}
+	if cond {
+		return x
+	}
+	return x
+}
+
+func genericLocalForward() *Outer { // expect_effects: return_effects:0:Mid return_effects:0:Value.Child
+	x := genericConcrete[int]()
+	return x
+}
+
+func localForward() *Outer { // expect_effects: return_effects:0:Mid return_effects:0:Value.Child
+	x := directForward()
+	return x
+}
+
+func forwardSecondResult() *Node { // expect_effects: return_effects:0:Child
+	_, n := pair()
+	return n
+}
+
+// No return effects: mutating the local invalidates its tracked allocation.
+func mutatedLocal() *Outer { // expect_effects:
+	x := &Outer{}
+	x.Mid = &Node{}
+	return x
+}
+
+// No return effects: reassigning the local invalidates its tracked allocation.
+func reassignedLocal() *Outer { // expect_effects:
+	x := &Outer{}
+	x = safeOuter()
+	return x
+}
+
+// No return effects: mixed reassignment invalidates the tracked local.
+func mixedReassignment() *Outer { // expect_effects:
+	x := &Outer{}
+	x, used := safeOuter(), true
+	_ = used
+	return x
+}
+
+// No return effects: the range assignment overwrites the tracked local.
+func rangeReassignment() *Outer { // expect_effects:
+	x := &Outer{}
+	for _, x = range []*Outer{safeOuter()} {
+	}
+	return x
+}
+
+func rangeWithoutOperands() *Outer { // expect_effects: return_effects:0:Mid return_effects:0:Value.Child
+	x := &Outer{}
+	for range []int{} {
+	}
+	return x
+}
+
+// No return effects: taking the local's address exposes it to mutation.
+func addressTaken() *Outer { // expect_effects:
+	x := &Outer{}
+	_ = &x
+	return x
+}
+
+func escape(*Outer) {}
+
+// No return effects: passing the local to a call exposes it to mutation.
+func passedToCall() *Outer { // expect_effects:
+	x := &Outer{}
+	escape(x)
+	return x
+}
+
+// No return effects: assigning the local to an alias loses exclusive ownership.
+func aliasedLocal() *Outer { // expect_effects:
+	x := &Outer{}
+	y := x
+	_ = y
+	return x
+}
+
+// No return effects: capturing the local allows deferred mutation. This is a false negative
+// caused by conservativeness: the closure is never invoked, so x's allocation is in fact safe to
+// track, but collectStableStructVars disqualifies any captured candidate without distinguishing
+// called from uncalled closures.
+func capturedLocal() *Outer { // expect_effects:
+	x := &Outer{}
+	_ = func() { x.Mid = &Node{} }
+	return x
+}
+
+// No return effects: capturing the local allows deferred mutation, and here the closure is actually
+// invoked, so conservativeness is justified and the loss of effects is a true negative.
+func capturedLocalInvoked() *Outer { // expect_effects:
+	x := &Outer{}
+	f := func() { x.Mid = &Node{} }
+	f()
+	return x
+}
+
+// No return effects: a return from a closure is not an allowed use of the enclosing local.
+func returnedFromClosure() *Outer { // expect_effects:
+	x := &Outer{}
+	_ = func() *Outer { return x }
+	return x
+}
+
+// No return effects: even a non-mutating observation is outside the stable local pattern.
+func observedLocal() *Outer { // expect_effects:
+	x := &Outer{}
+	if x.Mid == nil {
+		return safeOuter()
+	}
+	return x
+}
+
+// No return effects: field projections are not tracked as concrete return sources.
+func fieldProjection() *Node { // expect_effects:
+	x := &Outer{}
+	return x.Mid
+}
+
+// No return effects: an uninitialized local is not a tracked allocation.
+func zeroValue() Outer { // expect_effects:
+	var x Outer
+	return x
+}
+
+// No return effects: a naked return has no explicit result expression.
+func nakedReturn() (out Outer) { // expect_effects:
+	return
+}


### PR DESCRIPTION
Support struct field-effect collection when a function returns a local variable.

Changes
- Track locals initialized from concrete struct allocations or struct-returning calls.
- Emit concrete return effects or return-forwarding edges when those locals are returned.
- Conservatively discard tracked locals after mutation, reassignment, aliasing, escape, address-taking, or closure capture.
- Add test coverage for allocation locals, forwarded results, multi-result calls, and invalidating operations.
