### PR TITLE
test(struct-init-v2): repartition return-effect coverage

### DIFF
--- a/assertion/function/structfieldeffects/effects.go
+++ b/assertion/function/structfieldeffects/effects.go
@@ -161,7 +161,7 @@ func (c *collectedFieldEffects) collectFunction(pass *analysishelper.EnhancedPas
 	// Locals bound directly to a struct-returning call, so a later dereference of the local's fields
 	// can be attributed to that callee's result (the return-read demand).
 	resultVars := collectStructResultVars(pass, fd.Body)
-	c.collectReturnEffects(pass, fd, funcObj)
+	c.collectReturnEffects(pass, fd, funcObj, resultVars)
 
 	ast.Inspect(fd.Body, func(n ast.Node) bool {
 		switch n := n.(type) {
@@ -182,9 +182,9 @@ func (c *collectedFieldEffects) collectFunction(pass *analysishelper.EnhancedPas
 }
 
 // collectReturnEffects records this function's concrete nil result fields and same-package return
-// forwarding edges. Only direct construction sites and direct same-package call returns are
-// recognized; returned locals are handled by a later revision.
-func (c *collectedFieldEffects) collectReturnEffects(pass *analysishelper.EnhancedPass, fd *ast.FuncDecl, funcObj *types.Func) {
+// forwarding edges. resultVars maps locals bound directly to struct-returning calls and is shared
+// with the later read-demand pass.
+func (c *collectedFieldEffects) collectReturnEffects(pass *analysishelper.EnhancedPass, fd *ast.FuncDecl, funcObj *types.Func, resultVars map[*types.Var]structResultSource) {
 	sig := funcObj.Signature()
 	// Fast path: no struct-shaped result can ever produce a concrete return effect or forwarding
 	// edge, so the body walk below would do nothing. Use the same predicate as
@@ -199,8 +199,10 @@ func (c *collectedFieldEffects) collectReturnEffects(pass *analysishelper.Enhanc
 	if !hasStructResult {
 		return
 	}
+	allocationVars := collectStructAllocationVars(pass, fd.Body)
+	stableVars := collectStableStructVars(pass, fd.Body, allocationVars, resultVars)
 	collectConcreteReturnEffects(
-		pass, fd.Body, funcObj,
+		pass, fd.Body, funcObj, allocationVars, resultVars, stableVars,
 		c.summary.ReturnEffects, c.returnForwardingEdges,
 	)
 }
@@ -269,7 +271,7 @@ func (e fieldEffects) add(funcObj *types.Func, key IndexedFieldPath) bool {
 // structResultSource identifies the struct-returning callee and result index a local variable was
 // assigned from, so dereferences of that local's fields can be attributed to the callee's return.
 type structResultSource struct {
-	callee *types.Func
+	callee typeshelper.StaticCallTarget
 	idx    int
 }
 
@@ -308,7 +310,7 @@ func collectStructResultVars(pass *analysishelper.EnhancedPass, body *ast.BlockS
 				continue
 			}
 			if _, seen := out[v]; !seen {
-				out[v] = structResultSource{callee: target.Origin, idx: i}
+				out[v] = structResultSource{callee: target, idx: i}
 			}
 		}
 	}
@@ -356,11 +358,115 @@ func staticStructAllocation(pass *analysishelper.EnhancedPass, expr ast.Expr) (s
 	return structAllocationSource{}, false
 }
 
+// collectStructAllocationVars records locals whose defining value is a concrete struct allocation.
+func collectStructAllocationVars(pass *analysishelper.EnhancedPass, body *ast.BlockStmt) map[*types.Var]structAllocationSource {
+	var out map[*types.Var]structAllocationSource
+	record := func(ident *ast.Ident, expr ast.Expr) {
+		v, ok := pass.TypesInfo.Defs[ident].(*types.Var)
+		if !ok {
+			return
+		}
+		source, ok := staticStructAllocation(pass, expr)
+		if ok {
+			if out == nil {
+				out = make(map[*types.Var]structAllocationSource)
+			}
+			out[v] = source
+		}
+	}
+	ast.Inspect(body, func(n ast.Node) bool {
+		switch n := n.(type) {
+		case *ast.AssignStmt:
+			if len(n.Lhs) != len(n.Rhs) {
+				return true
+			}
+			for i, lhs := range n.Lhs {
+				if ident, ok := ast.Unparen(lhs).(*ast.Ident); ok {
+					record(ident, n.Rhs[i])
+				}
+			}
+		case *ast.ValueSpec:
+			if len(n.Names) != len(n.Values) {
+				return true
+			}
+			for i, ident := range n.Names {
+				record(ident, n.Values[i])
+			}
+		case *ast.FuncLit:
+			return false
+		}
+		return true
+	})
+	return out
+}
+
+// collectStableStructVars returns candidate locals whose only uses are as bare operands of explicit
+// returns from the enclosing function. Starting from known-safe uses makes unfamiliar syntax
+// conservative by default: any reassignment, mutation, alias, observation, escape, or closure
+// capture is a non-return use and disqualifies the local.
+func collectStableStructVars(pass *analysishelper.EnhancedPass, body *ast.BlockStmt, allocationVars map[*types.Var]structAllocationSource, resultVars map[*types.Var]structResultSource) map[*types.Var]bool {
+	if len(allocationVars) == 0 && len(resultVars) == 0 {
+		return nil
+	}
+
+	candidates := make(map[*types.Var]bool, len(allocationVars)+len(resultVars))
+	for v := range allocationVars {
+		candidates[v] = true
+	}
+	for v := range resultVars {
+		candidates[v] = true
+	}
+
+	// Record exact identifier occurrences that are bare return operands. Returns inside closures do
+	// not return from the function being summarized, so they are not allowed uses.
+	allowedUses := make(map[*ast.Ident]bool)
+	ast.Inspect(body, func(n ast.Node) bool {
+		switch n := n.(type) {
+		case *ast.FuncLit:
+			return false
+		case *ast.ReturnStmt:
+			for _, result := range n.Results {
+				if ident, ok := ast.Unparen(result).(*ast.Ident); ok {
+					allowedUses[ident] = true
+				}
+			}
+		}
+		return true
+	})
+
+	// Only candidates that are actually returned start stable. The second walk intentionally enters
+	// closures so a captured candidate is seen as a disallowed use.
+	stable := make(map[*types.Var]bool)
+	for ident := range allowedUses {
+		if v, ok := pass.TypesInfo.Uses[ident].(*types.Var); ok && candidates[v] {
+			stable[v] = true
+		}
+	}
+
+	// Reject a candidate if any of its uses is not one of the exact return occurrences recorded
+	// above. Definitions are absent from TypesInfo.Uses, so they do not disqualify the candidate.
+	ast.Inspect(body, func(n ast.Node) bool {
+		ident, ok := n.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		v, ok := pass.TypesInfo.Uses[ident].(*types.Var)
+		if ok && candidates[v] && !allowedUses[ident] {
+			delete(stable, v)
+		}
+		return true
+	})
+	return stable
+}
+
 // collectConcreteReturnEffects records concrete nil result fields and same-package forwarding edges.
 func collectConcreteReturnEffects(
 	pass *analysishelper.EnhancedPass,
 	body *ast.BlockStmt,
 	funcObj *types.Func,
+	allocationVars map[*types.Var]structAllocationSource,
+	resultVars map[*types.Var]structResultSource,
+	stableVars map[*types.Var]bool,
 	effects fieldEffects,
 	edges map[*types.Func][]returnForwardEdge,
 ) {
@@ -405,6 +511,21 @@ func collectConcreteReturnEffects(
 						addEdge(resultIdx, target, 0)
 					}
 					continue
+				}
+				ident, ok := ast.Unparen(resultExpr).(*ast.Ident)
+				if !ok {
+					continue
+				}
+				v, ok := pass.TypesInfo.ObjectOf(ident).(*types.Var)
+				if !ok || !stableVars[v] {
+					continue
+				}
+				if source, ok := allocationVars[v]; ok {
+					enumerateConcreteReturnEffects(pass, funcObj, resultIdx, source.structType, source.fieldInits, "", effects)
+					continue
+				}
+				if source, ok := resultVars[v]; ok {
+					addEdge(resultIdx, source.callee, source.idx)
 				}
 			}
 			return false
@@ -458,7 +579,7 @@ func collectFieldReadDemand(pass *analysishelper.EnhancedPass, sel *ast.Selector
 		return
 	}
 	if src, ok := resultVars[v]; ok {
-		returnReads.add(src.callee, IndexedFieldPath{Idx: src.idx, Path: prefix})
+		returnReads.add(src.callee.Origin, IndexedFieldPath{Idx: src.idx, Path: prefix})
 	}
 }
 

--- a/assertion/function/structfieldeffects/testdata/src/go.uber.org/returneffects/main.go
+++ b/assertion/function/structfieldeffects/testdata/src/go.uber.org/returneffects/main.go
@@ -122,3 +122,154 @@ func multiResultWithNil() (Outer, error) { // expect_effects: return_effects:0:M
 func multiResultSpread() (Outer, error) { // expect_effects:
 	return multiResultWithNil()
 }
+
+func shortLocal() *Outer { // expect_effects: return_effects:0:Mid return_effects:0:Value.Child
+	x := &Outer{}
+	return x
+}
+
+func declaredLocal() *Outer { // expect_effects: return_effects:0:Mid.Child return_effects:0:Value.Child
+	var x = &Outer{Mid: &Node{}}
+	return x
+}
+
+func parenthesizedLocal() *Outer { // expect_effects: return_effects:0:Mid return_effects:0:Value.Child
+	x := &Outer{}
+	return (x)
+}
+
+func multipleLocalReturns(cond bool) *Outer { // expect_effects: return_effects:0:Mid return_effects:0:Value.Child
+	x := &Outer{}
+	if cond {
+		return x
+	}
+	return x
+}
+
+func genericLocalForward() *Outer { // expect_effects: return_effects:0:Mid return_effects:0:Value.Child
+	x := genericConcrete[int]()
+	return x
+}
+
+func localForward() *Outer { // expect_effects: return_effects:0:Mid return_effects:0:Value.Child
+	x := directForward()
+	return x
+}
+
+func forwardSecondResult() *Node { // expect_effects: return_effects:0:Child
+	_, n := pair()
+	return n
+}
+
+// No return effects: mutating the local invalidates its tracked allocation.
+func mutatedLocal() *Outer { // expect_effects:
+	x := &Outer{}
+	x.Mid = &Node{}
+	return x
+}
+
+// No return effects: reassigning the local invalidates its tracked allocation.
+func reassignedLocal() *Outer { // expect_effects:
+	x := &Outer{}
+	x = safeOuter()
+	return x
+}
+
+// No return effects: mixed reassignment invalidates the tracked local.
+func mixedReassignment() *Outer { // expect_effects:
+	x := &Outer{}
+	x, used := safeOuter(), true
+	_ = used
+	return x
+}
+
+// No return effects: the range assignment overwrites the tracked local.
+func rangeReassignment() *Outer { // expect_effects:
+	x := &Outer{}
+	for _, x = range []*Outer{safeOuter()} {
+	}
+	return x
+}
+
+func rangeWithoutOperands() *Outer { // expect_effects: return_effects:0:Mid return_effects:0:Value.Child
+	x := &Outer{}
+	for range []int{} {
+	}
+	return x
+}
+
+// No return effects: taking the local's address exposes it to mutation.
+func addressTaken() *Outer { // expect_effects:
+	x := &Outer{}
+	_ = &x
+	return x
+}
+
+func escape(*Outer) {}
+
+// No return effects: passing the local to a call exposes it to mutation.
+func passedToCall() *Outer { // expect_effects:
+	x := &Outer{}
+	escape(x)
+	return x
+}
+
+// No return effects: assigning the local to an alias loses exclusive ownership.
+func aliasedLocal() *Outer { // expect_effects:
+	x := &Outer{}
+	y := x
+	_ = y
+	return x
+}
+
+// No return effects: capturing the local allows deferred mutation. This is a false negative
+// caused by conservativeness: the closure is never invoked, so x's allocation is in fact safe to
+// track, but collectStableStructVars disqualifies any captured candidate without distinguishing
+// called from uncalled closures.
+func capturedLocal() *Outer { // expect_effects:
+	x := &Outer{}
+	_ = func() { x.Mid = &Node{} }
+	return x
+}
+
+// No return effects: capturing the local allows deferred mutation, and here the closure is actually
+// invoked, so conservativeness is justified and the loss of effects is a true negative.
+func capturedLocalInvoked() *Outer { // expect_effects:
+	x := &Outer{}
+	f := func() { x.Mid = &Node{} }
+	f()
+	return x
+}
+
+// No return effects: a return from a closure is not an allowed use of the enclosing local.
+func returnedFromClosure() *Outer { // expect_effects:
+	x := &Outer{}
+	_ = func() *Outer { return x }
+	return x
+}
+
+// No return effects: even a non-mutating observation is outside the stable local pattern.
+func observedLocal() *Outer { // expect_effects:
+	x := &Outer{}
+	if x.Mid == nil {
+		return safeOuter()
+	}
+	return x
+}
+
+// No return effects: field projections are not tracked as concrete return sources.
+func fieldProjection() *Node { // expect_effects:
+	x := &Outer{}
+	return x.Mid
+}
+
+// No return effects: an uninitialized local is not a tracked allocation.
+func zeroValue() Outer { // expect_effects:
+	var x Outer
+	return x
+}
+
+// No return effects: a naked return has no explicit result expression.
+func nakedReturn() (out Outer) { // expect_effects:
+	return
+}

--- a/testdata/src/go.uber.org/structinitv2/limitations/limitations.go
+++ b/testdata/src/go.uber.org/structinitv2/limitations/limitations.go
@@ -172,38 +172,6 @@ func tForwardViaFuncValue() *int {
 	return b.child.ptr
 }
 
-// False negative: a struct-returning call forwarded through a return (`return f()`) is unsupported.
-// The callee's per-field return summary is not composed across the forward, so the nil child from
-// makeNilNode is not tracked at the caller. Supporting it would need the return-read demand closed
-// over forwarding edges (as closeParamFieldSets does for params), which is not computed for returns.
-func makeNilNode() *Node { return &Node{} }
-
-func forwardNilNode() *Node { return makeNilNode() }
-
-func tForwardedReturnNotComposed() *int {
-	b := forwardNilNode()
-	return b.child.ptr
-}
-
-// False negative: a struct-returning call used directly as an argument is not composed into the
-// parameter boundary. Return-effects support must bind makeNilNodeForParam's field summary to n.
-func makeNilNodeForParam() *Node { return &Node{} }
-
-func readReturnedParam(n *Node) *int { return n.child.ptr }
-
-func tReturnedCallAsParam() *int {
-	return readReturnedParam(makeNilNodeForParam())
-}
-
-// False negative: the same missing return-to-boundary composition applies to a method receiver.
-func makeNilNodeForReceiver() *Node { return &Node{} }
-
-func (n *Node) readReturnedReceiver() *int { return n.child.ptr }
-
-func tReturnedCallAsReceiver() *int {
-	return makeNilNodeForReceiver().readReturnedReceiver()
-}
-
 // ---------------------------------------------------------------------------------------------
 // FALSE POSITIVES (over-reports — //want required)
 // ---------------------------------------------------------------------------------------------

--- a/testdata/src/go.uber.org/structinitv2/returncrosspkg/app/app.go
+++ b/testdata/src/go.uber.org/structinitv2/returncrosspkg/app/app.go
@@ -1,0 +1,46 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package app is the consumer side of the cross-package return-shape tests: the deep dereferences
+// land here, so the diagnostics are asserted with //want in this package. See package lib.
+package app
+
+import (
+	"go.uber.org/structinitv2/returncrosspkg/lib"
+	"go.uber.org/structinitv2/returncrosspkg/mid"
+)
+
+// ReturnDeepNil leaves Mid.Child nil; the deep deref must flag.
+func useReturnDeepNil() {
+	a := lib.ReturnDeepNil()
+	print(a.Mid.Child.Ptr) //want "field `Mid.Child` of result 0 of `ReturnDeepNil`"
+}
+
+// ReturnDeepNonNil initializes Mid.Child; the same deref must NOT flag.
+func useReturnDeepNonNil() {
+	a := lib.ReturnDeepNonNil()
+	print(a.Mid.Child.Ptr)
+}
+
+// Transitive across two package hops (app -> mid.ForwardImportedResult -> lib.ReturnDeepNil).
+func useForwardImportedResult() {
+	a := mid.ForwardImportedResult()
+	print(a.Mid.Child.Ptr) //want "field `Mid.Child` of result 0 of `ForwardImportedResult`"
+}
+
+// `return g()` is as deep as g's own return shape.
+func useReturnForwardedConstructor() {
+	a := lib.ReturnForwardedConstructor()
+	print(a.Mid.Child.Ptr) //want "field `Mid.Child` of result 0 of `ReturnForwardedConstructor`"
+}

--- a/testdata/src/go.uber.org/structinitv2/returncrosspkg/lib/lib.go
+++ b/testdata/src/go.uber.org/structinitv2/returncrosspkg/lib/lib.go
@@ -1,0 +1,51 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package lib is the producer side of the cross-package return-shape tests: its constructors return
+// values whose deep field nilability is dereferenced only by the sibling app package. The struct
+// types are distinct at each level (Outer -> Node -> Leaf) so the deep paths are non-recursive.
+package lib
+
+// Leaf is the deepest struct; its Ptr is the dereference target.
+type Leaf struct {
+	Ptr *int
+}
+
+// Node nests a Leaf.
+type Node struct {
+	Child *Leaf
+}
+
+// Outer nests a Node, giving the depth-2 field path Mid.Child.
+type Outer struct {
+	Mid *Node
+}
+
+// ReturnDeepNil returns a value whose Mid is set but whose nested Mid.Child is left nil.
+func ReturnDeepNil() *Outer {
+	x := &Outer{Mid: &Node{}}
+	return x
+}
+
+// ReturnDeepNonNil is the negative control: it initializes Mid.Child, so the same deref is safe.
+func ReturnDeepNonNil() *Outer {
+	x := &Outer{Mid: &Node{Child: &Leaf{}}}
+	return x
+}
+
+// ReturnForwardedConstructor forwards a constructor's result directly (`return g()`), so it is as
+// deep as ReturnDeepNil's own return shape.
+func ReturnForwardedConstructor() *Outer {
+	return ReturnDeepNil()
+}

--- a/testdata/src/go.uber.org/structinitv2/returncrosspkg/mid/mid.go
+++ b/testdata/src/go.uber.org/structinitv2/returncrosspkg/mid/mid.go
@@ -13,15 +13,15 @@
 // limitations under the License.
 
 // Package mid is the middle hop of the transitive cross-package return-shape test: it forwards a
-// param-forwarder defined in lib so the app package (two hops away) can tie the result to its own
-// argument.
+// constructor defined in lib, re-exporting its shape so the app package (two hops away) still sees
+// the deep nil field.
 package mid
 
-import "go.uber.org/structinitv2/returnshape/lib"
+import "go.uber.org/structinitv2/returncrosspkg/lib"
 
-// ForwardParamCrossPkg returns a call to lib.ForwardParam (a param-forwarder in another package), so
-// it forwards its own param 0 to result 0; a caller in app ties the result to its own argument across
-// two package hops.
-func ForwardParamCrossPkg(y *lib.Outer) *lib.Outer {
-	return lib.ForwardParam(y)
+// ForwardImportedResult forwards lib.ReturnDeepNil's result, re-exporting the deep shape so a caller
+// two packages away inherits it.
+func ForwardImportedResult() *lib.Outer {
+	x := lib.ReturnDeepNil()
+	return x
 }

--- a/testdata/src/go.uber.org/structinitv2/returnerr/funcreturnwitherrors.go
+++ b/testdata/src/go.uber.org/structinitv2/returnerr/funcreturnwitherrors.go
@@ -12,16 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Tests the (value, error) constructor pattern: a struct returned alongside a non-nil (or unknown)
-// error is never observed by a caller that checks `err != nil`, so its possibly-nil fields must not
-// poison the success-path summary; but a caller that ignores the error is still flagged.
-
-package funcreturnfields
+// Package returnerr tests the (value, error) constructor pattern: a struct returned alongside a
+// non-nil (or unknown) error is never observed by a caller that checks `err != nil`, so its
+// possibly-nil fields must not poison the success-path summary; but a caller that ignores the error
+// is still flagged.
+package returnerr
 
 import (
 	"errors"
 	"fmt"
 )
+
+type leaf struct {
+	ptr *int
+}
+
+type A11 struct {
+	aptr *leaf
+}
 
 // 1. Always returns a non-nil error: the nil-fielded value is never observed on the success path.
 type myErr struct{}

--- a/testdata/src/go.uber.org/structinitv2/returnlocal/funcreturnbasic.go
+++ b/testdata/src/go.uber.org/structinitv2/returnlocal/funcreturnbasic.go
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package funcreturnfields tests nilability flowing through fields of a function or method result.
-package funcreturnfields
+// Package returnlocal tests nilability flowing through fields of a function or method result
+// within a single package.
+package returnlocal
 
 import (
 	"go.uber.org/structinit/multipackage/packageone"

--- a/testdata/src/go.uber.org/structinitv2/returnlocal/functionreturntransitive.go
+++ b/testdata/src/go.uber.org/structinitv2/returnlocal/functionreturntransitive.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package funcreturnfields
+package returnlocal
 
 // Direct return of a composite literal local.
 

--- a/testdata/src/go.uber.org/structinitv2/returnlocal/methodreturnbasic.go
+++ b/testdata/src/go.uber.org/structinitv2/returnlocal/methodreturnbasic.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package funcreturnfields
+package returnlocal
 
 // Same as funcreturnbasic.go, but for methods.
 

--- a/testdata/src/go.uber.org/structinitv2/returnlocal/returncallboundary.go
+++ b/testdata/src/go.uber.org/structinitv2/returnlocal/returncallboundary.go
@@ -1,0 +1,48 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Composing a struct-returning call directly into a parameter or receiver boundary: the callee's
+// per-field return summary must bind to the parameter (or receiver) the returned value flows into.
+
+package returnlocal
+
+type composedLeaf struct {
+	ptr *int
+}
+
+type composedNode struct {
+	child *composedLeaf
+}
+
+// A struct-returning call used directly as an argument is composed into the parameter boundary.
+func giveComposedForParam() *composedNode { return &composedNode{} }
+
+func readComposedParam(n *composedNode) *int {
+	return n.child.ptr //want "accessed field `ptr`"
+}
+
+func mComposedParam() *int {
+	return readComposedParam(giveComposedForParam())
+}
+
+// The same return-to-boundary composition applies to a method receiver.
+func giveComposedForReceiver() *composedNode { return &composedNode{} }
+
+func (n *composedNode) readComposedReceiver() *int {
+	return n.child.ptr //want "accessed field `ptr`"
+}
+
+func mComposedReceiver() *int {
+	return giveComposedForReceiver().readComposedReceiver()
+}

--- a/testdata/src/go.uber.org/structinitv2/returnprojection/app/app.go
+++ b/testdata/src/go.uber.org/structinitv2/returnprojection/app/app.go
@@ -1,0 +1,43 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package app checks return projections and recursive return shapes from package lib.
+package app
+
+import "go.uber.org/structinitv2/returnprojection/lib"
+
+// Field-projection return `return x.In`; x.In.Child is nil.
+func useReturnProjection() {
+	a := lib.ReturnProjection()
+	print(a.Child.Ptr) //want "field `Child` of result 0 of `ReturnProjection`"
+}
+
+// ReturnProjectionSafe initializes Child; no flag.
+func useReturnProjectionSafe() {
+	a := lib.ReturnProjectionSafe()
+	print(a.Child.Ptr)
+}
+
+// The recursive constructor's top-level Ptr is tracked.
+func useRecTop() {
+	a := lib.MkRec()
+	print(*a.Ptr) //want "field `Ptr` of result 0 of `MkRec`"
+}
+
+// One unrolling of the recursive type is supported, and Self.Ptr is genuinely nil, so this flags.
+// Paths beyond the first unrolling (Self.Self.Ptr) stay under-reports.
+func useRecDeep() {
+	a := lib.MkRec()
+	print(*a.Self.Ptr) //want "field `Self.Ptr` of result 0 of `MkRec`"
+}

--- a/testdata/src/go.uber.org/structinitv2/returnprojection/lib/lib.go
+++ b/testdata/src/go.uber.org/structinitv2/returnprojection/lib/lib.go
@@ -1,0 +1,58 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package lib is the producer side of the cross-package return-shape tests: its constructors return
+// values whose deep field nilability is dereferenced only by the sibling app package. The struct
+// types are distinct at each level (Outer -> Node -> Leaf) so the deep paths are non-recursive.
+package lib
+
+// Leaf is the deepest struct; its Ptr is the dereference target.
+type Leaf struct {
+	Ptr *int
+}
+
+// Inner and Wrap give a field-projection return target.
+type Inner struct {
+	Child *Leaf
+}
+
+// Wrap nests an Inner so ReturnProjection can return the projection x.In.
+type Wrap struct {
+	In *Inner
+}
+
+// ReturnProjection returns a field projection (`return x.In`); the result is an *Inner whose Child
+// is left nil.
+func ReturnProjection() *Inner {
+	x := &Wrap{In: &Inner{}}
+	return x.In
+}
+
+// ReturnProjectionSafe is the negative control for ReturnProjection: Child is initialized.
+func ReturnProjectionSafe() *Inner {
+	x := &Wrap{In: &Inner{Child: &Leaf{}}}
+	return x.In
+}
+
+// Rec is a self-referential type: paths through Self are recursive and skipped past the first
+// unrolling, so MkRec's top-level Ptr is tracked but Self.Ptr is not.
+type Rec struct {
+	Ptr  *int
+	Self *Rec
+}
+
+// MkRec constructs a recursive value with Self set but Ptr (and Self.Ptr) nil.
+func MkRec() *Rec {
+	return &Rec{Self: &Rec{}}
+}

--- a/testdata/src/go.uber.org/structinitv2/returnshape/app/app.go
+++ b/testdata/src/go.uber.org/structinitv2/returnshape/app/app.go
@@ -21,67 +21,6 @@ import (
 	"go.uber.org/structinitv2/returnshape/mid"
 )
 
-// ReturnDeepNil leaves Mid.Child nil; the deep deref must flag.
-func useReturnDeepNil() {
-	a := lib.ReturnDeepNil()
-	print(a.Mid.Child.Ptr) //want "field `Mid.Child` of result 0 of `ReturnDeepNil`"
-}
-
-// ReturnDeepNonNil initializes Mid.Child; the same deref must NOT flag.
-func useReturnDeepNonNil() {
-	a := lib.ReturnDeepNonNil()
-	print(a.Mid.Child.Ptr)
-}
-
-// Transitive across two package hops (app -> mid.ForwardImportedResult -> lib.ReturnDeepNil).
-func useForwardImportedResult() {
-	a := mid.ForwardImportedResult()
-	print(a.Mid.Child.Ptr) //want "field `Mid.Child` of result 0 of `ForwardImportedResult`"
-}
-
-// `return g()` is as deep as g's own return shape.
-func useReturnForwardedConstructor() {
-	a := lib.ReturnForwardedConstructor()
-	print(a.Mid.Child.Ptr) //want "field `Mid.Child` of result 0 of `ReturnForwardedConstructor`"
-}
-
-// Field-projection return `return x.In`; x.In.Child is nil.
-func useReturnProjection() {
-	a := lib.ReturnProjection()
-	print(a.Child.Ptr) //want "field `Child` of result 0 of `ReturnProjection`"
-}
-
-// ReturnProjectionSafe initializes Child; no flag.
-func useReturnProjectionSafe() {
-	a := lib.ReturnProjectionSafe()
-	print(a.Child.Ptr)
-}
-
-// Zero-value return `var x Outer; return x`; Mid is nil.
-func useReturnZeroValue() {
-	a := lib.ReturnZeroValue()
-	print(a.Mid.Child) //want "field `Mid` of result 0 of `ReturnZeroValue`"
-}
-
-// Naked named return is a documented under-report — NOT flagged.
-func useNaked() {
-	a := lib.NakedRet()
-	print(a.Mid.Child)
-}
-
-// The recursive constructor's top-level Ptr is tracked.
-func useRecTop() {
-	a := lib.MkRec()
-	print(*a.Ptr) //want "field `Ptr` of result 0 of `MkRec`"
-}
-
-// One unrolling of the recursive type is supported, and Self.Ptr is genuinely nil, so this flags.
-// Paths beyond the first unrolling (Self.Self.Ptr) stay under-reports.
-func useRecDeep() {
-	a := lib.MkRec()
-	print(*a.Self.Ptr) //want "field `Self.Ptr` of result 0 of `MkRec`"
-}
-
 // Param tie: b ties to t; t.Mid.Child is nil, so the deep deref flags.
 func useForwardParam() {
 	t := &lib.Outer{Mid: &lib.Node{}}

--- a/testdata/src/go.uber.org/structinitv2/returnshape/lib/lib.go
+++ b/testdata/src/go.uber.org/structinitv2/returnshape/lib/lib.go
@@ -32,24 +32,6 @@ type Outer struct {
 	Mid *Node
 }
 
-// ReturnDeepNil returns a value whose Mid is set but whose nested Mid.Child is left nil.
-func ReturnDeepNil() *Outer {
-	x := &Outer{Mid: &Node{}}
-	return x
-}
-
-// ReturnDeepNonNil is the negative control: it initializes Mid.Child, so the same deref is safe.
-func ReturnDeepNonNil() *Outer {
-	x := &Outer{Mid: &Node{Child: &Leaf{}}}
-	return x
-}
-
-// ReturnForwardedConstructor forwards a constructor's result directly (`return g()`), so it is as
-// deep as ReturnDeepNil's own return shape.
-func ReturnForwardedConstructor() *Outer {
-	return ReturnDeepNil()
-}
-
 // Inner and Wrap give a field-projection return target.
 type Inner struct {
 	Child *Leaf
@@ -58,44 +40,6 @@ type Inner struct {
 // Wrap nests an Inner so ReturnProjection can return the projection x.In.
 type Wrap struct {
 	In *Inner
-}
-
-// ReturnProjection returns a field projection (`return x.In`); the result is an *Inner whose Child
-// is left nil.
-func ReturnProjection() *Inner {
-	x := &Wrap{In: &Inner{}}
-	return x.In
-}
-
-// ReturnProjectionSafe is the negative control for ReturnProjection: Child is initialized.
-func ReturnProjectionSafe() *Inner {
-	x := &Wrap{In: &Inner{Child: &Leaf{}}}
-	return x.In
-}
-
-// ReturnZeroValue returns a zero-value struct (`var x Outer; return x`), so Mid is nil. The value
-// form is summarized; the naked form below is not.
-func ReturnZeroValue() Outer {
-	var x Outer
-	return x
-}
-
-// NakedRet is a documented under-report: a naked named return has no result expression, so its shape
-// is not summarized and the cross-package deref is NOT flagged.
-func NakedRet() (x Outer) {
-	return
-}
-
-// Rec is a self-referential type: paths through Self are recursive and skipped past the first
-// unrolling, so MkRec's top-level Ptr is tracked but Self.Ptr is not.
-type Rec struct {
-	Ptr  *int
-	Self *Rec
-}
-
-// MkRec constructs a recursive value with Self set but Ptr (and Self.Ptr) nil.
-func MkRec() *Rec {
-	return &Rec{Self: &Rec{}}
 }
 
 // ForwardParam forwards its parameter to its result (`return x`); the result's shape is the caller's

--- a/testdata/src/go.uber.org/structinitv2/returnzerovalue/app/app.go
+++ b/testdata/src/go.uber.org/structinitv2/returnzerovalue/app/app.go
@@ -12,16 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package mid is the middle hop of the transitive cross-package return-shape test: it forwards a
-// param-forwarder defined in lib so the app package (two hops away) can tie the result to its own
-// argument.
-package mid
+// Package app is the consumer side of the zero-value return tests.
+package app
 
-import "go.uber.org/structinitv2/returnshape/lib"
+import "go.uber.org/structinitv2/returnzerovalue/lib"
 
-// ForwardParamCrossPkg returns a call to lib.ForwardParam (a param-forwarder in another package), so
-// it forwards its own param 0 to result 0; a caller in app ties the result to its own argument across
-// two package hops.
-func ForwardParamCrossPkg(y *lib.Outer) *lib.Outer {
-	return lib.ForwardParam(y)
+// Zero-value return `var x Outer; return x`; Mid is nil.
+func useReturnZeroValue() {
+	a := lib.ReturnZeroValue()
+	print(a.Mid.Child) //want "field `Mid` of result 0 of `ReturnZeroValue`"
+}
+
+// Naked named return is a documented under-report — NOT flagged.
+func useNaked() {
+	a := lib.NakedRet()
+	print(a.Mid.Child)
 }

--- a/testdata/src/go.uber.org/structinitv2/returnzerovalue/lib/lib.go
+++ b/testdata/src/go.uber.org/structinitv2/returnzerovalue/lib/lib.go
@@ -1,0 +1,44 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package lib is the producer side of the zero-value return tests.
+package lib
+
+// Leaf is the deepest struct; its Ptr is the dereference target.
+type Leaf struct {
+	Ptr *int
+}
+
+// Node nests a Leaf.
+type Node struct {
+	Child *Leaf
+}
+
+// Outer nests a Node, giving the depth-2 field path Mid.Child.
+type Outer struct {
+	Mid *Node
+}
+
+// ReturnZeroValue returns a zero-value struct (`var x Outer; return x`), so Mid is nil. The value
+// form is summarized; the naked form below is not.
+func ReturnZeroValue() Outer {
+	var x Outer
+	return x
+}
+
+// NakedRet is a documented under-report: a naked named return has no result expression, so its shape
+// is not summarized and the cross-package deref is NOT flagged.
+func NakedRet() (x Outer) {
+	return
+}


### PR DESCRIPTION
Repartition the inert return testdata into one package per upcoming return-effect boundary.

- Split `returnshape/` into `returncrosspkg/`, `returnprojection/`,  and `returnzerovalue/`; keep only parameter-dependent cases in it.
- Move local return cases from `funcreturnfields/` to `returnlocal/`;  rename the remaining `(value, error)` package to `returnerr/`.
- Move the returned-call boundary regressions from `limitations/` to  `returnlocal/` and restore their `//want`s.
- No implementation or `analysistest.Run` changes; all packages stay inert.