### PR TITLE
feat(struct-init-v2): handle return zero value structs

### DIFF
--- a/assertion/function/structfieldeffects/effects.go
+++ b/assertion/function/structfieldeffects/effects.go
@@ -369,17 +369,20 @@ func staticStructAllocation(pass *analysishelper.EnhancedPass, expr ast.Expr) (s
 // collectStructAllocationVars records locals whose defining value is a concrete struct allocation.
 func collectStructAllocationVars(pass *analysishelper.EnhancedPass, body *ast.BlockStmt) map[*types.Var]structAllocationSource {
 	var out map[*types.Var]structAllocationSource
-	record := func(ident *ast.Ident, expr ast.Expr) {
+	recordAllocation := func(ident *ast.Ident, source structAllocationSource) {
 		v, ok := pass.TypesInfo.Defs[ident].(*types.Var)
 		if !ok {
 			return
 		}
+		if out == nil {
+			out = make(map[*types.Var]structAllocationSource)
+		}
+		out[v] = source
+	}
+	recordIfAllocation := func(ident *ast.Ident, expr ast.Expr) {
 		source, ok := staticStructAllocation(pass, expr)
 		if ok {
-			if out == nil {
-				out = make(map[*types.Var]structAllocationSource)
-			}
-			out[v] = source
+			recordAllocation(ident, source)
 		}
 	}
 	ast.Inspect(body, func(n ast.Node) bool {
@@ -390,15 +393,28 @@ func collectStructAllocationVars(pass *analysishelper.EnhancedPass, body *ast.Bl
 			}
 			for i, lhs := range n.Lhs {
 				if ident, ok := ast.Unparen(lhs).(*ast.Ident); ok {
-					record(ident, n.Rhs[i])
+					recordIfAllocation(ident, n.Rhs[i])
 				}
 			}
 		case *ast.ValueSpec:
+			if len(n.Values) == 0 {
+				for _, ident := range n.Names {
+					// `var x *A` declares a nil pointer, not a zero-valued struct: it has no
+					// field shape to summarize
+					if typeshelper.IsDeeplyType[*types.Pointer](pass.TypesInfo.TypeOf(ident)) {
+						continue
+					}
+					if structType := typeshelper.AsDeeplyStruct(pass.TypesInfo.TypeOf(ident)); structType != nil {
+						recordAllocation(ident, structAllocationSource{structType: structType})
+					}
+				}
+				return true
+			}
 			if len(n.Names) != len(n.Values) {
 				return true
 			}
 			for i, ident := range n.Names {
-				record(ident, n.Values[i])
+				recordIfAllocation(ident, n.Values[i])
 			}
 		case *ast.FuncLit:
 			return false

--- a/assertion/function/structfieldeffects/testdata/src/go.uber.org/returneffects/main.go
+++ b/assertion/function/structfieldeffects/testdata/src/go.uber.org/returneffects/main.go
@@ -263,8 +263,7 @@ func fieldProjection() *Node { // expect_effects:
 	return x.Mid
 }
 
-// No return effects: an uninitialized local is not a tracked allocation.
-func zeroValue() Outer { // expect_effects:
+func zeroValue() Outer { // expect_effects: return_effects:0:Mid return_effects:0:Value.Child
 	var x Outer
 	return x
 }
@@ -272,4 +271,11 @@ func zeroValue() Outer { // expect_effects:
 // No return effects: a naked return has no explicit result expression.
 func nakedReturn() (out Outer) { // expect_effects:
 	return
+}
+
+// No return effects: `var x *Outer` is a nil pointer, not a zero-valued struct — it has no field
+// shape to summarize (its top-level nilness is the ordinary annotation machinery's job).
+func pointerZeroVar() *Outer { // expect_effects:
+	var x *Outer
+	return x
 }

--- a/nilaway_test.go
+++ b/nilaway_test.go
@@ -122,6 +122,7 @@ func TestStructInitV2(t *testing.T) { //nolint:paralleltest
 		"go.uber.org/structinitv2/paramfield",
 		"go.uber.org/structinitv2/paramsideeffect",
 		"go.uber.org/structinitv2/returnlocal",
+		"go.uber.org/structinitv2/returnzerovalue/app",
 	)
 }
 


### PR DESCRIPTION
Summarize zero-value struct locals (`var x Outer; return x`) as concrete allocations, so nil fields of a returned zero value are reported at dereference sites.

Changes
- Record value-less `var` declarations of struct type in `collectStructAllocationVars`, treating them like an empty composite literal (every nilable field nil).
- Skip pointer-typed declarations (var x *Outer): they declare a nil pointer with no field shape to summarize
- Wire `structinitv2/returnzerovalue/app` into `TestStructInitV2`