### PR TITLE
fix(struct-init-v2): record selector value demand in read collection

### DIFF
--- a/assertion/function/structfieldeffects/effects.go
+++ b/assertion/function/structfieldeffects/effects.go
@@ -171,9 +171,18 @@ func (c *collectedFieldEffects) collectFunction(pass *analysishelper.EnhancedPas
 	resultVars := collectStructResultVars(pass, fd.Body)
 	c.collectReturnEffects(pass, fd, funcObj, resultVars)
 
+	// Selectors assigned to (`a.y = ...`) write their selected field rather than read it, so they
+	// must not contribute value demand. ast.Inspect visits an AssignStmt before descending into its
+	// LHS, so the set is always populated before the selector itself is visited.
+	assignedSelectors := make(map[*ast.SelectorExpr]bool)
 	ast.Inspect(fd.Body, func(n ast.Node) bool {
 		switch n := n.(type) {
 		case *ast.AssignStmt:
+			for _, lhs := range n.Lhs {
+				if sel, ok := ast.Unparen(lhs).(*ast.SelectorExpr); ok {
+					assignedSelectors[sel] = true
+				}
+			}
 			collectParamFieldWrites(pass, n, paramIdx, funcObj, c.summary.ParamWrites)
 		case *ast.CallExpr:
 			if callee := collectParamForwardEdges(pass, n, paramIdx, funcObj, c.paramForwardingEdges); callee != nil {
@@ -182,7 +191,7 @@ func (c *collectedFieldEffects) collectFunction(pass *analysishelper.EnhancedPas
 		case *ast.SelectorExpr:
 			collectFieldReadDemand(
 				pass, n, paramIdx, resultVars, funcObj,
-				c.summary.ParamReads, c.summary.ReturnReads,
+				c.summary.ParamReads, c.summary.ReturnReads, assignedSelectors[n],
 			)
 		}
 		return true
@@ -582,29 +591,53 @@ func enumerateConcreteReturnEffects(pass *analysishelper.EnhancedPass, funcObj *
 	}
 }
 
-// collectFieldReadDemand records the field-path dereference demand implied by a single selector
-// expression. To evaluate `base.Sel`, base must be non-nil, so the field path of base (relative to
-// the boundary value it roots at) is a read of that value. If base roots at a parameter/receiver of
-// funcObj the demand goes to reads (param-in); if it roots at a local bound from a struct-returning
-// call (resultVars) it goes to returnReads, attributed to that callee's result. A selector whose
-// base is the boundary value itself (prefix "") only requires the value's own top-level nilability,
-// handled by the ordinary annotation machinery, so it is skipped here.
-func collectFieldReadDemand(pass *analysishelper.EnhancedPass, sel *ast.SelectorExpr, paramIdx map[*types.Var]int, resultVars map[*types.Var]structResultSource, funcObj *types.Func, reads, returnReads fieldEffects) {
+// collectFieldReadDemand records the finite field-path demand implied by a single selector
+// expression. There are two distinct demands:
+//
+//   - Base demand: to evaluate `base.Sel`, base must be non-nil, so the field path of base
+//     (relative to the boundary value it roots at) is a read of that value. For `a.y.z` this
+//     records `y`. A selector whose base is the boundary value itself (prefix "") only requires
+//     the value's own top-level nilability, handled by the ordinary annotation machinery.
+//   - Value demand: reading the selected field value itself may later flow through a local
+//     snapshot (`w := a.y; return &D{v: w}`), so for a nilable selected field the full selector
+//     path is recorded. This is what makes `a.y` demand `y`, not only deeper selectors like
+//     `a.y.z`. Suppressed for assignment LHS selectors (skipValueDemand), which write rather
+//     than read the selected field.
+//
+// If the root is a parameter/receiver of funcObj the demand goes to reads (param-in); if it roots
+// at a local bound from a struct-returning call (resultVars) it goes to returnReads, attributed to
+// that callee's result.
+func collectFieldReadDemand(pass *analysishelper.EnhancedPass, sel *ast.SelectorExpr, paramIdx map[*types.Var]int, resultVars map[*types.Var]structResultSource, funcObj *types.Func, reads, returnReads fieldEffects, skipValueDemand bool) {
+	record := func(base *ast.Ident, path string) {
+		if base == nil || path == "" {
+			return
+		}
+		v, ok := pass.TypesInfo.ObjectOf(base).(*types.Var)
+		if !ok {
+			return
+		}
+		if idx, ok := paramIdx[v]; ok {
+			reads.add(funcObj, IndexedFieldPath{Idx: idx, Path: path})
+			return
+		}
+		if src, ok := resultVars[v]; ok {
+			returnReads.add(src.callee.Origin, IndexedFieldPath{Idx: src.idx, Path: path})
+		}
+	}
+
+	// Base demand: `a.y.z` needs `a.y` to be non-nil.
 	base, prefix := asthelper.SplitFieldChain(sel.X)
-	if base == nil || prefix == "" {
+	record(base, prefix)
+
+	// Value demand: `a.y` reads field `y` as a value. Only nilable field values need a field
+	// nilability summary; non-nilable value-struct sub-fields are reached by their own later
+	// selectors.
+	field, ok := pass.TypesInfo.ObjectOf(sel.Sel).(*types.Var)
+	if skipValueDemand || !ok || typeshelper.TypeBarsNilness(field.Type()) {
 		return
 	}
-	v, ok := pass.TypesInfo.ObjectOf(base).(*types.Var)
-	if !ok {
-		return
-	}
-	if idx, ok := paramIdx[v]; ok {
-		reads.add(funcObj, IndexedFieldPath{Idx: idx, Path: prefix})
-		return
-	}
-	if src, ok := resultVars[v]; ok {
-		returnReads.add(src.callee.Origin, IndexedFieldPath{Idx: src.idx, Path: prefix})
-	}
+	base, path := asthelper.SplitFieldChain(sel)
+	record(base, path)
 }
 
 // collectParamFieldWrites records nilable fields assigned through a pointer parameter or receiver.

--- a/assertion/function/structfieldeffects/testdata/src/go.uber.org/paramfieldeffects/factexport/downstream/downstream.go
+++ b/assertion/function/structfieldeffects/testdata/src/go.uber.org/paramfieldeffects/factexport/downstream/downstream.go
@@ -2,7 +2,7 @@ package downstream // want package:".*"
 
 import "go.uber.org/paramfieldeffects/factexport/upstream"
 
-func Forward(o *upstream.Outer) { // expect_effects: param_reads:0:Mid param_reads:0:Mid.Child
+func Forward(o *upstream.Outer) { // expect_effects: param_reads:0:Mid param_reads:0:Mid.Child param_reads:0:Mid.Child.Ptr
 	upstream.ExportedRead(o)
 }
 

--- a/assertion/function/structfieldeffects/testdata/src/go.uber.org/paramfieldeffects/factexport/upstream/upstream.go
+++ b/assertion/function/structfieldeffects/testdata/src/go.uber.org/paramfieldeffects/factexport/upstream/upstream.go
@@ -14,11 +14,11 @@ type Outer struct {
 
 // Ordinary field-access analysis requires o to be non-nil. These field-read effects additionally
 // require Mid and Mid.Child to be non-nil; Ptr itself may be nil because it is not dereferenced.
-func ExportedRead(o *Outer) { // expect_effects: param_reads:0:Mid param_reads:0:Mid.Child
+func ExportedRead(o *Outer) { // expect_effects: param_reads:0:Mid param_reads:0:Mid.Child param_reads:0:Mid.Child.Ptr
 	_ = o.Mid.Child.Ptr
 }
 
-func ReadOneLevelDeep(o *Outer) { // expect_effects:
+func ReadOneLevelDeep(o *Outer) { // expect_effects: param_reads:0:Mid
 	_ = o.Mid
 }
 
@@ -28,7 +28,7 @@ func ExportedNoRead(o *Outer) {
 	_ = o
 }
 
-func unexportedRead(o *Outer) { // expect_effects: param_reads:0:Mid param_reads:0:Mid.Child
+func unexportedRead(o *Outer) { // expect_effects: param_reads:0:Mid param_reads:0:Mid.Child param_reads:0:Mid.Child.Ptr
 	_ = o.Mid.Child.Ptr
 }
 

--- a/assertion/function/structfieldeffects/testdata/src/go.uber.org/paramfieldeffects/main.go
+++ b/assertion/function/structfieldeffects/testdata/src/go.uber.org/paramfieldeffects/main.go
@@ -39,43 +39,43 @@ type Rec struct {
 
 // directRead dereferences two nested field prefixes of its parameter: reaching o.Mid.Child.Ptr
 // requires o.Mid and o.Mid.Child to be non-nil, so both paths are param reads.
-func directRead(o *Outer) { // expect_effects: param_reads:0:Mid param_reads:0:Mid.Child
+func directRead(o *Outer) { // expect_effects: param_reads:0:Mid param_reads:0:Mid.Child param_reads:0:Mid.Child.Ptr
 	_ = o.Mid.Child.Ptr
 }
 
-func explicitDerefRead(o *Outer) { // expect_effects: param_reads:0:Mid param_reads:0:Mid.Child
+func explicitDerefRead(o *Outer) { // expect_effects: param_reads:0:Mid param_reads:0:Mid.Child param_reads:0:Mid.Child.Ptr
 	_ = (*o).Mid.Child.Ptr
 }
 
-func intermediateDerefRead(o *Outer) { // expect_effects: param_reads:0:Mid param_reads:0:Mid.Child
+func intermediateDerefRead(o *Outer) { // expect_effects: param_reads:0:Mid param_reads:0:Mid.Child param_reads:0:Mid.Child.Ptr
 	_ = (*o.Mid).Child.Ptr
 }
 
-func doublePointerRead(o **Outer) { // expect_effects: param_reads:0:Mid param_reads:0:Mid.Child
+func doublePointerRead(o **Outer) { // expect_effects: param_reads:0:Mid param_reads:0:Mid.Child param_reads:0:Mid.Child.Ptr
 	_ = (*o).Mid.Child.Ptr
 }
 
 // forwarder passes its parameter straight through, so the closure copies directRead's reads verbatim.
-func forwarder(o *Outer) { // expect_effects: param_reads:0:Mid param_reads:0:Mid.Child
+func forwarder(o *Outer) { // expect_effects: param_reads:0:Mid param_reads:0:Mid.Child param_reads:0:Mid.Child.Ptr
 	directRead(o)
 }
 
-func forwardDerefPointerRead(o **Outer) { // expect_effects: param_reads:0:Mid param_reads:0:Mid.Child
+func forwardDerefPointerRead(o **Outer) { // expect_effects: param_reads:0:Mid param_reads:0:Mid.Child param_reads:0:Mid.Child.Ptr
 	directRead(*o)
 }
 
 // forwardField forwards a nested field of its parameter, so the inherited reads gain the "Inner" prefix.
-func forwardField(w *Wrap) { // expect_effects: param_reads:0:Inner.Mid param_reads:0:Inner.Mid.Child
+func forwardField(w *Wrap) { // expect_effects: param_reads:0:Inner param_reads:0:Inner.Mid param_reads:0:Inner.Mid.Child param_reads:0:Inner.Mid.Child.Ptr
 	directRead(w.Inner)
 }
 
 // recvRead exercises the receiver boundary index (ReceiverParamIndex).
-func (o *Outer) recvRead() { // expect_effects: param_reads:-1:Mid param_reads:-1:Mid.Child
+func (o *Outer) recvRead() { // expect_effects: param_reads:-1:Mid param_reads:-1:Mid.Child param_reads:-1:Mid.Child.Ptr
 	_ = o.Mid.Child.Ptr
 }
 
 // makeOuter is a struct-returning constructor; a caller's deref of its result becomes a return read.
-func makeOuter() *Outer { // expect_effects: return_reads:0:Mid return_reads:0:Mid.Child return_effects:0:Mid
+func makeOuter() *Outer { // expect_effects: return_reads:0:Mid return_reads:0:Mid.Child return_reads:0:Mid.Child.Ptr return_effects:0:Mid
 	return &Outer{}
 }
 
@@ -86,12 +86,12 @@ func consumeReturn() {
 }
 
 // recRead directly dereferences a self-recursive field chain; direct reads keep the exact paths.
-func recRead(r *Rec) { // expect_effects: param_reads:0:Self param_reads:0:Self.Self
+func recRead(r *Rec) { // expect_effects: param_reads:0:Self param_reads:0:Self.Self param_reads:0:Self.Self.Ptr
 	_ = r.Self.Self.Ptr
 }
 
 // recForward forwards a self-recursive field, so the closure must stop the path from growing.
-func recForward(r *Rec) { // expect_effects:
+func recForward(r *Rec) { // expect_effects: param_reads:0:Self
 	recRead(r.Self)
 }
 
@@ -107,7 +107,7 @@ func (o *Outer) receiverWrite() { // expect_effects: param_writes:-1:Mid
 	o.Mid = &Node{}
 }
 
-func forwardWrite(o *Outer) { // expect_effects: param_writes:0:Mid.Child
+func forwardWrite(o *Outer) { // expect_effects: param_reads:0:Mid param_writes:0:Mid.Child
 	writeChild(o.Mid)
 }
 
@@ -115,7 +115,7 @@ func forwardDerefPointerWrite(o **Outer) { // expect_effects: param_writes:0:Mid
 	directWrite(*o)
 }
 
-func forwardWriteAgain(w *Wrap) { // expect_effects: param_writes:0:Inner.Mid.Child
+func forwardWriteAgain(w *Wrap) { // expect_effects: param_reads:0:Inner param_reads:0:Inner.Mid param_writes:0:Inner.Mid.Child
 	forwardWrite(w.Inner)
 }
 

--- a/testdata/src/go.uber.org/structinitv2/crosspkg/app/fieldvalueescape.go
+++ b/testdata/src/go.uber.org/structinitv2/crosspkg/app/fieldvalueescape.go
@@ -12,24 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package shared defines a struct type returned by both sibling constructors p1.New and p2.New.
-// See package app.
-package shared
+// A parameter field read as a value in another package: shared.Get returns a.Aptr without
+// dereferencing it, so the imported read summary must carry the value demand for `Aptr` for the
+// caller-side dereference of the escaped value to be flagged.
 
-// A is returned by both p1.New and p2.New.
-type A struct {
-	Ptr  *int
-	Aptr *Leaf
+package app
+
+import "go.uber.org/structinitv2/crosspkg/shared"
+
+func unsafeFieldValueEscape() {
+	a := &shared.A{}
+	usePtr(shared.Get(a).Ptr) //want "uninitialized field `Aptr`"
 }
 
-// Leaf is the dereference target of A.Aptr.
-type Leaf struct {
-	Ptr *int
-}
-
-// Get reads the Aptr field as a value without dereferencing it, so only the selector's value
-// demand exports `Aptr` in the parameter read summary. A caller in another package dereferences
-// the escaped value; without value demand the nil field never reaches the boundary site.
-func Get(a *A) *Leaf {
-	return a.Aptr
+func safeFieldValueEscape() {
+	a := &shared.A{Aptr: &shared.Leaf{}}
+	usePtr(shared.Get(a).Ptr)
 }

--- a/testdata/src/go.uber.org/structinitv2/paramfield/fieldvalueescape.go
+++ b/testdata/src/go.uber.org/structinitv2/paramfield/fieldvalueescape.go
@@ -1,0 +1,72 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Reading a parameter field as a value that escapes the reading function: `return b.inner` reads
+// field `inner` without dereferencing it, so only the selector's value demand (not the base demand
+// of a deeper selector) puts `inner` in the parameter's read set. The dereference then happens at
+// the caller, on the escaped value; without value demand no boundary consumer exists and the nil
+// flow is silently dropped.
+
+package paramfield
+
+type escapeLeaf struct {
+	ptr *int
+}
+
+type escapeBox struct {
+	inner *escapeLeaf
+}
+
+// The field value escapes by being returned directly.
+func escapeDirect(b *escapeBox) *escapeLeaf {
+	return b.inner
+}
+
+func useEscapeDirectUnsafe() {
+	b := &escapeBox{}
+	print(escapeDirect(b).ptr) //want "uninitialized field `inner`"
+}
+
+func useEscapeDirectSafe() {
+	b := &escapeBox{inner: &escapeLeaf{}}
+	print(escapeDirect(b).ptr)
+}
+
+// The field value escapes through a local snapshot before being returned.
+func escapeSnapshot(b *escapeBox) *escapeLeaf {
+	w := b.inner
+	return w
+}
+
+func useEscapeSnapshotUnsafe() {
+	b := &escapeBox{}
+	print(escapeSnapshot(b).ptr) //want "uninitialized field `inner`"
+}
+
+func useEscapeSnapshotSafe() {
+	b := &escapeBox{inner: &escapeLeaf{}}
+	print(escapeSnapshot(b).ptr)
+}
+
+// The same value demand applies to a method receiver boundary. No safe negative control here:
+// the method's shared return site currently merges all callers, so a safe caller of innerValue
+// would inherit this caller's nil flow (context-insensitive return merge).
+func (b *escapeBox) innerValue() *escapeLeaf {
+	return b.inner
+}
+
+func useReceiverEscapeUnsafe() {
+	b := &escapeBox{}
+	print(b.innerValue().ptr) //want "uninitialized field `inner`"
+}


### PR DESCRIPTION
Record a selector's own field path as read demand, so a field read as a value
(`return b.inner`, `w := b.inner`) reaches the boundary and its escaped nil is
reported at the caller's dereference (`escapeDirect(b).ptr`); previously only
the base demand of deeper selectors (`a.y.z` → `y`) was recorded and the flow
was silently dropped.

Changes
- Record value demand for nilable selected fields in `collectFieldReadDemand`,
  alongside the existing base demand; non-nilable value-struct sub-fields are
  skipped (reached by their own deeper selectors).
- Suppress value demand for assignment LHS selectors (`a.y = ...` writes, not
  reads)
- Add same-package escape tests (direct return, local snapshot, receiver) in
  `structinitv2/paramfield` and a cross-package variant in
  `structinitv2/crosspkg` covering the fact export/import path.
- Update `paramfieldeffects` expectations with the leaf paths value demand now
  records (e.g. `param_reads:0:Mid.Child.Ptr`), including forwarder closure;
  write-only functions stay read-free.