### PR TITLE
fix(struct-init-v2): include kind in context-site inference identity

### DIFF
--- a/annotation/structinitv2.go
+++ b/annotation/structinitv2.go
@@ -126,7 +126,10 @@ func (s *StructFieldContextSite) copy() Key {
 }
 
 func (s *StructFieldContextSite) String() string {
-	return fmt.Sprintf("field `%s` of %s", s.Path, boundaryDesc(s.Kind, s.Index, s.FuncObj.Name()))
+	// Kind value is included in String to differentiate param-in and param-out site. Without it the two
+	// would collapse into one inference site, conflating a parameter's entry value with its
+	// post-call state.
+	return fmt.Sprintf("field `%s` of kind %d %s", s.Path, s.Kind, boundaryDesc(s.Kind, s.Index, s.FuncObj.Name()))
 }
 
 // StructFieldFromContext is a producer: the value of a field (read from a boundary, e.g.

--- a/testdata/src/go.uber.org/structinitv2/paramsideeffect/paramsideeffect.go
+++ b/testdata/src/go.uber.org/structinitv2/paramsideeffect/paramsideeffect.go
@@ -164,3 +164,23 @@ func testStructObject() *int {
 	populate11(&b)
 	return b.newPtr.ptr
 }
+
+// Negative test: a callee that both reads through and writes the same parameter field creates
+// two context sites that differ only in kind: PARAM (the entry value, read via the guarded
+// deep access) and PARAM_OUT (the post-call value, unconditionally assigned). The two must stay
+// distinct inference sites: the nil entering at the call in m16 poisons only the entry site, so
+// the post-call dereference stays safe. If the kinds collapsed into one site, the nil argument
+// would falsely reach the post-call dereference.
+
+func readAndSet(x *A) {
+	if x.aptr != nil {
+		print(x.aptr.ptr) // deep read through `aptr`, guarded so safe here
+	}
+	x.aptr = &A{} // post-call x.aptr is never nil
+}
+
+func m16() {
+	b := &A{} // b.aptr is nil on entry to readAndSet
+	readAndSet(b)
+	print(b.aptr.ptr) // safe: readAndSet always assigns aptr before returning
+}


### PR DESCRIPTION
Include the context kind in `StructFieldContextSite.String()`, which the inference engine uses for site identity. Without it, param-in and param-out sites for the same function, index, and field path collapse into one site, conflating a parameter field's entry value with its post-call state — a nil argument field then falsely flags post-call dereferences even when the callee always assigns the field.

Changes
- Render `Kind` in `StructFieldContextSite.String()` so param-in and param-out sites stay distinct.
- Add a negative test in structinitv2/paramsideeffect that fails with a false positive without the fix.