### PR TITLE
feat(struct-init-v2): collect return param sources

### DIFF
--- a/assertion/function/structfieldeffects/collector.go
+++ b/assertion/function/structfieldeffects/collector.go
@@ -31,6 +31,9 @@ type collectedFieldEffects struct {
 	summary               *BoundaryFieldEffects
 	paramForwardingEdges  map[*types.Func][]paramFieldForwardEdge
 	returnForwardingEdges map[*types.Func][]returnForwardEdge
+	// resultsWithConstructSite marks, per function, the result indices with at least one in-package
+	// construction return site. Used to drop ambiguous mixed construct/forward param sources in close().
+	resultsWithConstructSite map[*types.Func]map[int]bool
 	// calledFunctions is the set of functions statically called from this package, whose facts
 	// are imported before the collection is closed.
 	calledFunctions map[*types.Func]bool
@@ -39,14 +42,16 @@ type collectedFieldEffects struct {
 func newCollectedFieldEffects() *collectedFieldEffects {
 	return &collectedFieldEffects{
 		summary: &BoundaryFieldEffects{
-			ParamReads:    make(fieldEffects),
-			ReturnReads:   make(fieldEffects),
-			ParamWrites:   make(fieldEffects),
-			ReturnEffects: make(fieldEffects),
+			ParamReads:         make(fieldEffects),
+			ReturnReads:        make(fieldEffects),
+			ParamWrites:        make(fieldEffects),
+			ReturnEffects:      make(fieldEffects),
+			returnParamSources: make(returnParamSourceSet),
 		},
-		paramForwardingEdges:  make(map[*types.Func][]paramFieldForwardEdge),
-		returnForwardingEdges: make(map[*types.Func][]returnForwardEdge),
-		calledFunctions:       make(map[*types.Func]bool),
+		paramForwardingEdges:     make(map[*types.Func][]paramFieldForwardEdge),
+		returnForwardingEdges:    make(map[*types.Func][]returnForwardEdge),
+		resultsWithConstructSite: make(map[*types.Func]map[int]bool),
+		calledFunctions:          make(map[*types.Func]bool),
 	}
 }
 
@@ -72,6 +77,12 @@ func (c *collectedFieldEffects) addReturnEffect(fn *types.Func, p IndexedFieldPa
 	c.summary.ReturnEffects.add(fn, p)
 }
 
+// addReturnParamSource records a source relating fn's result (or result field) to the parameter
+// that supplies it.
+func (c *collectedFieldEffects) addReturnParamSource(fn *types.Func, source ReturnParamSource) {
+	c.summary.returnParamSources.add(fn, source)
+}
+
 // addParamForwardEdge records that fn passes one of its parameters (at a field prefix) as a
 // callee argument.
 func (c *collectedFieldEffects) addParamForwardEdge(fn *types.Func, e paramFieldForwardEdge) {
@@ -87,6 +98,15 @@ func (c *collectedFieldEffects) addReturnForwardEdge(fn *types.Func, e returnFor
 // imported before the collection is closed.
 func (c *collectedFieldEffects) markCalled(fn *types.Func) {
 	c.calledFunctions[fn] = true
+}
+
+// markResultWithConstructSite records that fn's resultIdx has an in-package construction return site,
+// so close() can drop the ambiguous whole-result sources of mixed construct/forward results.
+func (c *collectedFieldEffects) markResultWithConstructSite(fn *types.Func, resultIdx int) {
+	if c.resultsWithConstructSite[fn] == nil {
+		c.resultsWithConstructSite[fn] = make(map[int]bool)
+	}
+	c.resultsWithConstructSite[fn][resultIdx] = true
 }
 
 // computeBoundaryFieldEffects collects the unclosed boundary summary and forwarding state for every
@@ -123,7 +143,7 @@ func (c *collectedFieldEffects) collectFunction(pass *analysishelper.EnhancedPas
 	if !ok {
 		return
 	}
-	fc.collectReturnEffects()
+	fc.collectReturnSites()
 	fc.collectUseEffects()
 }
 
@@ -145,10 +165,12 @@ type functionCollector struct {
 	// of the local's fields can be attributed to that callee's result (the return-read demand).
 	resultVars map[*types.Var]structResultSource
 	// allocationVars maps locals whose defining value is a concrete struct allocation, and
-	// stableVars is the subset of allocation/result locals used only as bare return operands.
-	// Both are populated by collectReturnEffects, the only pass that reads them.
 	allocationVars map[*types.Var]structAllocationSource
-	stableVars     map[*types.Var]bool
+	// stableVars is the subset of allocation/result locals used only as bare return operands.
+	stableVars map[*types.Var]bool
+	// unstableParams holds the parameters whose value at a return may not be the caller's
+	// argument (reassigned or address-taken), which never produce param sources.
+	unstableParams map[*types.Var]bool
 	// collected is the package-level collection every pass accumulates into.
 	collected *collectedFieldEffects
 }
@@ -214,17 +236,19 @@ func (fc *functionCollector) collectUseEffects() {
 	})
 }
 
-// collectReturnEffects records this function's concrete nil result fields and return
-// forwarding edges, classifying each struct-shaped return operand once
-// (collectReturnOperandEffect).
-func (fc *functionCollector) collectReturnEffects() {
-	// Fast path: no struct-shaped result can ever produce a concrete return effect or forwarding
-	// edge, so the state preparation and walks below would do nothing.
+// collectReturnSites gathers everything derived from this function's return statements: concrete
+// nil result fields, return param sources, and return forwarding edges. One loop owns the site guards so
+// the param-source and effect collections always see the same return sites — the mixed construct/forward
+// drop in close() relies on that agreement.
+func (fc *functionCollector) collectReturnSites() {
+	// Fast path: no struct-shaped result can ever produce a concrete return effect, param source, or
+	// forwarding edge, so the state preparation and walks below would do nothing.
 	if !hasStructShapedResult(fc.sig) {
 		return
 	}
 	fc.allocationVars = collectStructAllocationVars(fc.pass, fc.fd.Body)
 	fc.stableVars = fc.collectStableStructVars()
+	fc.unstableParams = fc.collectUnstableParamVars()
 
 	for _, stmt := range returnStatements(fc.fd.Body) {
 		// A bare spreading return such as `return f()` is one expression that yields every
@@ -237,7 +261,8 @@ func (fc *functionCollector) collectReturnEffects() {
 			if typeshelper.AsDeeplyStruct(fc.sig.Results().At(resultIdx).Type()) == nil {
 				continue
 			}
-			fc.collectReturnOperandEffect(resultIdx, resultExpr)
+			fc.collectReturnSiteEffect(resultIdx, resultExpr)
+			fc.collectWholeResultParamSource(resultIdx, resultExpr)
 		}
 	}
 }
@@ -477,12 +502,13 @@ func (fc *functionCollector) collectStableStructVars() map[*types.Var]bool {
 	return stable
 }
 
-// collectReturnOperandEffect records what one struct-shaped return operand contributes to the
-// effects summary: a construction (direct or through a stable local) enumerates its nil fields;
-// a direct return of a static call result — or of a stable local bound to one — adds a return
-// forwarding edge.
-func (fc *functionCollector) collectReturnOperandEffect(resultIdx int, resultExpr ast.Expr) {
+// collectReturnSiteEffect records what one struct-shaped return operand contributes to the
+// effects summary: a construction (direct or through a stable local) enumerates its nil fields
+// and marks the result index as constructed (see markResultWithConstructSite); a direct return of a
+// static call result — or of a stable local bound to one — adds a return forwarding edge.
+func (fc *functionCollector) collectReturnSiteEffect(resultIdx int, resultExpr ast.Expr) {
 	if source, ok := staticStructAllocation(fc.pass, resultExpr); ok {
+		fc.collected.markResultWithConstructSite(fc.funcObj, resultIdx)
 		fc.enumerateConcreteReturnEffects(resultIdx, source.structType, source.fieldInits, "")
 		return
 	}
@@ -502,6 +528,7 @@ func (fc *functionCollector) collectReturnOperandEffect(resultIdx int, resultExp
 		return
 	}
 	if source, ok := fc.allocationVars[v]; ok {
+		fc.collected.markResultWithConstructSite(fc.funcObj, resultIdx)
 		fc.enumerateConcreteReturnEffects(resultIdx, source.structType, source.fieldInits, "")
 		return
 	}
@@ -527,7 +554,8 @@ func (fc *functionCollector) addReturnEdge(callerResultIdx int, target typeshelp
 	})
 }
 
-// enumerateConcreteReturnEffects records omitted and explicitly nil fields from one allocation.
+// enumerateConcreteReturnEffects records omitted and explicitly nil fields from one allocation,
+// and the field-level param sources of fields initialized from parameters (recordFieldParamSource).
 func (fc *functionCollector) enumerateConcreteReturnEffects(resultIdx int, structType *types.Struct, fieldInits []ast.Expr, prefix string) {
 	for i := range structType.NumFields() {
 		field := structType.Field(i)
@@ -544,6 +572,7 @@ func (fc *functionCollector) enumerateConcreteReturnEffects(resultIdx int, struc
 				fc.collected.addReturnEffect(fc.funcObj, IndexedFieldPath{Idx: resultIdx, Path: path})
 			}
 		default:
+			fc.recordFieldParamSource(resultIdx, path, fieldVal)
 			if source, ok := staticStructAllocation(fc.pass, fieldVal); ok {
 				fc.enumerateConcreteReturnEffects(resultIdx, source.structType, source.fieldInits, path)
 			}

--- a/assertion/function/structfieldeffects/effects.go
+++ b/assertion/function/structfieldeffects/effects.go
@@ -46,6 +46,9 @@ type BoundaryFieldEffects struct {
 	// ReturnEffects records (result idx, field path) pairs that are provably nil at a concrete
 	// construction return site. Closed over return forwarding edges.
 	ReturnEffects fieldEffects
+	// returnParamSources records, per function, the sources relating a result (or result field)
+	// to the parameter that supplies it. See ReturnParamSource for the collection rules.
+	returnParamSources returnParamSourceSet
 }
 
 // ParamReadPaths returns the field paths read from funcObj's parameter or receiver at idx.
@@ -98,6 +101,7 @@ func (c *collectedFieldEffects) close() *BoundaryFieldEffects {
 	closeParamFieldSets(c.summary.ParamWrites, c.paramForwardingEdges)
 	closeParamFieldSets(c.summary.ParamReads, c.paramForwardingEdges)
 	closeReturnEffects(c.summary.ReturnEffects, c.returnForwardingEdges)
+	c.dropMixedResultParamSources()
 	return c.summary
 }
 

--- a/assertion/function/structfieldeffects/effects_test.go
+++ b/assertion/function/structfieldeffects/effects_test.go
@@ -30,7 +30,9 @@ import (
 
 // _expectEffectsPrefix precedes a fixture function's expected boundary effects. Each trailing token
 // is "<kind>:<idx>:<path>", where kind identifies parameter writes, parameter reads, return reads,
-// or concrete return effects. A function with no effects carries an empty comment.
+// or concrete return effects; return param sources use the five-part
+// "return_param_source:<resultIdx>:<resultPath>:<paramIdx>:<paramPath>". A function with no effects
+// carries an empty comment.
 const _expectEffectsPrefix = "expect_effects:"
 
 func TestComputeBoundaryFieldEffects(t *testing.T) {
@@ -59,12 +61,17 @@ func TestComputeBoundaryFieldEffects(t *testing.T) {
 		wantReturn := make(map[*types.Func][]IndexedFieldPath)
 		wantWrites := make(map[*types.Func][]IndexedFieldPath)
 		wantReturnEffects := make(map[*types.Func][]IndexedFieldPath)
+		wantSources := make(map[*types.Func][]ReturnParamSource)
 		for node, tokens := range nilawaytest.FindExpectedValues(pass, _expectEffectsPrefix) {
 			fd, ok := node.(*ast.FuncDecl)
 			require.True(t, ok)
 			funcObj, ok := pass.TypesInfo.ObjectOf(fd.Name).(*types.Func)
 			require.True(t, ok)
 			for _, token := range tokens {
+				if source, ok := parseExpectedParamSource(t, token); ok {
+					wantSources[funcObj] = append(wantSources[funcObj], source)
+					continue
+				}
 				kind, key := parseExpectedEffect(t, token)
 				switch kind {
 				case "param_writes":
@@ -85,7 +92,27 @@ func TestComputeBoundaryFieldEffects(t *testing.T) {
 		requireEffects(t, effects.ReturnReads, wantReturn)
 		requireEffects(t, effects.ParamWrites, wantWrites)
 		requireEffects(t, effects.ReturnEffects, wantReturnEffects)
+		requireParamSources(t, effects, wantSources)
 	}
+}
+
+// parseExpectedParamSource parses a "return_param_source:<resultIdx>:<resultPath>:<paramIdx>:<paramPath>"
+// token, reporting ok=false for tokens of any other kind.
+func parseExpectedParamSource(t *testing.T, token string) (ReturnParamSource, bool) {
+	t.Helper()
+	parts := strings.Split(token, ":")
+	if parts[0] != "return_param_source" {
+		return ReturnParamSource{}, false
+	}
+	require.Lenf(t, parts, 5, "malformed return_param_source token %q", token)
+	resultIdx, err := strconv.Atoi(parts[1])
+	require.NoErrorf(t, err, "malformed result index in return_param_source token %q", token)
+	paramIdx, err := strconv.Atoi(parts[3])
+	require.NoErrorf(t, err, "malformed param index in return_param_source token %q", token)
+	return ReturnParamSource{
+		Result: IndexedFieldPath{Idx: resultIdx, Path: parts[2]},
+		Param:  IndexedFieldPath{Idx: paramIdx, Path: parts[4]},
+	}, true
 }
 
 // parseExpectedEffect splits a "<kind>:<idx>:<path>" expect_effects token into its kind and boundary key.
@@ -113,5 +140,22 @@ func requireEffects(t *testing.T, got fieldEffects, want map[*types.Func][]Index
 			gotKeys = append(gotKeys, key)
 		}
 		require.ElementsMatchf(t, want[funcObj], gotKeys, "effects mismatch for %s", funcObj.Name())
+	}
+}
+
+// requireParamSources asserts the collected return param sources match want for every function in either
+// set, so both missing and unexpected sources fail the test.
+func requireParamSources(t *testing.T, got *BoundaryFieldEffects, want map[*types.Func][]ReturnParamSource) {
+	t.Helper()
+	funcs := make(map[*types.Func]bool)
+	for funcObj := range got.returnParamSources {
+		funcs[funcObj] = true
+	}
+	for funcObj := range want {
+		funcs[funcObj] = true
+	}
+	for funcObj := range funcs {
+		require.ElementsMatchf(t, want[funcObj], got.ReturnParamSources(funcObj),
+			"return param sources mismatch for %s", funcObj.Name())
 	}
 }

--- a/assertion/function/structfieldeffects/return_contracts.go
+++ b/assertion/function/structfieldeffects/return_contracts.go
@@ -1,0 +1,209 @@
+//  Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file owns return param-source collection: the syntactic result <- parameter relations
+// (ReturnParamSource) recorded per function. The rest of the collector integrates through
+// three hooks — collectWholeResultParamSource for whole-result sources, recordFieldParamSource for
+// construction fields, and dropMixedResultParamSources in close(). The return-site iteration that
+// feeds collectWholeResultParamSource lives in collectReturnSites.
+
+package structfieldeffects
+
+import (
+	"cmp"
+	"go/ast"
+	"go/token"
+	"go/types"
+	"slices"
+
+	"go.uber.org/nilaway/util/asthelper"
+)
+
+// ReturnParamSource records a result (or result field) whose value is the caller's own argument:
+// the Result endpoint is supplied by the Param endpoint (the receiver uses
+// annotation.ReceiverParamIndex). An empty Result path denotes the whole result value
+// (`return p`, `return p.x`); an empty Param path the bare parameter. Collection is syntactic
+// and conservative: a source is recorded only when the relation holds on every path to the return
+// (see the drops in collectUnstableParamVars and dropMixedResultParamSources). Collected so later
+// revisions can resolve param-sourced results from the actual argument at each call site instead of the
+// shared return summary, severing one caller's argument from every other caller's result.
+type ReturnParamSource struct {
+	Result IndexedFieldPath
+	Param  IndexedFieldPath
+}
+
+// returnParamSourceSet maps each function to its set of return param sources.
+type returnParamSourceSet map[*types.Func]map[ReturnParamSource]bool
+
+// add records source for funcObj, allocating the inner set on first use.
+func (s returnParamSourceSet) add(funcObj *types.Func, source ReturnParamSource) {
+	if s[funcObj] == nil {
+		s[funcObj] = make(map[ReturnParamSource]bool)
+	}
+	s[funcObj][source] = true
+}
+
+// ReturnParamSources returns funcObj's return param sources in a deterministic order. The sources come
+// from a map-backed set and reach an exported fact and trigger emission, so map iteration order
+// must not affect either.
+func (e *BoundaryFieldEffects) ReturnParamSources(funcObj *types.Func) []ReturnParamSource {
+	if e == nil || len(e.returnParamSources[funcObj]) == 0 {
+		return nil
+	}
+	sources := make([]ReturnParamSource, 0, len(e.returnParamSources[funcObj]))
+	for c := range e.returnParamSources[funcObj] {
+		sources = append(sources, c)
+	}
+	slices.SortFunc(sources, func(a, b ReturnParamSource) int {
+		return cmp.Or(
+			a.Result.compare(b.Result),
+			a.Param.compare(b.Param),
+		)
+	})
+	return sources
+}
+
+// collectWholeResultParamSource records the whole-result param source of one return operand: a
+// returned parameter or parameter field chain (`return p`, `return p.x`, receiver variants).
+// Disagreeing sources for the same result (a different parameter per return site) are all kept —
+// consumers refuse to answer when sources disagree, which keeps the collected set deterministic. A
+// result index that both constructs in-package and carries a whole-result source is ambiguous and
+// dropped in close(); field-level sources of constructed results are recorded by
+// recordFieldParamSource instead.
+func (fc *functionCollector) collectWholeResultParamSource(resultIdx int, expr ast.Expr) {
+	source, ok := fc.resolveReturnParamSource(expr)
+	if !ok {
+		return
+	}
+	fc.collected.addReturnParamSource(fc.funcObj, ReturnParamSource{
+		Result: IndexedFieldPath{Idx: resultIdx},
+		Param:  source,
+	})
+}
+
+// recordFieldParamSource records the param source of one construction field: a field at path
+// within the result initialized from a stable parameter or a field chain rooted at one
+// (`return &T{f: p.x}` records result field `f` as supplied by param field `x`). Sources are
+// recorded for any field, not just nilable ones: a source on a value-struct field re-roots deeper
+// accesses (`result.V.Child` under source `V <- p.node` resolves to `p.node.Child`).
+func (fc *functionCollector) recordFieldParamSource(resultIdx int, path string, fieldVal ast.Expr) {
+	source, ok := fc.resolveReturnParamSource(fieldVal)
+	if !ok {
+		return
+	}
+	if !resultFieldPathIsAcyclic(fc.funcObj, resultIdx, path) ||
+		(source.Path != "" && !paramFieldPathIsAcyclic(fc.funcObj, source.Idx, source.Path)) {
+		return
+	}
+	fc.collected.addReturnParamSource(fc.funcObj, ReturnParamSource{
+		Result: IndexedFieldPath{Idx: resultIdx, Path: path},
+		Param:  source,
+	})
+}
+
+// dropMixedResultParamSources removes every param source of a result index that has an in-package
+// construction return site alongside a whole-result source. Such a result sometimes carries the
+// parameter and sometimes a fresh object, so no context-insensitive source is sound for it;
+// dropping is a deliberate under-report.
+func (c *collectedFieldEffects) dropMixedResultParamSources() {
+	for fn, results := range c.resultsWithConstructSite {
+		for idx := range results {
+			mixed := false
+			for source := range c.summary.returnParamSources[fn] {
+				if source.Result.Idx == idx && source.Result.Path == "" {
+					mixed = true
+					break
+				}
+			}
+			if mixed {
+				c.dropReturnParamSources(fn, idx)
+			}
+		}
+	}
+}
+
+func (c *collectedFieldEffects) dropReturnParamSources(fn *types.Func, result int) {
+	for key := range c.summary.returnParamSources[fn] {
+		if key.Result.Idx == result {
+			delete(c.summary.returnParamSources[fn], key)
+		}
+	}
+}
+
+// resolveReturnParamSource resolves expr as a stable parameter or a field chain rooted at one,
+// yielding the parameter (or receiver) endpoint: the parameter index and the dotted path within
+// it ("" for the bare parameter). An unstable parameter (reassigned or address-taken) resolves
+// to nothing: its value at the return may not be the caller's argument.
+func (fc *functionCollector) resolveReturnParamSource(expr ast.Expr) (IndexedFieldPath, bool) {
+	base, path := asthelper.SplitFieldChain(expr)
+	if base == nil {
+		return IndexedFieldPath{}, false
+	}
+	v, ok := fc.pass.TypesInfo.ObjectOf(base).(*types.Var)
+	if !ok {
+		return IndexedFieldPath{}, false
+	}
+	idx, ok := fc.paramIdx[v]
+	if !ok || fc.unstableParams[v] {
+		return IndexedFieldPath{}, false
+	}
+	return IndexedFieldPath{Idx: idx, Path: path}, true
+}
+
+// collectUnstableParamVars returns the parameters (and receiver) whose value at a return
+// statement cannot be assumed to be the caller's argument: parameters reassigned anywhere in the
+// body — including inside function literals, whose bodies run with the captured variable — or
+// having their address taken. A param source rooted at such a parameter would attribute some
+// other value to the caller's argument, so collection skips it (a sound under-report).
+func (fc *functionCollector) collectUnstableParamVars() map[*types.Var]bool {
+	var out map[*types.Var]bool
+	markUnstable := func(expr ast.Expr) {
+		ident, ok := ast.Unparen(expr).(*ast.Ident)
+		if !ok {
+			return
+		}
+		v, ok := fc.pass.TypesInfo.ObjectOf(ident).(*types.Var)
+		if !ok {
+			return
+		}
+		if _, isParam := fc.paramIdx[v]; !isParam {
+			return
+		}
+		if out == nil {
+			out = make(map[*types.Var]bool)
+		}
+		out[v] = true
+	}
+	ast.Inspect(fc.fd.Body, func(n ast.Node) bool {
+		switch n := n.(type) {
+		case *ast.AssignStmt:
+			// Only assignment targets destabilize; `:=` defines fresh variables whose objects
+			// differ from the parameters, so they never resolve to a parameter here.
+			for _, lhs := range n.Lhs {
+				markUnstable(lhs)
+			}
+		case *ast.UnaryExpr:
+			if n.Op == token.AND {
+				markUnstable(n.X)
+			}
+		case *ast.RangeStmt:
+			if n.Tok == token.ASSIGN {
+				markUnstable(n.Key)
+				markUnstable(n.Value)
+			}
+		}
+		return true
+	})
+	return out
+}

--- a/assertion/function/structfieldeffects/testdata/src/go.uber.org/returneffects/main.go
+++ b/assertion/function/structfieldeffects/testdata/src/go.uber.org/returneffects/main.go
@@ -56,7 +56,7 @@ func nestedAllocation() *Outer { // expect_effects: return_effects:0:Mid.Child r
 	return &Outer{Mid: &Node{}}
 }
 
-func unknownInitializer(mid *Node) *Outer { // expect_effects: return_effects:0:Value.Child
+func unknownInitializer(mid *Node) *Outer { // expect_effects: return_effects:0:Value.Child return_param_source:0:Mid:0:
 	return &Outer{
 		Mid:   mid,
 		Value: Node{},

--- a/assertion/function/structfieldeffects/testdata/src/go.uber.org/returneffects/paramdependent.go
+++ b/assertion/function/structfieldeffects/testdata/src/go.uber.org/returneffects/paramdependent.go
@@ -1,0 +1,117 @@
+//  Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is the fixture for return param sources (ReturnParamSource): results whose value is the
+// caller's own argument. Whole-result sources come from returned parameters and projections;
+// field-level sources come from construction fields initialized from parameters. Sources are dropped
+// whenever the syntactic relation is not unconditional: mixed construct/forward results,
+// reassigned or address-taken parameters, and spread returns.
+
+package returneffects
+
+// Pair copies caller-dependent values into a fresh allocation, so its fields are param-sourced rather
+// than summarized as concrete effects.
+type Pair struct {
+	Existing  *Leaf
+	Requested *Leaf
+}
+
+func forwardParam(y *Outer) *Outer { // expect_effects: return_param_source:0::0:
+	return y
+}
+
+func forwardParamProjection(y *Outer) *Node { // expect_effects: return_param_source:0::0:Mid param_reads:0:Mid
+	return y.Mid
+}
+
+func (o *Outer) receiverProjection() *Node { // expect_effects: return_param_source:0::-1:Mid param_reads:-1:Mid
+	return o.Mid
+}
+
+func forwardWithErr(y *Outer) (*Outer, error) { // expect_effects: return_param_source:0::0:
+	return y, nil
+}
+
+// Both branches' sources are kept even though they disagree; consumers refuse to answer a path
+// with disagreeing sources, so keeping both stays deterministic and sound.
+func forwardEitherParam(y *Outer, z *Outer, pick bool) *Outer { // expect_effects: return_param_source:0::0: return_param_source:0::1:
+	if pick {
+		return y
+	}
+	return z
+}
+
+func newPair(existing, requested *Leaf) *Pair { // expect_effects: return_param_source:0:Existing:0: return_param_source:0:Requested:1:
+	return &Pair{Existing: existing, Requested: requested}
+}
+
+// A nested construction records the source at the composed result path.
+func wrapChild(child *Leaf) *Outer { // expect_effects: return_param_source:0:Mid.Child:0: return_effects:0:Value.Child
+	return &Outer{Mid: &Node{Child: child}}
+}
+
+// A field initialized from a parameter field chain records the source path within the parameter.
+func wrapDeep(src *Outer) *Node { // expect_effects: return_param_source:0:Child:0:Mid.Child param_reads:0:Mid param_reads:0:Mid.Child
+	return &Node{Child: src.Mid.Child}
+}
+
+// A non-nilable value-struct field gets a source too: the source re-roots deeper accesses of the
+// result under the parameter (`result.Value.Child` resolves to `src.Value.Child`). Reading
+// `src.Value` itself creates no param-read demand (value structs bar nilness).
+func copyValueField(src *Outer) *Outer { // expect_effects: return_param_source:0:Value:0:Value return_effects:0:Mid
+	return &Outer{Value: src.Value}
+}
+
+// A result that sometimes constructs and sometimes forwards its parameter carries no sound source;
+// the whole-result source is dropped in close(). (The construct branch's concrete effects remain —
+// their interaction with mixed results is owned by a later fix revision.)
+func mixedConstructOrForward(y *Outer, pick bool) *Outer { // expect_effects: return_effects:0:Mid return_effects:0:Value.Child
+	if pick {
+		return &Outer{}
+	}
+	return y
+}
+
+// A reassigned parameter may not hold the caller's argument at the return: no source.
+func reassignedParam(y *Outer, z *Outer) *Outer { // expect_effects:
+	y = z
+	return y
+}
+
+// The reassigned parameter loses only its own sources; the stable sibling keeps its source.
+func reassignedBeforeConstruct(existing, requested *Leaf) *Pair { // expect_effects: return_param_source:0:Requested:1:
+	existing = nil
+	return &Pair{Existing: existing, Requested: requested}
+}
+
+// An address-taken parameter can be reassigned through the alias: no source.
+func addressTakenParam(y *Outer) *Outer { // expect_effects:
+	escapeOuter(&y)
+	return y
+}
+
+func escapeOuter(**Outer) {}
+
+// A closure reassignment destabilizes the captured parameter exactly like a direct one.
+func closureReassignedParam(y *Outer, z *Outer) *Outer { // expect_effects:
+	swap := func() { y = z }
+	swap()
+	return y
+}
+
+// A spread return supplies every result from one expression; no argument expression identifies a
+// single result, so no source is recorded (the forwarding edge machinery is also bypassed).
+func spreadReturn(y *Outer) (*Outer, error) { // expect_effects:
+	return forwardWithErr(y)
+}


### PR DESCRIPTION
Collect, per function, the relations `result (field) <- parameter (field)` that make a returned value depend on the caller's own argument — the marks later revisions use to sever caller-dependent results from the shared return summary and resolve them per call site. Collection is syntactic and refuses anything conditional or ambiguous; disagreeing sources for one result are all kept so consumers can detect the disagreement and refuse to answer. Collector only: sources stay package-internal and nothing consumes them yet, so reported errors are unchanged.

Changes
- Record whole-result sources at return sites (`return p`, `return p.x`, receiver variants) in `collectWholeResultParamSource`; spread returns record nothing.
- Record field-level sources for construction fields initialized from a parameter or parameter field chain (`return &T{f: p.x}`) in `enumerateConcreteReturnEffects`, for any field kind: a source on a value-struct field re-roots deeper accesses of the result under the parameter.
- Never source unstable parameters: reassigned, address-taken, or closure-reassigned parameters may not hold the caller's argument at the return (`collectUnstableParamVars`).
- Drop the whole-result sources of mixed construct/forward results in `close()`: a result with both an in-package construction return site (`resultsWithConstructSite`) and a whole-result source has no context-insensitive owner (`dropMixedResultParamSources`).
- Gate collected paths with the existing acyclicity checks on both the result and parameter sides.
- Rename the return walk to `collectReturnSites` / `collectReturnSiteEffect`: one loop owns the site guards so the param-source and effect collections see identical return sites — the mixed drop relies on that agreement.
- Cover with collector fixtures in `returneffects/paramdependent.go` (`return_param_source` expectations for constructor fields, deep chains, receiver projections, and every drop rule).
