### PR TITLE
fix(struct-init-v2): treat address-of as non-nil in shallow expr nilability

### DIFF
--- a/assertion/function/assertiontree/structinitv2.go
+++ b/assertion/function/assertiontree/structinitv2.go
@@ -88,12 +88,19 @@ func (r *RootAssertionNode) addAllocationFieldProducers(lhsVal, rhsVal ast.Expr)
 
 // getShallowExprNilabilityProducer returns the producer encoding the nilability of the value of expr: an
 // always-nil producer for an explicit `nil`, the shallow producer of a trackable/nilable
-// expression, or Never for a value that cannot be nil (e.g. `&A{}`, `new(A)`).
+// expression, or Never for a value that cannot be nil (e.g. `&A{}`, `new(A)`, `&local`).
 func (r *RootAssertionNode) getShallowExprNilabilityProducer(expr ast.Expr) annotation.ProducingAnnotationTrigger {
 	if ident, ok := ast.Unparen(expr).(*ast.Ident); ok && r.isNil(ident) {
 		return &annotation.ProduceTriggerTautology{}
 	}
 	if _, _, ok := r.asStructAllocation(expr); ok {
+		return &annotation.ProduceTriggerNever{}
+	}
+	// The address of any expression is a non-nil pointer at the shallow level. ParseExprAsProducer's
+	// `&A{} ≡ A{}` rule re-parses the pointee for field tracking, so its GetShallow returns the
+	// pointee's shallow nilability — which defaults to nilable for an unannotated local. That leaks
+	// the pointee's deep concern into a shallow answer; short-circuit to Never here.
+	if u, ok := ast.Unparen(expr).(*ast.UnaryExpr); ok && u.Op == token.AND {
 		return &annotation.ProduceTriggerNever{}
 	}
 	if _, producers := r.ParseExprAsProducer(expr, true); len(producers) != 0 {

--- a/testdata/src/go.uber.org/structinitv2/returnlocal/addrfieldinit.go
+++ b/testdata/src/go.uber.org/structinitv2/returnlocal/addrfieldinit.go
@@ -1,0 +1,41 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Tests shallow nilability of struct fields initialized to the address of a local. The address of
+// any expression is a non-nil pointer at the shallow level, so a field set to `&local` must not be
+// reported as nilable merely because the local has no boundary annotation.
+
+package returnlocal
+
+type addrLeaf struct {
+	v *int
+}
+
+type addrHolder struct {
+	p *addrLeaf
+}
+
+// giveAddrOfLocalInit initializes p to the address of a local; the field holds a non-nil pointer,
+// so the caller's deep deref of p.v must not fire. Without the fix getShallowExprNilabilityProducer
+// follows ParseExprAsProducer's `&A{} ≡ A{}` rule into the pointee, whose unannotated local shallow
+// defaults to nilable, so the field is reported nilable and the deref fires as a false positive.
+func giveAddrOfLocalInit() *addrHolder {
+	local := addrLeaf{v: new(int)}
+	return &addrHolder{p: &local}
+}
+
+func readAddrOfLocalInit() *int {
+	b := giveAddrOfLocalInit()
+	return b.p.v // safe: &local is a non-nil pointer, so b.p is non-nil
+}


### PR DESCRIPTION
- Treat address-of expressions such as &local as shallowly non-nil.
- Prevent false positives when struct fields are initialized with addresses of local variables.
- Add regression coverage for dereferencing such fields.

Testing
- Added a test case for address-of local field initialization.