### PR TITLE
fix(struct-init-v2): bind param-out writes from any local-rooted value

### DIFF
--- a/assertion/function/assertiontree/structinitv2.go
+++ b/assertion/function/assertiontree/structinitv2.go
@@ -147,6 +147,26 @@ func (r *RootAssertionNode) addFieldProducers(structType *types.Struct, fieldIni
 	}
 }
 
+// isLocalRootedValue reports whether expr is a function-local variable, a field chain rooted
+// at one, or the address of either. Locals have no boundary annotation to snapshot statically, so
+// callers must resolve them through their flow-sensitive producers instead. Address-of is
+// unwrapped because even a proven-non-nil pointer snapshot carries no pointee field shape.
+func (r *RootAssertionNode) isLocalRootedValue(expr ast.Expr) bool {
+	if u, ok := ast.Unparen(expr).(*ast.UnaryExpr); ok && u.Op == token.AND {
+		expr = u.X
+	}
+	base, _ := asthelper.SplitFieldChain(expr)
+	if base == nil {
+		return false
+	}
+	v, ok := r.ObjectOf(base).(*types.Var)
+	if !ok {
+		return false
+	}
+	funcObj := r.FuncObj()
+	return !annotation.VarIsParam(funcObj, v) && !annotation.VarIsRecv(funcObj, v) && !annotation.VarIsGlobal(v)
+}
+
 // accessedFieldPath is one accessed field path under a boundary value, paired with the synthesized
 // selector expression that reaches it.
 type accessedFieldPath struct {
@@ -656,14 +676,13 @@ func (r *RootAssertionNode) bindParamFieldWriteToContext(lhs, rhs ast.Expr) {
 			Expr:       lhs,
 			Guards:     guard.NoGuards(),
 		}
-		if ident, ok := ast.Unparen(rhs).(*ast.Ident); ok {
-			if v, ok := r.ObjectOf(ident).(*types.Var); ok {
-				if _, isParam := r.getParamIndex(v); !isParam && !annotation.VarIsGlobal(v) {
-					consumer.Expr = rhs
-					r.AddConsumption(consumer)
-					return
-				}
-			}
+		// A local-rooted RHS has no boundary annotation to snapshot; attach the param-out
+		// supply as a consumption so backpropagation resolves its flow-sensitive producer.
+		// Any other RHS snapshots to its provable boundary nilability below.
+		if r.isLocalRootedValue(rhs) {
+			consumer.Expr = rhs
+			r.AddConsumption(consumer)
+			return
 		}
 		r.AddNewTriggers(annotation.FullTrigger{
 			Producer: &annotation.ProduceTrigger{

--- a/testdata/src/go.uber.org/structinitv2/paramsideeffect/localrootedrhs.go
+++ b/testdata/src/go.uber.org/structinitv2/paramsideeffect/localrootedrhs.go
@@ -1,0 +1,52 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Tests param-out writes whose RHS is a field chain rooted at a local or the address of a local
+// value. Such values must be resolved through their flow-sensitive producers rather than a static
+// snapshot.
+
+package paramsideeffect
+
+type wrapper struct {
+	inner *A
+}
+
+func nilA() *A { return nil }
+
+// Case 1: field chain rooted at a function-local holding a provably nil field fires.
+func setFromFieldChainNil(x *A) {
+	inner := nilA()
+	local := wrapper{inner: inner}
+	x.aptr = local.inner
+}
+
+func readFieldChainNil() *int {
+	b := &A{}
+	setFromFieldChainNil(b)
+	return b.aptr.ptr //want "field `aptr` of param 0 of `setFromFieldChainNil`"
+}
+
+// Case 2: address of a function-local value with the dereferenced field initialized does not
+// fire. `&value` is a non-nil pointer collapsed to the pointee's trackable path, so the post-call
+// deref resolves to the initialized (non-nil) producer of value.ptr.
+func setFromAddressOfLocal(x *A) {
+	value := A{ptr: new(int)}
+	x.aptr = &value
+}
+
+func readAddressOfLocal() *int {
+	b := &A{}
+	setFromAddressOfLocal(b)
+	return b.aptr.ptr // safe: value.ptr is initialized
+}


### PR DESCRIPTION
Bind param-out writes whose RHS is any local-rooted value — a local variable, a field chain rooted at one (`x.aptr = local.inner`), or the address of either (`x.aptr = &value`) — through the flow-sensitive consumption path. Previously only a bare local identifier qualified; the other forms fell back to a static snapshot that has no boundary annotation for a local, missing provably nil writes at post-call dereferences (false negative) and, for &value, losing the pointee's field shape (false positive).

Changes
- Extract the RHS classification into `isLocalRootedValue`, covering field chains and address-of; unwrap & since `ParseExprAsProducer` collapses &structValue to the pointee's trackable path.
- Add positive (nil field chain) and negative (address of local with initialized field) tests in structinitv2/paramsideeffect.