### PR TITLE
ci: cancel stale golden test runs

### DIFF
--- a/.github/workflows/golden-test-run.yml
+++ b/.github/workflows/golden-test-run.yml
@@ -16,6 +16,10 @@ name: Golden Test
 on:
   pull_request:
 
+concurrency:
+  group: golden-test-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   golden-test:
     name: Run


### PR DESCRIPTION
Prevent superseded Golden Test runs from causing the follow-up comment workflow to fail after a PR is updated.

Changes
- Group Golden Test runs by PR number and cancel an in-progress run when a newer run starts.
- Treat a completed run whose SHA is no longer an open PR head as stale and skip its comment processing.