### PR TITLE
Replace `Prestring` interface with generic `fmt.Stringer`

### DIFF
--- a/annotation/consume_trigger.go
+++ b/annotation/consume_trigger.go
@@ -39,7 +39,7 @@ type ConsumingAnnotationTrigger interface {
 	// for example - an `ArgPass` trigger triggers iff the corresponding function arg has
 	// nonNil type
 	CheckConsume(Map) bool
-	Prestring() Prestring
+	Prestring() fmt.Stringer
 
 	// Kind returns the kind of the trigger.
 	Kind() TriggerKind
@@ -68,13 +68,6 @@ type ConsumingAnnotationTrigger interface {
 	// SetNeedsGuard sets the underlying Guard-Neediness of this ConsumerTrigger, if present.
 	// Default setting for ConsumerTriggers is that they need a guard. Override this method to set the need for a guard to false.
 	SetNeedsGuard(bool)
-}
-
-// Prestring is an interface used to encode objects that have compact on-the-wire encodings
-// (via gob) but can still be expanded into verbose string representations on demand using
-// type information. These are key for compact encoding of InferredAnnotationMaps
-type Prestring interface {
-	String() string
 }
 
 // Assignment is a struct that represents an assignment to an expression
@@ -204,14 +197,14 @@ func (t *TriggerIfNonNil) AddAssignment(e Assignment) {
 	t.addEntry(e)
 }
 
-// Prestring returns this Prestring as a Prestring
-func (t *TriggerIfNonNil) Prestring() Prestring {
+// Prestring returns a compact string representation.
+func (t *TriggerIfNonNil) Prestring() fmt.Stringer {
 	return TriggerIfNonNilPrestring{
 		AssignmentStr: t.String(),
 	}
 }
 
-// TriggerIfNonNilPrestring is a Prestring storing the needed information to compactly encode a TriggerIfNonNil
+// TriggerIfNonNilPrestring is a fmt.Stringer storing the needed information to compactly encode a TriggerIfNonNil
 type TriggerIfNonNilPrestring struct {
 	AssignmentStr string
 }
@@ -275,14 +268,14 @@ func (t *TriggerIfDeepNonNil) AddAssignment(e Assignment) {
 	t.addEntry(e)
 }
 
-// Prestring returns this Prestring as a Prestring
-func (t *TriggerIfDeepNonNil) Prestring() Prestring {
+// Prestring returns a compact string representation.
+func (t *TriggerIfDeepNonNil) Prestring() fmt.Stringer {
 	return TriggerIfDeepNonNilPrestring{
 		AssignmentStr: t.String(),
 	}
 }
 
-// TriggerIfDeepNonNilPrestring is a Prestring storing the needed information to compactly encode a TriggerIfDeepNonNil
+// TriggerIfDeepNonNilPrestring is a fmt.Stringer storing the needed information to compactly encode a TriggerIfDeepNonNil
 type TriggerIfDeepNonNilPrestring struct {
 	AssignmentStr string
 }
@@ -341,14 +334,14 @@ func (c *ConsumeTriggerTautology) AddAssignment(e Assignment) {
 	c.addEntry(e)
 }
 
-// Prestring returns this Prestring as a Prestring
-func (c *ConsumeTriggerTautology) Prestring() Prestring {
+// Prestring returns a compact string representation.
+func (c *ConsumeTriggerTautology) Prestring() fmt.Stringer {
 	return ConsumeTriggerTautologyPrestring{
 		AssignmentStr: c.String(),
 	}
 }
 
-// ConsumeTriggerTautologyPrestring is a Prestring storing the needed information to compactly encode a ConsumeTriggerTautology
+// ConsumeTriggerTautologyPrestring is a fmt.Stringer storing the needed information to compactly encode a ConsumeTriggerTautology
 type ConsumeTriggerTautologyPrestring struct {
 	AssignmentStr string
 }
@@ -380,14 +373,14 @@ func (p *PtrLoad) Copy() ConsumingAnnotationTrigger {
 	return &copyConsumer
 }
 
-// Prestring returns this PtrLoad as a Prestring
-func (p *PtrLoad) Prestring() Prestring {
+// Prestring returns this PtrLoad as a fmt.Stringer
+func (p *PtrLoad) Prestring() fmt.Stringer {
 	return PtrLoadPrestring{
 		AssignmentStr: p.String(),
 	}
 }
 
-// PtrLoadPrestring is a Prestring storing the needed information to compactly encode a PtrLoad
+// PtrLoadPrestring is a fmt.Stringer storing the needed information to compactly encode a PtrLoad
 type PtrLoadPrestring struct {
 	AssignmentStr string
 }
@@ -421,14 +414,14 @@ func (i *MapAccess) Copy() ConsumingAnnotationTrigger {
 	return &copyConsumer
 }
 
-// Prestring returns this MapAccess as a Prestring
-func (i *MapAccess) Prestring() Prestring {
+// Prestring returns this MapAccess as a fmt.Stringer
+func (i *MapAccess) Prestring() fmt.Stringer {
 	return MapAccessPrestring{
 		AssignmentStr: i.String(),
 	}
 }
 
-// MapAccessPrestring is a Prestring storing the needed information to compactly encode a MapAccess
+// MapAccessPrestring is a fmt.Stringer storing the needed information to compactly encode a MapAccess
 type MapAccessPrestring struct {
 	AssignmentStr string
 }
@@ -461,14 +454,14 @@ func (m *MapWrittenTo) Copy() ConsumingAnnotationTrigger {
 	return &copyConsumer
 }
 
-// Prestring returns this MapWrittenTo as a Prestring
-func (m *MapWrittenTo) Prestring() Prestring {
+// Prestring returns this MapWrittenTo as a fmt.Stringer
+func (m *MapWrittenTo) Prestring() fmt.Stringer {
 	return MapWrittenToPrestring{
 		AssignmentStr: m.String(),
 	}
 }
 
-// MapWrittenToPrestring is a Prestring storing the needed information to compactly encode a MapWrittenTo
+// MapWrittenToPrestring is a fmt.Stringer storing the needed information to compactly encode a MapWrittenTo
 type MapWrittenToPrestring struct {
 	AssignmentStr string
 }
@@ -500,14 +493,14 @@ func (s *SliceAccess) Copy() ConsumingAnnotationTrigger {
 	return &copyConsumer
 }
 
-// Prestring returns this SliceAccess as a Prestring
-func (s *SliceAccess) Prestring() Prestring {
+// Prestring returns this SliceAccess as a fmt.Stringer
+func (s *SliceAccess) Prestring() fmt.Stringer {
 	return SliceAccessPrestring{
 		AssignmentStr: s.String(),
 	}
 }
 
-// SliceAccessPrestring is a Prestring storing the needed information to compactly encode a SliceAccess
+// SliceAccessPrestring is a fmt.Stringer storing the needed information to compactly encode a SliceAccess
 type SliceAccessPrestring struct {
 	AssignmentStr string
 }
@@ -541,8 +534,8 @@ func (f *FldAccess) Copy() ConsumingAnnotationTrigger {
 	return &copyConsumer
 }
 
-// Prestring returns this FldAccess as a Prestring
-func (f *FldAccess) Prestring() Prestring {
+// Prestring returns this FldAccess as a fmt.Stringer
+func (f *FldAccess) Prestring() fmt.Stringer {
 	fieldName, methodName := "", ""
 	switch t := f.Sel.(type) {
 	case *types.Var:
@@ -560,7 +553,7 @@ func (f *FldAccess) Prestring() Prestring {
 	}
 }
 
-// FldAccessPrestring is a Prestring storing the needed information to compactly encode a FldAccess
+// FldAccessPrestring is a fmt.Stringer storing the needed information to compactly encode a FldAccess
 type FldAccessPrestring struct {
 	FieldName     string
 	MethodName    string
@@ -603,8 +596,8 @@ func (u *UseAsErrorResult) Copy() ConsumingAnnotationTrigger {
 	return &copyConsumer
 }
 
-// Prestring returns this UseAsErrorResult as a Prestring
-func (u *UseAsErrorResult) Prestring() Prestring {
+// Prestring returns this UseAsErrorResult as a fmt.Stringer
+func (u *UseAsErrorResult) Prestring() fmt.Stringer {
 	retAnn := u.Ann.(*RetAnnotationKey)
 	return UseAsErrorResultPrestring{
 		Pos:              retAnn.RetNum,
@@ -615,7 +608,7 @@ func (u *UseAsErrorResult) Prestring() Prestring {
 	}
 }
 
-// UseAsErrorResultPrestring is a Prestring storing the needed information to compactly encode a UseAsErrorResult
+// UseAsErrorResultPrestring is a fmt.Stringer storing the needed information to compactly encode a UseAsErrorResult
 type UseAsErrorResultPrestring struct {
 	Pos              int
 	ReturningFuncStr string
@@ -663,8 +656,8 @@ func (f *FldAssign) Copy() ConsumingAnnotationTrigger {
 	return &copyConsumer
 }
 
-// Prestring returns this FldAssign as a Prestring
-func (f *FldAssign) Prestring() Prestring {
+// Prestring returns this FldAssign as a fmt.Stringer
+func (f *FldAssign) Prestring() fmt.Stringer {
 	fldAnn := f.Ann.(*FieldAnnotationKey)
 	return FldAssignPrestring{
 		FieldName:     fldAnn.FieldDecl.Name(),
@@ -672,7 +665,7 @@ func (f *FldAssign) Prestring() Prestring {
 	}
 }
 
-// FldAssignPrestring is a Prestring storing the needed information to compactly encode a FldAssign
+// FldAssignPrestring is a fmt.Stringer storing the needed information to compactly encode a FldAssign
 type FldAssignPrestring struct {
 	FieldName     string
 	AssignmentStr string
@@ -707,8 +700,8 @@ func (f *ArgFldPass) Copy() ConsumingAnnotationTrigger {
 	return &copyConsumer
 }
 
-// Prestring returns this ArgFldPass as a Prestring
-func (f *ArgFldPass) Prestring() Prestring {
+// Prestring returns this ArgFldPass as a fmt.Stringer
+func (f *ArgFldPass) Prestring() fmt.Stringer {
 	ann := f.Ann.(*ParamFieldAnnotationKey)
 	recvName := ""
 	if ann.IsReceiver() {
@@ -725,7 +718,7 @@ func (f *ArgFldPass) Prestring() Prestring {
 	}
 }
 
-// ArgFldPassPrestring is a Prestring storing the needed information to compactly encode a ArgFldPass
+// ArgFldPassPrestring is a fmt.Stringer storing the needed information to compactly encode a ArgFldPass
 type ArgFldPassPrestring struct {
 	FieldName     string
 	FuncName      string
@@ -772,8 +765,8 @@ func (g *GlobalVarAssign) Copy() ConsumingAnnotationTrigger {
 	return &copyConsumer
 }
 
-// Prestring returns this GlobalVarAssign as a Prestring
-func (g *GlobalVarAssign) Prestring() Prestring {
+// Prestring returns this GlobalVarAssign as a fmt.Stringer
+func (g *GlobalVarAssign) Prestring() fmt.Stringer {
 	varAnn := g.Ann.(*GlobalVarAnnotationKey)
 	return GlobalVarAssignPrestring{
 		VarName:       varAnn.VarDecl.Name(),
@@ -781,7 +774,7 @@ func (g *GlobalVarAssign) Prestring() Prestring {
 	}
 }
 
-// GlobalVarAssignPrestring is a Prestring storing the needed information to compactly encode a GlobalVarAssign
+// GlobalVarAssignPrestring is a fmt.Stringer storing the needed information to compactly encode a GlobalVarAssign
 type GlobalVarAssignPrestring struct {
 	VarName       string
 	AssignmentStr string
@@ -819,8 +812,8 @@ func (a *ArgPass) Copy() ConsumingAnnotationTrigger {
 	return &copyConsumer
 }
 
-// Prestring returns this ArgPass as a Prestring
-func (a *ArgPass) Prestring() Prestring {
+// Prestring returns this ArgPass as a fmt.Stringer
+func (a *ArgPass) Prestring() fmt.Stringer {
 	switch key := a.Ann.(type) {
 	case *ParamAnnotationKey:
 		return ArgPassPrestring{
@@ -842,7 +835,7 @@ func (a *ArgPass) Prestring() Prestring {
 	}
 }
 
-// ArgPassPrestring is a Prestring storing the needed information to compactly encode a ArgPass
+// ArgPassPrestring is a fmt.Stringer storing the needed information to compactly encode a ArgPass
 type ArgPassPrestring struct {
 	ParamName string
 	FuncName  string
@@ -882,8 +875,8 @@ func (a *ArgPassDeep) Copy() ConsumingAnnotationTrigger {
 	return &copyConsumer
 }
 
-// Prestring returns this ArgPassDeep as a Prestring
-func (a *ArgPassDeep) Prestring() Prestring {
+// Prestring returns this ArgPassDeep as a fmt.Stringer
+func (a *ArgPassDeep) Prestring() fmt.Stringer {
 	switch key := a.Ann.(type) {
 	case *ParamAnnotationKey:
 		return ArgPassPrestring{
@@ -905,7 +898,7 @@ func (a *ArgPassDeep) Prestring() Prestring {
 	}
 }
 
-// ArgPassDeepPrestring is a Prestring storing the needed information to compactly encode a ArgPassDeep
+// ArgPassDeepPrestring is a fmt.Stringer storing the needed information to compactly encode a ArgPassDeep
 type ArgPassDeepPrestring struct {
 	ParamName string
 	FuncName  string
@@ -946,8 +939,8 @@ func (a *RecvPass) Copy() ConsumingAnnotationTrigger {
 	return &copyConsumer
 }
 
-// Prestring returns this RecvPass as a Prestring
-func (a *RecvPass) Prestring() Prestring {
+// Prestring returns this RecvPass as a fmt.Stringer
+func (a *RecvPass) Prestring() fmt.Stringer {
 	recvAnn := a.Ann.(*RecvAnnotationKey)
 	return RecvPassPrestring{
 		FuncName:      recvAnn.FuncDecl.Name(),
@@ -955,7 +948,7 @@ func (a *RecvPass) Prestring() Prestring {
 	}
 }
 
-// RecvPassPrestring is a Prestring storing the needed information to compactly encode a RecvPass
+// RecvPassPrestring is a fmt.Stringer storing the needed information to compactly encode a RecvPass
 type RecvPassPrestring struct {
 	FuncName      string
 	AssignmentStr string
@@ -991,8 +984,8 @@ func (i *InterfaceResultFromImplementation) Copy() ConsumingAnnotationTrigger {
 	return &copyConsumer
 }
 
-// Prestring returns this InterfaceResultFromImplementation as a Prestring
-func (i *InterfaceResultFromImplementation) Prestring() Prestring {
+// Prestring returns this InterfaceResultFromImplementation as a fmt.Stringer
+func (i *InterfaceResultFromImplementation) Prestring() fmt.Stringer {
 	retAnn := i.Ann.(*RetAnnotationKey)
 	return InterfaceResultFromImplementationPrestring{
 		retAnn.RetNum,
@@ -1002,7 +995,7 @@ func (i *InterfaceResultFromImplementation) Prestring() Prestring {
 	}
 }
 
-// InterfaceResultFromImplementationPrestring is a Prestring storing the needed information to compactly encode a InterfaceResultFromImplementation
+// InterfaceResultFromImplementationPrestring is a fmt.Stringer storing the needed information to compactly encode a InterfaceResultFromImplementation
 type InterfaceResultFromImplementationPrestring struct {
 	RetNum        int
 	IntName       string
@@ -1041,8 +1034,8 @@ func (m *MethodParamFromInterface) Copy() ConsumingAnnotationTrigger {
 	return &copyConsumer
 }
 
-// Prestring returns this MethodParamFromInterface as a Prestring
-func (m *MethodParamFromInterface) Prestring() Prestring {
+// Prestring returns this MethodParamFromInterface as a fmt.Stringer
+func (m *MethodParamFromInterface) Prestring() fmt.Stringer {
 	paramAnn := m.Ann.(*ParamAnnotationKey)
 	return MethodParamFromInterfacePrestring{
 		paramAnn.ParamNameString(),
@@ -1052,7 +1045,7 @@ func (m *MethodParamFromInterface) Prestring() Prestring {
 	}
 }
 
-// MethodParamFromInterfacePrestring is a Prestring storing the needed information to compactly encode a MethodParamFromInterface
+// MethodParamFromInterfacePrestring is a fmt.Stringer storing the needed information to compactly encode a MethodParamFromInterface
 type MethodParamFromInterfacePrestring struct {
 	ParamName     string
 	ImplName      string
@@ -1116,8 +1109,8 @@ func (u *UseAsReturn) Copy() ConsumingAnnotationTrigger {
 	return &copyConsumer
 }
 
-// Prestring returns this UseAsReturn as a Prestring
-func (u *UseAsReturn) Prestring() Prestring {
+// Prestring returns this UseAsReturn as a fmt.Stringer
+func (u *UseAsReturn) Prestring() fmt.Stringer {
 	switch key := u.Ann.(type) {
 	case *RetAnnotationKey:
 		return UseAsReturnPrestring{
@@ -1142,7 +1135,7 @@ func (u *UseAsReturn) Prestring() Prestring {
 	}
 }
 
-// UseAsReturnPrestring is a Prestring storing the needed information to compactly encode a UseAsReturn
+// UseAsReturnPrestring is a fmt.Stringer storing the needed information to compactly encode a UseAsReturn
 type UseAsReturnPrestring struct {
 	FuncName      string
 	RetNum        int
@@ -1202,8 +1195,8 @@ func (u *UseAsReturnDeep) Copy() ConsumingAnnotationTrigger {
 	return &copyConsumer
 }
 
-// Prestring returns this UseAsReturn as a Prestring
-func (u *UseAsReturnDeep) Prestring() Prestring {
+// Prestring returns this UseAsReturn as a fmt.Stringer
+func (u *UseAsReturnDeep) Prestring() fmt.Stringer {
 	key := u.Ann.(*RetAnnotationKey)
 	return UseAsReturnDeepPrestring{
 		key.FuncDecl.Name(),
@@ -1213,7 +1206,7 @@ func (u *UseAsReturnDeep) Prestring() Prestring {
 	}
 }
 
-// UseAsReturnDeepPrestring is a Prestring storing the needed information to compactly encode a UseAsReturnDeep
+// UseAsReturnDeepPrestring is a fmt.Stringer storing the needed information to compactly encode a UseAsReturnDeep
 type UseAsReturnDeepPrestring struct {
 	FuncName      string
 	RetNum        int
@@ -1261,8 +1254,8 @@ func (u *UseAsFldOfReturn) Copy() ConsumingAnnotationTrigger {
 	return &copyConsumer
 }
 
-// Prestring returns this UseAsFldOfReturn as a Prestring
-func (u *UseAsFldOfReturn) Prestring() Prestring {
+// Prestring returns this UseAsFldOfReturn as a fmt.Stringer
+func (u *UseAsFldOfReturn) Prestring() fmt.Stringer {
 	retAnn := u.Ann.(*RetFieldAnnotationKey)
 	return UseAsFldOfReturnPrestring{
 		retAnn.FuncDecl.Name(),
@@ -1272,7 +1265,7 @@ func (u *UseAsFldOfReturn) Prestring() Prestring {
 	}
 }
 
-// UseAsFldOfReturnPrestring is a Prestring storing the needed information to compactly encode a UseAsFldOfReturn
+// UseAsFldOfReturnPrestring is a fmt.Stringer storing the needed information to compactly encode a UseAsFldOfReturn
 type UseAsFldOfReturnPrestring struct {
 	FuncName      string
 	FieldName     string
@@ -1343,8 +1336,8 @@ func (f *SliceAssign) Copy() ConsumingAnnotationTrigger {
 	return &copyConsumer
 }
 
-// Prestring returns this SliceAssign as a Prestring
-func (f *SliceAssign) Prestring() Prestring {
+// Prestring returns this SliceAssign as a fmt.Stringer
+func (f *SliceAssign) Prestring() fmt.Stringer {
 	fldAnn := f.Ann.(*TypeNameAnnotationKey)
 	return SliceAssignPrestring{
 		fldAnn.TypeDecl.Name(),
@@ -1352,7 +1345,7 @@ func (f *SliceAssign) Prestring() Prestring {
 	}
 }
 
-// SliceAssignPrestring is a Prestring storing the needed information to compactly encode a SliceAssign
+// SliceAssignPrestring is a fmt.Stringer storing the needed information to compactly encode a SliceAssign
 type SliceAssignPrestring struct {
 	TypeName      string
 	AssignmentStr string
@@ -1385,8 +1378,8 @@ func (a *ArrayAssign) Copy() ConsumingAnnotationTrigger {
 	return &copyConsumer
 }
 
-// Prestring returns this ArrayAssign as a Prestring
-func (a *ArrayAssign) Prestring() Prestring {
+// Prestring returns this ArrayAssign as a fmt.Stringer
+func (a *ArrayAssign) Prestring() fmt.Stringer {
 	fldAnn := a.Ann.(*TypeNameAnnotationKey)
 	return ArrayAssignPrestring{
 		fldAnn.TypeDecl.Name(),
@@ -1394,7 +1387,7 @@ func (a *ArrayAssign) Prestring() Prestring {
 	}
 }
 
-// ArrayAssignPrestring is a Prestring storing the needed information to compactly encode a SliceAssign
+// ArrayAssignPrestring is a fmt.Stringer storing the needed information to compactly encode a SliceAssign
 type ArrayAssignPrestring struct {
 	TypeName      string
 	AssignmentStr string
@@ -1427,8 +1420,8 @@ func (f *PtrAssign) Copy() ConsumingAnnotationTrigger {
 	return &copyConsumer
 }
 
-// Prestring returns this PtrAssign as a Prestring
-func (f *PtrAssign) Prestring() Prestring {
+// Prestring returns this PtrAssign as a fmt.Stringer
+func (f *PtrAssign) Prestring() fmt.Stringer {
 	fldAnn := f.Ann.(*TypeNameAnnotationKey)
 	return PtrAssignPrestring{
 		fldAnn.TypeDecl.Name(),
@@ -1436,7 +1429,7 @@ func (f *PtrAssign) Prestring() Prestring {
 	}
 }
 
-// PtrAssignPrestring is a Prestring storing the needed information to compactly encode a PtrAssign
+// PtrAssignPrestring is a fmt.Stringer storing the needed information to compactly encode a PtrAssign
 type PtrAssignPrestring struct {
 	TypeName      string
 	AssignmentStr string
@@ -1469,8 +1462,8 @@ func (f *MapAssign) Copy() ConsumingAnnotationTrigger {
 	return &copyConsumer
 }
 
-// Prestring returns this MapAssign as a Prestring
-func (f *MapAssign) Prestring() Prestring {
+// Prestring returns this MapAssign as a fmt.Stringer
+func (f *MapAssign) Prestring() fmt.Stringer {
 	fldAnn := f.Ann.(*TypeNameAnnotationKey)
 	return MapAssignPrestring{
 		fldAnn.TypeDecl.Name(),
@@ -1478,7 +1471,7 @@ func (f *MapAssign) Prestring() Prestring {
 	}
 }
 
-// MapAssignPrestring is a Prestring storing the needed information to compactly encode a MapAssign
+// MapAssignPrestring is a fmt.Stringer storing the needed information to compactly encode a MapAssign
 type MapAssignPrestring struct {
 	TypeName      string
 	AssignmentStr string
@@ -1512,14 +1505,14 @@ func (d *DeepAssignPrimitive) Copy() ConsumingAnnotationTrigger {
 	return &copyConsumer
 }
 
-// Prestring returns this Prestring as a Prestring
-func (d *DeepAssignPrimitive) Prestring() Prestring {
+// Prestring returns a compact string representation.
+func (d *DeepAssignPrimitive) Prestring() fmt.Stringer {
 	return DeepAssignPrimitivePrestring{
 		AssignmentStr: d.String(),
 	}
 }
 
-// DeepAssignPrimitivePrestring is a Prestring storing the needed information to compactly encode a DeepAssignPrimitive
+// DeepAssignPrimitivePrestring is a fmt.Stringer storing the needed information to compactly encode a DeepAssignPrimitive
 type DeepAssignPrimitivePrestring struct {
 	AssignmentStr string
 }
@@ -1551,15 +1544,15 @@ func (p *ParamAssignDeep) Copy() ConsumingAnnotationTrigger {
 	return &copyConsumer
 }
 
-// Prestring returns this ParamAssignDeep as a Prestring
-func (p *ParamAssignDeep) Prestring() Prestring {
+// Prestring returns this ParamAssignDeep as a fmt.Stringer
+func (p *ParamAssignDeep) Prestring() fmt.Stringer {
 	return ParamAssignDeepPrestring{
 		p.Ann.(*ParamAnnotationKey).MinimalString(),
 		p.String(),
 	}
 }
 
-// ParamAssignDeepPrestring is a Prestring storing the needed information to compactly encode a ParamAssignDeep
+// ParamAssignDeepPrestring is a fmt.Stringer storing the needed information to compactly encode a ParamAssignDeep
 type ParamAssignDeepPrestring struct {
 	ParamName     string
 	AssignmentStr string
@@ -1592,8 +1585,8 @@ func (f *FuncRetAssignDeep) Copy() ConsumingAnnotationTrigger {
 	return &copyConsumer
 }
 
-// Prestring returns this FuncRetAssignDeep as a Prestring
-func (f *FuncRetAssignDeep) Prestring() Prestring {
+// Prestring returns this FuncRetAssignDeep as a fmt.Stringer
+func (f *FuncRetAssignDeep) Prestring() fmt.Stringer {
 	retAnn := f.Ann.(*RetAnnotationKey)
 	return FuncRetAssignDeepPrestring{
 		retAnn.FuncDecl.Name(),
@@ -1602,7 +1595,7 @@ func (f *FuncRetAssignDeep) Prestring() Prestring {
 	}
 }
 
-// FuncRetAssignDeepPrestring is a Prestring storing the needed information to compactly encode a FuncRetAssignDeep
+// FuncRetAssignDeepPrestring is a fmt.Stringer storing the needed information to compactly encode a FuncRetAssignDeep
 type FuncRetAssignDeepPrestring struct {
 	FuncName      string
 	RetNum        int
@@ -1637,8 +1630,8 @@ func (v *VariadicParamAssignDeep) Copy() ConsumingAnnotationTrigger {
 	return &copyConsumer
 }
 
-// Prestring returns this VariadicParamAssignDeep as a Prestring
-func (v *VariadicParamAssignDeep) Prestring() Prestring {
+// Prestring returns this VariadicParamAssignDeep as a fmt.Stringer
+func (v *VariadicParamAssignDeep) Prestring() fmt.Stringer {
 	paramAnn := v.Ann.(*ParamAnnotationKey)
 	return VariadicParamAssignDeepPrestring{
 		ParamName:     paramAnn.MinimalString(),
@@ -1646,7 +1639,7 @@ func (v *VariadicParamAssignDeep) Prestring() Prestring {
 	}
 }
 
-// VariadicParamAssignDeepPrestring is a Prestring storing the needed information to compactly encode a VariadicParamAssignDeep
+// VariadicParamAssignDeepPrestring is a fmt.Stringer storing the needed information to compactly encode a VariadicParamAssignDeep
 type VariadicParamAssignDeepPrestring struct {
 	ParamName     string
 	AssignmentStr string
@@ -1679,8 +1672,8 @@ func (f *FieldAssignDeep) Copy() ConsumingAnnotationTrigger {
 	return &copyConsumer
 }
 
-// Prestring returns this FieldAssignDeep as a Prestring
-func (f *FieldAssignDeep) Prestring() Prestring {
+// Prestring returns this FieldAssignDeep as a fmt.Stringer
+func (f *FieldAssignDeep) Prestring() fmt.Stringer {
 	fldAnn := f.Ann.(*FieldAnnotationKey)
 	return FieldAssignDeepPrestring{
 		fldAnn.FieldDecl.Name(),
@@ -1688,7 +1681,7 @@ func (f *FieldAssignDeep) Prestring() Prestring {
 	}
 }
 
-// FieldAssignDeepPrestring is a Prestring storing the needed information to compactly encode a FieldAssignDeep
+// FieldAssignDeepPrestring is a fmt.Stringer storing the needed information to compactly encode a FieldAssignDeep
 type FieldAssignDeepPrestring struct {
 	FldName       string
 	AssignmentStr string
@@ -1721,8 +1714,8 @@ func (g *GlobalVarAssignDeep) Copy() ConsumingAnnotationTrigger {
 	return &copyConsumer
 }
 
-// Prestring returns this GlobalVarAssignDeep as a Prestring
-func (g *GlobalVarAssignDeep) Prestring() Prestring {
+// Prestring returns this GlobalVarAssignDeep as a fmt.Stringer
+func (g *GlobalVarAssignDeep) Prestring() fmt.Stringer {
 	varAnn := g.Ann.(*GlobalVarAnnotationKey)
 	return GlobalVarAssignDeepPrestring{
 		varAnn.VarDecl.Name(),
@@ -1730,7 +1723,7 @@ func (g *GlobalVarAssignDeep) Prestring() Prestring {
 	}
 }
 
-// GlobalVarAssignDeepPrestring is a Prestring storing the needed information to compactly encode a GlobalVarAssignDeep
+// GlobalVarAssignDeepPrestring is a fmt.Stringer storing the needed information to compactly encode a GlobalVarAssignDeep
 type GlobalVarAssignDeepPrestring struct {
 	VarName       string
 	AssignmentStr string
@@ -1763,15 +1756,15 @@ func (l *LocalVarAssignDeep) Copy() ConsumingAnnotationTrigger {
 	return &copyConsumer
 }
 
-// Prestring returns this LocalVarAssignDeep as a Prestring
-func (l *LocalVarAssignDeep) Prestring() Prestring {
+// Prestring returns this LocalVarAssignDeep as a fmt.Stringer
+func (l *LocalVarAssignDeep) Prestring() fmt.Stringer {
 	return LocalVarAssignDeepPrestring{
 		VarName:       l.Ann.(*LocalVarAnnotationKey).VarDecl.Name(),
 		AssignmentStr: l.String(),
 	}
 }
 
-// LocalVarAssignDeepPrestring is a Prestring storing the needed information to compactly encode a LocalVarAssignDeep
+// LocalVarAssignDeepPrestring is a fmt.Stringer storing the needed information to compactly encode a LocalVarAssignDeep
 type LocalVarAssignDeepPrestring struct {
 	VarName       string
 	AssignmentStr string
@@ -1804,8 +1797,8 @@ func (c *ChanSend) Copy() ConsumingAnnotationTrigger {
 	return &copyConsumer
 }
 
-// Prestring returns this ChanSend as a Prestring
-func (c *ChanSend) Prestring() Prestring {
+// Prestring returns this ChanSend as a fmt.Stringer
+func (c *ChanSend) Prestring() fmt.Stringer {
 	typeAnn := c.Ann.(*TypeNameAnnotationKey)
 	return ChanSendPrestring{
 		typeAnn.TypeDecl.Name(),
@@ -1813,7 +1806,7 @@ func (c *ChanSend) Prestring() Prestring {
 	}
 }
 
-// ChanSendPrestring is a Prestring storing the needed information to compactly encode a ChanSend
+// ChanSendPrestring is a fmt.Stringer storing the needed information to compactly encode a ChanSend
 type ChanSendPrestring struct {
 	TypeName      string
 	AssignmentStr string
@@ -1853,8 +1846,8 @@ func (f *FldEscape) Copy() ConsumingAnnotationTrigger {
 	return &copyConsumer
 }
 
-// Prestring returns this FldEscape as a Prestring
-func (f *FldEscape) Prestring() Prestring {
+// Prestring returns this FldEscape as a fmt.Stringer
+func (f *FldEscape) Prestring() fmt.Stringer {
 	ann := f.Ann.(*EscapeFieldAnnotationKey)
 	return FldEscapePrestring{
 		FieldName:     ann.FieldDecl.Name(),
@@ -1862,7 +1855,7 @@ func (f *FldEscape) Prestring() Prestring {
 	}
 }
 
-// FldEscapePrestring is a Prestring storing the needed information to compactly encode a FldEscape
+// FldEscapePrestring is a fmt.Stringer storing the needed information to compactly encode a FldEscape
 type FldEscapePrestring struct {
 	FieldName     string
 	AssignmentStr string
@@ -1900,8 +1893,8 @@ func (u *UseAsNonErrorRetDependentOnErrorRetNilability) Copy() ConsumingAnnotati
 	return &copyConsumer
 }
 
-// Prestring returns this UseAsNonErrorRetDependentOnErrorRetNilability as a Prestring
-func (u *UseAsNonErrorRetDependentOnErrorRetNilability) Prestring() Prestring {
+// Prestring returns this UseAsNonErrorRetDependentOnErrorRetNilability as a fmt.Stringer
+func (u *UseAsNonErrorRetDependentOnErrorRetNilability) Prestring() fmt.Stringer {
 	retAnn := u.Ann.(*RetAnnotationKey)
 	return UseAsNonErrorRetDependentOnErrorRetNilabilityPrestring{
 		retAnn.FuncDecl.Name(),
@@ -1913,7 +1906,7 @@ func (u *UseAsNonErrorRetDependentOnErrorRetNilability) Prestring() Prestring {
 	}
 }
 
-// UseAsNonErrorRetDependentOnErrorRetNilabilityPrestring is a Prestring storing the needed information to compactly encode a UseAsNonErrorRetDependentOnErrorRetNilability
+// UseAsNonErrorRetDependentOnErrorRetNilabilityPrestring is a fmt.Stringer storing the needed information to compactly encode a UseAsNonErrorRetDependentOnErrorRetNilability
 type UseAsNonErrorRetDependentOnErrorRetNilabilityPrestring struct {
 	FuncName      string
 	RetNum        int
@@ -1969,8 +1962,8 @@ func (u *UseAsErrorRetWithNilabilityUnknown) Copy() ConsumingAnnotationTrigger {
 	return &copyConsumer
 }
 
-// Prestring returns this UseAsErrorRetWithNilabilityUnknown as a Prestring
-func (u *UseAsErrorRetWithNilabilityUnknown) Prestring() Prestring {
+// Prestring returns this UseAsErrorRetWithNilabilityUnknown as a fmt.Stringer
+func (u *UseAsErrorRetWithNilabilityUnknown) Prestring() fmt.Stringer {
 	retAnn := u.Ann.(*RetAnnotationKey)
 	return UseAsErrorRetWithNilabilityUnknownPrestring{
 		retAnn.FuncDecl.Name(),
@@ -1981,7 +1974,7 @@ func (u *UseAsErrorRetWithNilabilityUnknown) Prestring() Prestring {
 	}
 }
 
-// UseAsErrorRetWithNilabilityUnknownPrestring is a Prestring storing the needed information to compactly encode a UseAsErrorRetWithNilabilityUnknown
+// UseAsErrorRetWithNilabilityUnknownPrestring is a fmt.Stringer storing the needed information to compactly encode a UseAsErrorRetWithNilabilityUnknown
 type UseAsErrorRetWithNilabilityUnknownPrestring struct {
 	FuncName      string
 	RetNum        int

--- a/annotation/full_trigger.go
+++ b/annotation/full_trigger.go
@@ -91,9 +91,9 @@ func (t *FullTrigger) equalsModuloGuardMatched(other FullTrigger) bool {
 		t.Consumer.Expr == other.Consumer.Expr
 }
 
-// A LocatedPrestring wraps another Prestring with a `token.Position` - for formatting with that position
+// A LocatedPrestring wraps another fmt.Stringer with a `token.Position` - for formatting with that position
 type LocatedPrestring struct {
-	Contained Prestring
+	Contained fmt.Stringer
 	Location  token.Position
 }
 
@@ -112,7 +112,7 @@ func (l LocatedPrestring) String() string {
 // with artifical expression generated from the position of that consumer in the assertion tree,
 // and producers that arise from non-trackable expressions correspond to those real non-trackable
 // expressions.
-func (t *FullTrigger) Prestrings(pass *analysishelper.EnhancedPass) (Prestring, Prestring) {
+func (t *FullTrigger) Prestrings(pass *analysishelper.EnhancedPass) (fmt.Stringer, fmt.Stringer) {
 	producerPrestring := t.Producer.Annotation.Prestring()
 	if pass.ExprIsAuthentic(t.Producer.Expr) {
 		producerPrestring = LocatedPrestring{

--- a/annotation/helper_test.go
+++ b/annotation/helper_test.go
@@ -86,9 +86,9 @@ func (m *mockProducingAnnotationTrigger) SetNeedsGuard(b bool) {
 	m.Called(b)
 }
 
-func (m *mockProducingAnnotationTrigger) Prestring() Prestring {
+func (m *mockProducingAnnotationTrigger) Prestring() fmt.Stringer {
 	args := m.Called()
-	return args.Get(0).(Prestring)
+	return args.Get(0).(fmt.Stringer)
 }
 
 func (m *mockProducingAnnotationTrigger) Kind() TriggerKind {

--- a/annotation/produce_trigger.go
+++ b/annotation/produce_trigger.go
@@ -53,7 +53,7 @@ type ProducingAnnotationTrigger interface {
 	// Default setting for ProduceTriggers is to not need a guard.
 	SetNeedsGuard(bool)
 
-	Prestring() Prestring
+	Prestring() fmt.Stringer
 
 	// Kind returns the kind of the trigger.
 	Kind() TriggerKind
@@ -73,12 +73,12 @@ type TriggerIfNilable struct {
 	NeedsGuard bool
 }
 
-// Prestring returns this Prestring as a Prestring
-func (*TriggerIfNilable) Prestring() Prestring {
+// Prestring returns a compact string representation.
+func (*TriggerIfNilable) Prestring() fmt.Stringer {
 	return TriggerIfNilablePrestring{}
 }
 
-// TriggerIfNilablePrestring is a Prestring storing the needed information to compactly encode a TriggerIfNilable
+// TriggerIfNilablePrestring is a fmt.Stringer storing the needed information to compactly encode a TriggerIfNilable
 type TriggerIfNilablePrestring struct{}
 
 func (TriggerIfNilablePrestring) String() string {
@@ -118,12 +118,12 @@ type TriggerIfDeepNilable struct {
 	NeedsGuard bool
 }
 
-// Prestring returns this Prestring as a Prestring
-func (*TriggerIfDeepNilable) Prestring() Prestring {
+// Prestring returns a compact string representation.
+func (*TriggerIfDeepNilable) Prestring() fmt.Stringer {
 	return TriggerIfDeepNilablePrestring{}
 }
 
-// TriggerIfDeepNilablePrestring is a Prestring storing the needed information to compactly encode a TriggerIfDeepNilable
+// TriggerIfDeepNilablePrestring is a fmt.Stringer storing the needed information to compactly encode a TriggerIfDeepNilable
 type TriggerIfDeepNilablePrestring struct{}
 
 func (TriggerIfDeepNilablePrestring) String() string {
@@ -174,12 +174,12 @@ func (p *ProduceTriggerTautology) NeedsGuardMatch() bool {
 // SetNeedsGuard sets the underlying Guard-Neediness of this ProduceTrigger, if present
 func (p *ProduceTriggerTautology) SetNeedsGuard(b bool) { p.NeedsGuard = b }
 
-// Prestring returns this Prestring as a Prestring
-func (*ProduceTriggerTautology) Prestring() Prestring {
+// Prestring returns a compact string representation.
+func (*ProduceTriggerTautology) Prestring() fmt.Stringer {
 	return ProduceTriggerTautologyPrestring{}
 }
 
-// ProduceTriggerTautologyPrestring is a Prestring storing the needed information to compactly encode a ProduceTriggerTautology
+// ProduceTriggerTautologyPrestring is a fmt.Stringer storing the needed information to compactly encode a ProduceTriggerTautology
 type ProduceTriggerTautologyPrestring struct{}
 
 func (ProduceTriggerTautologyPrestring) String() string {
@@ -205,12 +205,12 @@ type ProduceTriggerNever struct {
 	NeedsGuard bool
 }
 
-// Prestring returns this Prestring as a Prestring
-func (*ProduceTriggerNever) Prestring() Prestring {
+// Prestring returns a compact string representation.
+func (*ProduceTriggerNever) Prestring() fmt.Stringer {
 	return ProduceTriggerNeverPrestring{}
 }
 
-// ProduceTriggerNeverPrestring is a Prestring storing the needed information to compactly encode a ProduceTriggerNever
+// ProduceTriggerNeverPrestring is a fmt.Stringer storing the needed information to compactly encode a ProduceTriggerNever
 type ProduceTriggerNeverPrestring struct{}
 
 func (ProduceTriggerNeverPrestring) String() string {
@@ -287,12 +287,12 @@ func (p *PositiveNilCheck) equals(other ProducingAnnotationTrigger) bool {
 	return false
 }
 
-// Prestring returns this Prestring as a Prestring
-func (*PositiveNilCheck) Prestring() Prestring {
+// Prestring returns a compact string representation.
+func (*PositiveNilCheck) Prestring() fmt.Stringer {
 	return PositiveNilCheckPrestring{}
 }
 
-// PositiveNilCheckPrestring is a Prestring storing the needed information to compactly encode a PositiveNilCheck
+// PositiveNilCheckPrestring is a fmt.Stringer storing the needed information to compactly encode a PositiveNilCheck
 type PositiveNilCheckPrestring struct{}
 
 func (PositiveNilCheckPrestring) String() string {
@@ -312,12 +312,12 @@ func (n *NegativeNilCheck) equals(other ProducingAnnotationTrigger) bool {
 	return false
 }
 
-// Prestring returns this Prestring as a Prestring
-func (*NegativeNilCheck) Prestring() Prestring {
+// Prestring returns a compact string representation.
+func (*NegativeNilCheck) Prestring() fmt.Stringer {
 	return NegativeNilCheckPrestring{}
 }
 
-// NegativeNilCheckPrestring is a Prestring storing the needed information to compactly encode a NegativeNilCheck
+// NegativeNilCheckPrestring is a fmt.Stringer storing the needed information to compactly encode a NegativeNilCheck
 type NegativeNilCheckPrestring struct{}
 
 func (NegativeNilCheckPrestring) String() string {
@@ -365,12 +365,12 @@ func (c *ConstNil) equals(other ProducingAnnotationTrigger) bool {
 	return false
 }
 
-// Prestring returns this Prestring as a Prestring
-func (*ConstNil) Prestring() Prestring {
+// Prestring returns a compact string representation.
+func (*ConstNil) Prestring() fmt.Stringer {
 	return ConstNilPrestring{}
 }
 
-// ConstNilPrestring is a Prestring storing the needed information to compactly encode a ConstNil
+// ConstNilPrestring is a fmt.Stringer storing the needed information to compactly encode a ConstNil
 type ConstNilPrestring struct{}
 
 func (ConstNilPrestring) String() string {
@@ -390,12 +390,12 @@ func (u *UnassignedFld) equals(other ProducingAnnotationTrigger) bool {
 	return false
 }
 
-// Prestring returns this Prestring as a Prestring
-func (*UnassignedFld) Prestring() Prestring {
+// Prestring returns a compact string representation.
+func (*UnassignedFld) Prestring() fmt.Stringer {
 	return UnassignedFldPrestring{}
 }
 
-// UnassignedFldPrestring is a Prestring storing the needed information to compactly encode a UnassignedFld
+// UnassignedFldPrestring is a fmt.Stringer storing the needed information to compactly encode a UnassignedFld
 type UnassignedFldPrestring struct{}
 
 func (UnassignedFldPrestring) String() string {
@@ -416,14 +416,14 @@ func (n *NoVarAssign) equals(other ProducingAnnotationTrigger) bool {
 	return false
 }
 
-// Prestring returns this Prestring as a Prestring
-func (n *NoVarAssign) Prestring() Prestring {
+// Prestring returns a compact string representation.
+func (n *NoVarAssign) Prestring() fmt.Stringer {
 	return NoVarAssignPrestring{
 		VarName: n.VarObj.Name(),
 	}
 }
 
-// NoVarAssignPrestring is a Prestring storing the needed information to compactly encode a NoVarAssign
+// NoVarAssignPrestring is a fmt.Stringer storing the needed information to compactly encode a NoVarAssign
 type NoVarAssignPrestring struct {
 	VarName string
 }
@@ -445,12 +445,12 @@ func (b *BlankVarReturn) equals(other ProducingAnnotationTrigger) bool {
 	return false
 }
 
-// Prestring returns this Prestring as a Prestring
-func (*BlankVarReturn) Prestring() Prestring {
+// Prestring returns a compact string representation.
+func (*BlankVarReturn) Prestring() fmt.Stringer {
 	return BlankVarReturnPrestring{}
 }
 
-// BlankVarReturnPrestring is a Prestring storing the needed information to compactly encode a BlankVarReturn
+// BlankVarReturnPrestring is a fmt.Stringer storing the needed information to compactly encode a BlankVarReturn
 type BlankVarReturnPrestring struct{}
 
 func (BlankVarReturnPrestring) String() string {
@@ -487,8 +487,8 @@ func (f *FuncParam) equals(other ProducingAnnotationTrigger) bool {
 	return false
 }
 
-// Prestring returns this FuncParam as a Prestring
-func (f *FuncParam) Prestring() Prestring {
+// Prestring returns this FuncParam as a fmt.Stringer
+func (f *FuncParam) Prestring() fmt.Stringer {
 	switch key := f.Ann.(type) {
 	case *ParamAnnotationKey:
 		return FuncParamPrestring{key.ParamNameString(), key.FuncDecl.Name(), ""}
@@ -499,7 +499,7 @@ func (f *FuncParam) Prestring() Prestring {
 	}
 }
 
-// FuncParamPrestring is a Prestring storing the needed information to compactly encode a FuncParam
+// FuncParamPrestring is a fmt.Stringer storing the needed information to compactly encode a FuncParam
 type FuncParamPrestring struct {
 	ParamName string
 	FuncName  string
@@ -531,12 +531,12 @@ func (m *MethodRecv) equals(other ProducingAnnotationTrigger) bool {
 	return false
 }
 
-// Prestring returns this MethodRecv as a Prestring
-func (m *MethodRecv) Prestring() Prestring {
+// Prestring returns this MethodRecv as a fmt.Stringer
+func (m *MethodRecv) Prestring() fmt.Stringer {
 	return MethodRecvPrestring{m.VarDecl.Name()}
 }
 
-// MethodRecvPrestring is a Prestring storing the needed information to compactly encode a MethodRecv
+// MethodRecvPrestring is a fmt.Stringer storing the needed information to compactly encode a MethodRecv
 type MethodRecvPrestring struct {
 	RecvName string
 }
@@ -559,12 +559,12 @@ func (m *MethodRecvDeep) equals(other ProducingAnnotationTrigger) bool {
 	return false
 }
 
-// Prestring returns this MethodRecv as a Prestring
-func (m *MethodRecvDeep) Prestring() Prestring {
+// Prestring returns this MethodRecv as a fmt.Stringer
+func (m *MethodRecvDeep) Prestring() fmt.Stringer {
 	return MethodRecvDeepPrestring{m.VarDecl.Name()}
 }
 
-// MethodRecvDeepPrestring is a Prestring storing the needed information to compactly encode a MethodRecv
+// MethodRecvDeepPrestring is a fmt.Stringer storing the needed information to compactly encode a MethodRecv
 type MethodRecvDeepPrestring struct {
 	RecvName string
 }
@@ -588,12 +588,12 @@ func (v *VariadicFuncParam) equals(other ProducingAnnotationTrigger) bool {
 	return false
 }
 
-// Prestring returns this Prestring as a Prestring
-func (v *VariadicFuncParam) Prestring() Prestring {
+// Prestring returns a compact string representation.
+func (v *VariadicFuncParam) Prestring() fmt.Stringer {
 	return VariadicFuncParamPrestring{v.VarDecl.Name()}
 }
 
-// VariadicFuncParamPrestring is a Prestring storing the needed information to compactly encode a VariadicFuncParam
+// VariadicFuncParamPrestring is a fmt.Stringer storing the needed information to compactly encode a VariadicFuncParam
 type VariadicFuncParamPrestring struct {
 	ParamName string
 }
@@ -615,12 +615,12 @@ func (t *TrustedFuncNilable) equals(other ProducingAnnotationTrigger) bool {
 	return false
 }
 
-// Prestring returns this Prestring as a Prestring
-func (*TrustedFuncNilable) Prestring() Prestring {
+// Prestring returns a compact string representation.
+func (*TrustedFuncNilable) Prestring() fmt.Stringer {
 	return TrustedFuncNilablePrestring{}
 }
 
-// TrustedFuncNilablePrestring is a Prestring storing the needed information to compactly encode a TrustedFuncNilable
+// TrustedFuncNilablePrestring is a fmt.Stringer storing the needed information to compactly encode a TrustedFuncNilable
 type TrustedFuncNilablePrestring struct{}
 
 func (TrustedFuncNilablePrestring) String() string {
@@ -640,12 +640,12 @@ func (t *TrustedFuncNonnil) equals(other ProducingAnnotationTrigger) bool {
 	return false
 }
 
-// Prestring returns this Prestring as a Prestring
-func (*TrustedFuncNonnil) Prestring() Prestring {
+// Prestring returns a compact string representation.
+func (*TrustedFuncNonnil) Prestring() fmt.Stringer {
 	return TrustedFuncNonnilPrestring{}
 }
 
-// TrustedFuncNonnilPrestring is a Prestring storing the needed information to compactly encode a TrustedFuncNonnil
+// TrustedFuncNonnilPrestring is a fmt.Stringer storing the needed information to compactly encode a TrustedFuncNonnil
 type TrustedFuncNonnilPrestring struct{}
 
 func (TrustedFuncNonnilPrestring) String() string {
@@ -665,15 +665,15 @@ func (f *FldRead) equals(other ProducingAnnotationTrigger) bool {
 	return false
 }
 
-// Prestring returns this FldRead as a Prestring
-func (f *FldRead) Prestring() Prestring {
+// Prestring returns this FldRead as a fmt.Stringer
+func (f *FldRead) Prestring() fmt.Stringer {
 	if ek, ok := f.Ann.(*EscapeFieldAnnotationKey); ok {
 		return FldReadPrestring{ek.FieldDecl.Name()}
 	}
 	return FldReadPrestring{f.Ann.(*FieldAnnotationKey).FieldDecl.Name()}
 }
 
-// FldReadPrestring is a Prestring storing the needed information to compactly encode a FldRead
+// FldReadPrestring is a fmt.Stringer storing the needed information to compactly encode a FldRead
 type FldReadPrestring struct {
 	FieldName string
 }
@@ -696,15 +696,15 @@ func (f *ParamFldRead) equals(other ProducingAnnotationTrigger) bool {
 	return false
 }
 
-// Prestring returns this ParamFldRead as a Prestring
-func (f *ParamFldRead) Prestring() Prestring {
+// Prestring returns this ParamFldRead as a fmt.Stringer
+func (f *ParamFldRead) Prestring() fmt.Stringer {
 	ann := f.Ann.(*ParamFieldAnnotationKey)
 	return ParamFldReadPrestring{
 		FieldName: ann.FieldDecl.Name(),
 	}
 }
 
-// ParamFldReadPrestring is a Prestring storing the needed information to compactly encode a ParamFldRead
+// ParamFldReadPrestring is a fmt.Stringer storing the needed information to compactly encode a ParamFldRead
 type ParamFldReadPrestring struct {
 	FieldName string
 }
@@ -730,13 +730,13 @@ func (f FldReturn) String() string {
 	return f.Prestring().String()
 }
 
-// Prestring returns this FldReturn as a Prestring
-func (f *FldReturn) Prestring() Prestring {
+// Prestring returns this FldReturn as a fmt.Stringer
+func (f *FldReturn) Prestring() fmt.Stringer {
 	key := f.Ann.(*RetFieldAnnotationKey)
 	return FldReturnPrestring{key.RetNum, key.FuncDecl.Name(), key.FieldDecl.Name()}
 }
 
-// FldReturnPrestring is a Prestring storing the needed information to compactly encode a FldReturn
+// FldReturnPrestring is a fmt.Stringer storing the needed information to compactly encode a FldReturn
 type FldReturnPrestring struct {
 	RetNum    int
 	FuncName  string
@@ -768,8 +768,8 @@ func (f *FuncReturn) equals(other ProducingAnnotationTrigger) bool {
 	return false
 }
 
-// Prestring returns this FuncReturn as a Prestring
-func (f *FuncReturn) Prestring() Prestring {
+// Prestring returns this FuncReturn as a fmt.Stringer
+func (f *FuncReturn) Prestring() fmt.Stringer {
 	switch key := f.Ann.(type) {
 	case *RetAnnotationKey:
 		return FuncReturnPrestring{key.RetNum, key.FuncDecl.Name(), ""}
@@ -780,7 +780,7 @@ func (f *FuncReturn) Prestring() Prestring {
 	}
 }
 
-// FuncReturnPrestring is a Prestring storing the needed information to compactly encode a FuncReturn
+// FuncReturnPrestring is a fmt.Stringer storing the needed information to compactly encode a FuncReturn
 type FuncReturnPrestring struct {
 	RetNum   int
 	FuncName string
@@ -811,13 +811,13 @@ func (m *MethodReturn) equals(other ProducingAnnotationTrigger) bool {
 	return false
 }
 
-// Prestring returns this MethodReturn as a Prestring
-func (m *MethodReturn) Prestring() Prestring {
+// Prestring returns this MethodReturn as a fmt.Stringer
+func (m *MethodReturn) Prestring() fmt.Stringer {
 	retKey := m.Ann.(*RetAnnotationKey)
 	return MethodReturnPrestring{retKey.RetNum, retKey.FuncDecl.Name()}
 }
 
-// MethodReturnPrestring is a Prestring storing the needed information to compactly encode a MethodReturn
+// MethodReturnPrestring is a fmt.Stringer storing the needed information to compactly encode a MethodReturn
 type MethodReturnPrestring struct {
 	RetNum   int
 	FuncName string
@@ -843,8 +843,8 @@ func (m *MethodResultReachesInterface) equals(other ProducingAnnotationTrigger) 
 	return false
 }
 
-// Prestring returns this MethodResultReachesInterface as a Prestring
-func (m *MethodResultReachesInterface) Prestring() Prestring {
+// Prestring returns this MethodResultReachesInterface as a fmt.Stringer
+func (m *MethodResultReachesInterface) Prestring() fmt.Stringer {
 	retAnn := m.Ann.(*RetAnnotationKey)
 	return MethodResultReachesInterfacePrestring{
 		retAnn.RetNum,
@@ -853,7 +853,7 @@ func (m *MethodResultReachesInterface) Prestring() Prestring {
 	}
 }
 
-// MethodResultReachesInterfacePrestring is a Prestring storing the needed information to compactly encode a MethodResultReachesInterface
+// MethodResultReachesInterfacePrestring is a fmt.Stringer storing the needed information to compactly encode a MethodResultReachesInterface
 type MethodResultReachesInterfacePrestring struct {
 	RetNum   int
 	ImplName string
@@ -880,8 +880,8 @@ func (i *InterfaceParamReachesImplementation) equals(other ProducingAnnotationTr
 	return false
 }
 
-// Prestring returns this InterfaceParamReachesImplementation as a Prestring
-func (i *InterfaceParamReachesImplementation) Prestring() Prestring {
+// Prestring returns this InterfaceParamReachesImplementation as a fmt.Stringer
+func (i *InterfaceParamReachesImplementation) Prestring() fmt.Stringer {
 	paramAnn := i.Ann.(*ParamAnnotationKey)
 	return InterfaceParamReachesImplementationPrestring{
 		paramAnn.ParamNameString(),
@@ -890,7 +890,7 @@ func (i *InterfaceParamReachesImplementation) Prestring() Prestring {
 	}
 }
 
-// InterfaceParamReachesImplementationPrestring is a Prestring storing the needed information to compactly encode a InterfaceParamReachesImplementation
+// InterfaceParamReachesImplementationPrestring is a fmt.Stringer storing the needed information to compactly encode a InterfaceParamReachesImplementation
 type InterfaceParamReachesImplementationPrestring struct {
 	ParamName string
 	IntName   string
@@ -914,15 +914,15 @@ func (g *GlobalVarRead) equals(other ProducingAnnotationTrigger) bool {
 	return false
 }
 
-// Prestring returns this GlobalVarRead as a Prestring
-func (g *GlobalVarRead) Prestring() Prestring {
+// Prestring returns this GlobalVarRead as a fmt.Stringer
+func (g *GlobalVarRead) Prestring() fmt.Stringer {
 	key := g.Ann.(*GlobalVarAnnotationKey)
 	return GlobalVarReadPrestring{
 		key.VarDecl.Name(),
 	}
 }
 
-// GlobalVarReadPrestring is a Prestring storing the needed information to compactly encode a GlobalVarRead
+// GlobalVarReadPrestring is a fmt.Stringer storing the needed information to compactly encode a GlobalVarRead
 type GlobalVarReadPrestring struct {
 	VarName string
 }
@@ -945,13 +945,13 @@ func (m *MapRead) equals(other ProducingAnnotationTrigger) bool {
 	return false
 }
 
-// Prestring returns this MapRead as a Prestring
-func (m *MapRead) Prestring() Prestring {
+// Prestring returns this MapRead as a fmt.Stringer
+func (m *MapRead) Prestring() fmt.Stringer {
 	key := m.Ann.(*TypeNameAnnotationKey)
 	return MapReadPrestring{key.TypeDecl.Name()}
 }
 
-// MapReadPrestring is a Prestring storing the needed information to compactly encode a MapRead
+// MapReadPrestring is a fmt.Stringer storing the needed information to compactly encode a MapRead
 type MapReadPrestring struct {
 	TypeName string
 }
@@ -973,13 +973,13 @@ func (a *ArrayRead) equals(other ProducingAnnotationTrigger) bool {
 	return false
 }
 
-// Prestring returns this ArrayRead as a Prestring
-func (a *ArrayRead) Prestring() Prestring {
+// Prestring returns this ArrayRead as a fmt.Stringer
+func (a *ArrayRead) Prestring() fmt.Stringer {
 	key := a.Ann.(*TypeNameAnnotationKey)
 	return ArrayReadPrestring{key.TypeDecl.Name()}
 }
 
-// ArrayReadPrestring is a Prestring storing the needed information to compactly encode a ArrayRead
+// ArrayReadPrestring is a fmt.Stringer storing the needed information to compactly encode a ArrayRead
 type ArrayReadPrestring struct {
 	TypeName string
 }
@@ -1001,13 +1001,13 @@ func (s *SliceRead) equals(other ProducingAnnotationTrigger) bool {
 	return false
 }
 
-// Prestring returns this SliceRead as a Prestring
-func (s *SliceRead) Prestring() Prestring {
+// Prestring returns this SliceRead as a fmt.Stringer
+func (s *SliceRead) Prestring() fmt.Stringer {
 	key := s.Ann.(*TypeNameAnnotationKey)
 	return SliceReadPrestring{key.TypeDecl.Name()}
 }
 
-// SliceReadPrestring is a Prestring storing the needed information to compactly encode a SliceRead
+// SliceReadPrestring is a fmt.Stringer storing the needed information to compactly encode a SliceRead
 type SliceReadPrestring struct {
 	TypeName string
 }
@@ -1021,8 +1021,8 @@ type PtrRead struct {
 	*TriggerIfDeepNilable
 }
 
-// Prestring returns this PtrRead as a Prestring
-func (p *PtrRead) Prestring() Prestring {
+// Prestring returns this PtrRead as a fmt.Stringer
+func (p *PtrRead) Prestring() fmt.Stringer {
 	key := p.Ann.(*TypeNameAnnotationKey)
 	return PtrReadPrestring{key.TypeDecl.Name()}
 }
@@ -1035,7 +1035,7 @@ func (p *PtrRead) equals(other ProducingAnnotationTrigger) bool {
 	return false
 }
 
-// PtrReadPrestring is a Prestring storing the needed information to compactly encode a PtrRead
+// PtrReadPrestring is a fmt.Stringer storing the needed information to compactly encode a PtrRead
 type PtrReadPrestring struct {
 	TypeName string
 }
@@ -1057,13 +1057,13 @@ func (c *ChanRecv) equals(other ProducingAnnotationTrigger) bool {
 	return false
 }
 
-// Prestring returns this ChanRecv as a Prestring
-func (c *ChanRecv) Prestring() Prestring {
+// Prestring returns this ChanRecv as a fmt.Stringer
+func (c *ChanRecv) Prestring() fmt.Stringer {
 	key := c.Ann.(*TypeNameAnnotationKey)
 	return ChanRecvPrestring{key.TypeDecl.Name()}
 }
 
-// ChanRecvPrestring is a Prestring storing the needed information to compactly encode a ChanRecv
+// ChanRecvPrestring is a fmt.Stringer storing the needed information to compactly encode a ChanRecv
 type ChanRecvPrestring struct {
 	TypeName string
 }
@@ -1085,13 +1085,13 @@ func (f *FuncParamDeep) equals(other ProducingAnnotationTrigger) bool {
 	return false
 }
 
-// Prestring returns this FuncParamDeep as a Prestring
-func (f *FuncParamDeep) Prestring() Prestring {
+// Prestring returns this FuncParamDeep as a fmt.Stringer
+func (f *FuncParamDeep) Prestring() fmt.Stringer {
 	key := f.Ann.(*ParamAnnotationKey)
 	return FuncParamDeepPrestring{key.ParamNameString()}
 }
 
-// FuncParamDeepPrestring is a Prestring storing the needed information to compactly encode a FuncParamDeep
+// FuncParamDeepPrestring is a fmt.Stringer storing the needed information to compactly encode a FuncParamDeep
 type FuncParamDeepPrestring struct {
 	ParamName string
 }
@@ -1114,12 +1114,12 @@ func (v *VariadicFuncParamDeep) equals(other ProducingAnnotationTrigger) bool {
 	return false
 }
 
-// Prestring returns this VariadicFuncParamDeep as a Prestring
-func (v *VariadicFuncParamDeep) Prestring() Prestring {
+// Prestring returns this VariadicFuncParamDeep as a fmt.Stringer
+func (v *VariadicFuncParamDeep) Prestring() fmt.Stringer {
 	return VariadicFuncParamDeepPrestring{v.Ann.(*ParamAnnotationKey).ParamNameString()}
 }
 
-// VariadicFuncParamDeepPrestring is a Prestring storing the needed information to compactly encode a VariadicFuncParamDeep
+// VariadicFuncParamDeepPrestring is a fmt.Stringer storing the needed information to compactly encode a VariadicFuncParamDeep
 type VariadicFuncParamDeepPrestring struct {
 	ParamName string
 }
@@ -1142,13 +1142,13 @@ func (f *FuncReturnDeep) equals(other ProducingAnnotationTrigger) bool {
 	return false
 }
 
-// Prestring returns this FuncReturnDeep as a Prestring
-func (f *FuncReturnDeep) Prestring() Prestring {
+// Prestring returns this FuncReturnDeep as a fmt.Stringer
+func (f *FuncReturnDeep) Prestring() fmt.Stringer {
 	key := f.Ann.(*RetAnnotationKey)
 	return FuncReturnDeepPrestring{key.RetNum, key.FuncDecl.Name()}
 }
 
-// FuncReturnDeepPrestring is a Prestring storing the needed information to compactly encode a FuncReturnDeep
+// FuncReturnDeepPrestring is a fmt.Stringer storing the needed information to compactly encode a FuncReturnDeep
 type FuncReturnDeepPrestring struct {
 	RetNum   int
 	FuncName string
@@ -1172,13 +1172,13 @@ func (f *FldReadDeep) equals(other ProducingAnnotationTrigger) bool {
 	return false
 }
 
-// Prestring returns this FldReadDeep as a Prestring
-func (f *FldReadDeep) Prestring() Prestring {
+// Prestring returns this FldReadDeep as a fmt.Stringer
+func (f *FldReadDeep) Prestring() fmt.Stringer {
 	key := f.Ann.(*FieldAnnotationKey)
 	return FldReadDeepPrestring{key.FieldDecl.Name()}
 }
 
-// FldReadDeepPrestring is a Prestring storing the needed information to compactly encode a FldReadDeep
+// FldReadDeepPrestring is a fmt.Stringer storing the needed information to compactly encode a FldReadDeep
 type FldReadDeepPrestring struct {
 	FieldName string
 }
@@ -1200,13 +1200,13 @@ func (v *LocalVarReadDeep) equals(other ProducingAnnotationTrigger) bool {
 	return false
 }
 
-// Prestring returns this LocalVarReadDeep as a Prestring
-func (v LocalVarReadDeep) Prestring() Prestring {
+// Prestring returns this LocalVarReadDeep as a fmt.Stringer
+func (v LocalVarReadDeep) Prestring() fmt.Stringer {
 	varAnn := v.Ann.(*LocalVarAnnotationKey)
 	return LocalVarReadDeepPrestring{varAnn.VarDecl.Name()}
 }
 
-// LocalVarReadDeepPrestring is a Prestring storing the needed information to compactly encode a LocalVarReadDeep
+// LocalVarReadDeepPrestring is a fmt.Stringer storing the needed information to compactly encode a LocalVarReadDeep
 type LocalVarReadDeepPrestring struct {
 	VarName string
 }
@@ -1229,13 +1229,13 @@ func (g *GlobalVarReadDeep) equals(other ProducingAnnotationTrigger) bool {
 	return false
 }
 
-// Prestring returns this GlobalVarReadDeep as a Prestring
-func (g *GlobalVarReadDeep) Prestring() Prestring {
+// Prestring returns this GlobalVarReadDeep as a fmt.Stringer
+func (g *GlobalVarReadDeep) Prestring() fmt.Stringer {
 	key := g.Ann.(*GlobalVarAnnotationKey)
 	return GlobalVarReadDeepPrestring{key.VarDecl.Name()}
 }
 
-// GlobalVarReadDeepPrestring is a Prestring storing the needed information to compactly encode a GlobalVarReadDeep
+// GlobalVarReadDeepPrestring is a fmt.Stringer storing the needed information to compactly encode a GlobalVarReadDeep
 type GlobalVarReadDeepPrestring struct {
 	VarName string
 }
@@ -1267,14 +1267,14 @@ func (g *GuardMissing) equals(other ProducingAnnotationTrigger) bool {
 	return false
 }
 
-// Prestring returns this GuardMissing as a Prestring
-func (g *GuardMissing) Prestring() Prestring {
+// Prestring returns this GuardMissing as a fmt.Stringer
+func (g *GuardMissing) Prestring() fmt.Stringer {
 	return GuardMissingPrestring{g.OldAnnotation.Prestring()}
 }
 
-// GuardMissingPrestring is a Prestring storing the needed information to compactly encode a GuardMissing
+// GuardMissingPrestring is a fmt.Stringer storing the needed information to compactly encode a GuardMissing
 type GuardMissingPrestring struct {
-	OldPrestring Prestring
+	OldPrestring fmt.Stringer
 }
 
 func (g GuardMissingPrestring) String() string {

--- a/annotation/structinitv2.go
+++ b/annotation/structinitv2.go
@@ -41,12 +41,12 @@ func (s *StructFieldNil) equals(other ProducingAnnotationTrigger) bool {
 	return false
 }
 
-// Prestring returns this StructFieldNil as a Prestring.
-func (s *StructFieldNil) Prestring() Prestring {
+// Prestring returns this StructFieldNil as a fmt.Stringer.
+func (s *StructFieldNil) Prestring() fmt.Stringer {
 	return StructFieldNilPrestring{FieldName: s.FieldName}
 }
 
-// StructFieldNilPrestring is a Prestring storing the information needed to compactly encode a
+// StructFieldNilPrestring is a fmt.Stringer storing the information needed to compactly encode a
 // StructFieldNil.
 type StructFieldNilPrestring struct {
 	FieldName string
@@ -145,8 +145,8 @@ func (s *StructFieldFromContext) equals(other ProducingAnnotationTrigger) bool {
 	return false
 }
 
-// Prestring returns this StructFieldFromContext as a Prestring.
-func (s *StructFieldFromContext) Prestring() Prestring {
+// Prestring returns this StructFieldFromContext as a fmt.Stringer.
+func (s *StructFieldFromContext) Prestring() fmt.Stringer {
 	site := s.Ann.(*StructFieldContextSite)
 	return StructFieldFromContextPrestring{Path: site.Path, Kind: site.Kind, Index: site.Index, FuncName: site.FuncObj.Name()}
 }
@@ -184,8 +184,8 @@ func (s *StructFieldToContext) Copy() ConsumingAnnotationTrigger {
 	return &c
 }
 
-// Prestring returns this StructFieldToContext as a Prestring.
-func (s *StructFieldToContext) Prestring() Prestring {
+// Prestring returns this StructFieldToContext as a fmt.Stringer.
+func (s *StructFieldToContext) Prestring() fmt.Stringer {
 	site := s.Ann.(*StructFieldContextSite)
 	return StructFieldToContextPrestring{Path: site.Path, Kind: site.Kind, Index: site.Index, FuncName: site.FuncObj.Name()}
 }

--- a/diagnostic/nilflow.go
+++ b/diagnostic/nilflow.go
@@ -28,7 +28,7 @@ type nilFlow struct {
 }
 
 // addNilPathNode adds a new node to the nil path.
-func (n *nilFlow) addNilPathNode(p annotation.Prestring, c annotation.Prestring) {
+func (n *nilFlow) addNilPathNode(p fmt.Stringer, c fmt.Stringer) {
 	nodeObj := newNode(p, c)
 
 	// Note that in the implication graph, we traverse backwards from the point of conflict to the source of nilability.
@@ -39,7 +39,7 @@ func (n *nilFlow) addNilPathNode(p annotation.Prestring, c annotation.Prestring)
 }
 
 // addNonNilPathNode adds a new node to the non-nil path
-func (n *nilFlow) addNonNilPathNode(p annotation.Prestring, c annotation.Prestring) {
+func (n *nilFlow) addNonNilPathNode(p fmt.Stringer, c fmt.Stringer) {
 	nodeObj := newNode(p, c)
 	n.nonnilPath = append(n.nonnilPath, nodeObj)
 }
@@ -80,8 +80,8 @@ type node struct {
 
 // newNode creates a new node object from the given producer and consumer Prestrings.
 // LocatedPrestring contains accurate information about the position and the reason why NilAway deemed that position
-// to be nilable. We use it if available, else we use the raw string representation available from the Prestring.
-func newNode(p annotation.Prestring, c annotation.Prestring) node {
+// to be nilable. We use it if available, else we use the raw string representation available from the fmt.Stringer.
+func newNode(p fmt.Stringer, c fmt.Stringer) node {
 	nodeObj := node{}
 
 	// get producer representation string

--- a/inference/primitive.go
+++ b/inference/primitive.go
@@ -32,14 +32,12 @@ import (
 // only that information that will be relevant for formatting error messages: a prestring
 // representation  of their production, a prestring representation of their consumption, and the
 // position in the source.
-// See annotation.Prestring for more info, but in short prestrings are structs that store some
-// minimal information that will vary between string representations meant to be passed with the
-// static type information necessary to format that minimal information into a full string
-// representation without needing to encode it all when using Gob encodings through the Facts mechanism
+// Prestrings are fmt.Stringer implementations that store the minimal information needed to format
+// full string representations without encoding all of that information through the Facts mechanism.
 type primitiveFullTrigger struct {
 	Position     token.Position
-	ProducerRepr annotation.Prestring
-	ConsumerRepr annotation.Prestring
+	ProducerRepr fmt.Stringer
+	ConsumerRepr fmt.Stringer
 }
 
 // A primitiveSite represents an atomic choice that may be made about annotations. It is


### PR DESCRIPTION
Remove the redundant `Prestring` interface and replace its usages with `fmt.Stringer` to reduce unnecessary code. This does not affect fact encoding because the registered concrete types remain unchanged.