### PR TITLE
feat(struct-init-v2): propagate return effects across packages

### DIFF
--- a/assertion/function/structfieldeffects/analyzer.go
+++ b/assertion/function/structfieldeffects/analyzer.go
@@ -58,11 +58,14 @@ func run(p *analysis.Pass) (*BoundaryFieldEffects, error) {
 	packageSummary := collected.close()
 	fact := &BoundaryFieldEffectsPackageFact{}
 	encoder := &objectpath.Encoder{}
-	funcs := make(map[*types.Func]bool, len(packageSummary.ParamReads)+len(packageSummary.ParamWrites))
+	funcs := make(map[*types.Func]bool, len(packageSummary.ParamReads)+len(packageSummary.ParamWrites)+len(packageSummary.ReturnEffects))
 	for funcObj := range packageSummary.ParamReads {
 		funcs[funcObj] = true
 	}
 	for funcObj := range packageSummary.ParamWrites {
+		funcs[funcObj] = true
+	}
+	for funcObj := range packageSummary.ReturnEffects {
 		funcs[funcObj] = true
 	}
 	for funcObj := range funcs {
@@ -73,7 +76,8 @@ func run(p *analysis.Pass) (*BoundaryFieldEffects, error) {
 		// from their dereferences of results, opposite the direction of fact propagation.
 		reads := packageSummary.ParamReads.sortedPaths(funcObj)
 		writes := packageSummary.ParamWrites.sortedPaths(funcObj)
-		if len(reads) == 0 && len(writes) == 0 {
+		returnEffects := packageSummary.ReturnEffects.sortedPaths(funcObj)
+		if len(reads) == 0 && len(writes) == 0 && len(returnEffects) == 0 {
 			continue
 		}
 		path, err := encoder.For(funcObj)
@@ -84,6 +88,7 @@ func run(p *analysis.Pass) (*BoundaryFieldEffects, error) {
 			FunctionObjectPath: path,
 			ParamReads:         reads,
 			ParamWrites:        writes,
+			ReturnEffects:      returnEffects,
 		})
 	}
 	if len(fact.Functions) > 0 {
@@ -128,6 +133,7 @@ func importUsedParamEffects(pass *analysishelper.EnhancedPass, effects *Boundary
 			if found {
 				seedImportedParamEffects(effects.ParamReads, callee, fact.Functions[index].ParamReads)
 				seedImportedParamEffects(effects.ParamWrites, callee, fact.Functions[index].ParamWrites)
+				seedImportedParamEffects(effects.ReturnEffects, callee, fact.Functions[index].ReturnEffects)
 			}
 		}
 	}

--- a/assertion/function/structfieldeffects/effects.go
+++ b/assertion/function/structfieldeffects/effects.go
@@ -46,7 +46,7 @@ type BoundaryFieldEffects struct {
 	// receiver. Transitively closed over forwarding edges.
 	ParamWrites fieldEffects
 	// ReturnEffects records (result idx, field path) pairs that are provably nil at a concrete
-	// construction return site. Closed over same-package return forwarding edges.
+	// construction return site. Closed over return forwarding edges.
 	ReturnEffects fieldEffects
 }
 
@@ -189,7 +189,7 @@ func (c *collectedFieldEffects) collectFunction(pass *analysishelper.EnhancedPas
 	})
 }
 
-// collectReturnEffects records this function's concrete nil result fields and same-package return
+// collectReturnEffects records this function's concrete nil result fields and return
 // forwarding edges. resultVars maps locals bound directly to struct-returning calls and is shared
 // with the later read-demand pass.
 func (c *collectedFieldEffects) collectReturnEffects(pass *analysishelper.EnhancedPass, fd *ast.FuncDecl, funcObj *types.Func, resultVars map[*types.Var]structResultSource) {
@@ -467,7 +467,7 @@ func collectStableStructVars(pass *analysishelper.EnhancedPass, body *ast.BlockS
 	return stable
 }
 
-// collectConcreteReturnEffects records concrete nil result fields and same-package forwarding edges.
+// collectConcreteReturnEffects records concrete nil result fields and forwarding edges.
 func collectConcreteReturnEffects(
 	pass *analysishelper.EnhancedPass,
 	body *ast.BlockStmt,
@@ -480,7 +480,7 @@ func collectConcreteReturnEffects(
 ) {
 	sig := funcObj.Signature()
 	addEdge := func(callerResultIdx int, target typeshelper.StaticCallTarget, calleeResultIdx int) {
-		if target.Origin == nil || target.Origin.Pkg() != pass.Pkg {
+		if target.Origin == nil {
 			return
 		}
 		if calleeResultIdx < 0 || calleeResultIdx >= target.Signature.Results().Len() ||
@@ -681,7 +681,7 @@ type paramFieldForwardEdge struct {
 	calleeParamIdx int
 }
 
-// returnForwardEdge records that one result directly returns a same-package callee result.
+// returnForwardEdge records that one result directly returns a callee result.
 type returnForwardEdge struct {
 	callerResultIdx int
 	callee          *types.Func
@@ -740,7 +740,7 @@ func closeParamFieldSets(fields fieldEffects, edges map[*types.Func][]paramField
 	}
 }
 
-// closeReturnEffects copies concrete effects through direct same-package return forwarding to a
+// closeReturnEffects copies concrete effects through direct return forwarding to a
 // fixpoint. Paths are unchanged because field projections are not part of this boundary.
 func closeReturnEffects(effects fieldEffects, edges map[*types.Func][]returnForwardEdge) {
 	preds := make(map[*types.Func][]*types.Func)

--- a/assertion/function/structfieldeffects/fact.go
+++ b/assertion/function/structfieldeffects/fact.go
@@ -29,4 +29,5 @@ type FunctionFieldEffects struct {
 	FunctionObjectPath objectpath.Path
 	ParamReads         []IndexedFieldPath
 	ParamWrites        []IndexedFieldPath
+	ReturnEffects      []IndexedFieldPath
 }

--- a/assertion/function/structfieldeffects/fact_test.go
+++ b/assertion/function/structfieldeffects/fact_test.go
@@ -176,6 +176,9 @@ func newFact(functionCount int) *BoundaryFieldEffectsPackageFact {
 				{Idx: 0, Path: "Child.Leaf"},
 				{Idx: 1, Path: fmt.Sprintf("Argument%d.Field", i)},
 			},
+			ReturnEffects: []IndexedFieldPath{
+				{Idx: 0, Path: "Result"},
+			},
 		}
 	}
 	return &BoundaryFieldEffectsPackageFact{Functions: functions}

--- a/nilaway_test.go
+++ b/nilaway_test.go
@@ -117,6 +117,7 @@ func TestStructInitV2(t *testing.T) { //nolint:paralleltest
 		"go.uber.org/structinitv2/defaultfield",
 		"go.uber.org/structinitv2/deep",
 		"go.uber.org/structinitv2/crosspkg/app",
+		"go.uber.org/structinitv2/returncrosspkg/app",
 		"go.uber.org/structinitv2/crosspkgside/app",
 		"go.uber.org/structinitv2/paramfield",
 		"go.uber.org/structinitv2/paramsideeffect",


### PR DESCRIPTION
Make concrete nil return-field effects visible across packages, so a constructor's omitted fields are reported when the dereference lives in an importing package.

Changes
- Add ReturnEffects to the exported field-effects fact; export and import it alongside ParamReads/ParamWrites.
- Drop the same-package restriction on return-forwarding edges so closeReturnEffects closes through imported callees.
- Wire structinitv2/returncrosspkg/app into TestStructInitV2.