### PR TITLE
Remove no inference marker in stub files

### DIFF
--- a/testdata/src/go.uber.org/trustedfunc/trustedfuncs.go
+++ b/testdata/src/go.uber.org/trustedfunc/trustedfuncs.go
@@ -318,8 +318,8 @@ func (u *testSetupEmbeddedDepth1) testAmbiguity(t *testing.T, x *int) *int {
 	// calling the top-level function, where they are actually calling the `suite.Suite` method.
 	// NilAway should not be confused and assert that `x` is nonnil.
 
-	// The first error is for passing nilable x to the `msgAndArgs` argument.
-	u.NotNil(t, x) //want "passed"
+	// `msgAndArgs` is nilable, so passing x as a message argument is allowed.
+	u.NotNil(t, x)
 	// The second error is that x is still nilable (u.NotNil does not really do anything).
 	return x //want "returned"
 }

--- a/testdata/src/stubs/github.com/cockroachdb/errors/errors.go
+++ b/testdata/src/stubs/github.com/cockroachdb/errors/errors.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// <nilaway no inference>
 package errors
 
 // nilable(err, target)

--- a/testdata/src/stubs/github.com/stretchr/testify/assert/assert.go
+++ b/testdata/src/stubs/github.com/stretchr/testify/assert/assert.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// <nilaway no inference>
 package assert
 
 type any interface{}

--- a/testdata/src/stubs/github.com/stretchr/testify/require/require.go
+++ b/testdata/src/stubs/github.com/stretchr/testify/require/require.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// <nilaway no inference>
 package require
 
 type any interface{}

--- a/testdata/src/stubs/github.com/stretchr/testify/suite/suite.go
+++ b/testdata/src/stubs/github.com/stretchr/testify/suite/suite.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// <nilaway no inference>
 package suite
 
 import (

--- a/testdata/src/stubs/google.golang.org/grpc/codes/codes.go
+++ b/testdata/src/stubs/google.golang.org/grpc/codes/codes.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// <nilaway no inference>
 package codes
 
 // Code is a gRPC status code.

--- a/testdata/src/stubs/google.golang.org/grpc/status/status.go
+++ b/testdata/src/stubs/google.golang.org/grpc/status/status.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// <nilaway no inference>
 package status
 
 import "stubs/google.golang.org/grpc/codes"


### PR DESCRIPTION
This PR removes the nilaway no inference marker in stub files in testdata, as an initial step to eventually remove no infer mode.