### PR TITLE
refactor(struct-init-v2): unexport boundary field-effect sets

### DIFF
--- a/assertion/function/structfieldeffects/analyzer.go
+++ b/assertion/function/structfieldeffects/analyzer.go
@@ -58,14 +58,14 @@ func run(p *analysis.Pass) (*BoundaryFieldEffects, error) {
 	packageSummary := collected.close()
 	fact := &BoundaryFieldEffectsPackageFact{}
 	encoder := &objectpath.Encoder{}
-	funcs := make(map[*types.Func]bool, len(packageSummary.ParamReads)+len(packageSummary.ParamWrites)+len(packageSummary.ReturnEffects))
-	for funcObj := range packageSummary.ParamReads {
+	funcs := make(map[*types.Func]bool, len(packageSummary.paramReads)+len(packageSummary.paramWrites)+len(packageSummary.returnEffects))
+	for funcObj := range packageSummary.paramReads {
 		funcs[funcObj] = true
 	}
-	for funcObj := range packageSummary.ParamWrites {
+	for funcObj := range packageSummary.paramWrites {
 		funcs[funcObj] = true
 	}
-	for funcObj := range packageSummary.ReturnEffects {
+	for funcObj := range packageSummary.returnEffects {
 		funcs[funcObj] = true
 	}
 	for funcObj := range funcs {
@@ -74,9 +74,9 @@ func run(p *analysis.Pass) (*BoundaryFieldEffects, error) {
 		}
 		// Return reads remain local because callers infer them
 		// from their dereferences of results, opposite the direction of fact propagation.
-		reads := packageSummary.ParamReads.sortedPaths(funcObj)
-		writes := packageSummary.ParamWrites.sortedPaths(funcObj)
-		returnEffects := packageSummary.ReturnEffects.sortedPaths(funcObj)
+		reads := packageSummary.paramReads.sortedPaths(funcObj)
+		writes := packageSummary.paramWrites.sortedPaths(funcObj)
+		returnEffects := packageSummary.returnEffects.sortedPaths(funcObj)
 		if len(reads) == 0 && len(writes) == 0 && len(returnEffects) == 0 {
 			continue
 		}
@@ -131,9 +131,9 @@ func importUsedParamEffects(pass *analysishelper.EnhancedPass, effects *Boundary
 				return cmp.Compare(entry.FunctionObjectPath, path)
 			})
 			if found {
-				seedImportedParamEffects(effects.ParamReads, callee, fact.Functions[index].ParamReads)
-				seedImportedParamEffects(effects.ParamWrites, callee, fact.Functions[index].ParamWrites)
-				seedImportedParamEffects(effects.ReturnEffects, callee, fact.Functions[index].ReturnEffects)
+				seedImportedParamEffects(effects.paramReads, callee, fact.Functions[index].ParamReads)
+				seedImportedParamEffects(effects.paramWrites, callee, fact.Functions[index].ParamWrites)
+				seedImportedParamEffects(effects.returnEffects, callee, fact.Functions[index].ReturnEffects)
 			}
 		}
 	}

--- a/assertion/function/structfieldeffects/collector.go
+++ b/assertion/function/structfieldeffects/collector.go
@@ -42,10 +42,10 @@ type collectedFieldEffects struct {
 func newCollectedFieldEffects() *collectedFieldEffects {
 	return &collectedFieldEffects{
 		summary: &BoundaryFieldEffects{
-			ParamReads:         make(fieldEffects),
-			ReturnReads:        make(fieldEffects),
-			ParamWrites:        make(fieldEffects),
-			ReturnEffects:      make(fieldEffects),
+			paramReads:         make(fieldEffects),
+			returnReads:        make(fieldEffects),
+			paramWrites:        make(fieldEffects),
+			returnEffects:      make(fieldEffects),
 			returnParamSources: make(returnParamSourceSet),
 		},
 		paramForwardingEdges:     make(map[*types.Func][]paramFieldForwardEdge),
@@ -57,24 +57,24 @@ func newCollectedFieldEffects() *collectedFieldEffects {
 
 // addParamRead records that fn reads path from its parameter or receiver at fn's boundary.
 func (c *collectedFieldEffects) addParamRead(fn *types.Func, p IndexedFieldPath) {
-	c.summary.ParamReads.add(fn, p)
+	c.summary.paramReads.add(fn, p)
 }
 
 // addReturnRead records read demand on callee's result — callee is the function whose returned
 // value is dereferenced, not the function being collected.
 func (c *collectedFieldEffects) addReturnRead(callee *types.Func, p IndexedFieldPath) {
-	c.summary.ReturnReads.add(callee, p)
+	c.summary.returnReads.add(callee, p)
 }
 
 // addParamWrite records that fn writes path through its parameter or receiver.
 func (c *collectedFieldEffects) addParamWrite(fn *types.Func, p IndexedFieldPath) {
-	c.summary.ParamWrites.add(fn, p)
+	c.summary.paramWrites.add(fn, p)
 }
 
 // addReturnEffect records that fn's result field at p is provably nil at a construction return
 // site.
 func (c *collectedFieldEffects) addReturnEffect(fn *types.Func, p IndexedFieldPath) {
-	c.summary.ReturnEffects.add(fn, p)
+	c.summary.returnEffects.add(fn, p)
 }
 
 // addReturnParamSource records a source relating fn's result (or result field) to the parameter

--- a/assertion/function/structfieldeffects/effects.go
+++ b/assertion/function/structfieldeffects/effects.go
@@ -31,21 +31,21 @@ import (
 // The read sets bound the field binding at boundaries so it enumerates only the
 // field paths a boundary actually dereferences, never the full type graph.
 type BoundaryFieldEffects struct {
-	// ParamReads records (param idx, field path) pairs a function dereferences of that parameter —
+	// paramReads records (param idx, field path) pairs a function dereferences of that parameter —
 	// the demand a callee places on its caller's argument. Transitively closed over forwarding edges
 	// (a pure forwarder inherits its forwardees' reads), so a caller binds exactly the field paths
 	// the callee (and everything it forwards to) may dereference.
-	ParamReads fieldEffects
-	// ReturnReads records (result idx, field path) pairs that callers dereference of a function's
+	paramReads fieldEffects
+	// returnReads records (result idx, field path) pairs that callers dereference of a function's
 	// result — the demand callers place on a returned value, so a `return <var>` binds only those
 	// paths. Collected at call sites; not transitively closed (under-report only).
-	ReturnReads fieldEffects
-	// ParamWrites records (param idx, field path) pairs a function assigns through a parameter or
+	returnReads fieldEffects
+	// paramWrites records (param idx, field path) pairs a function assigns through a parameter or
 	// receiver. Transitively closed over forwarding edges.
-	ParamWrites fieldEffects
-	// ReturnEffects records (result idx, field path) pairs that are provably nil at a concrete
+	paramWrites fieldEffects
+	// returnEffects records (result idx, field path) pairs that are provably nil at a concrete
 	// construction return site. Closed over return forwarding edges.
-	ReturnEffects fieldEffects
+	returnEffects fieldEffects
 	// returnParamSources records, per function, the sources relating a result (or result field)
 	// to the parameter that supplies it. See ReturnParamSource for the collection rules.
 	returnParamSources returnParamSourceSet
@@ -56,7 +56,7 @@ func (e *BoundaryFieldEffects) ParamReadPaths(funcObj *types.Func, idx int) []st
 	if e == nil {
 		return nil
 	}
-	return fieldPathsForIndex(e.ParamReads, funcObj, idx)
+	return fieldPathsForIndex(e.paramReads, funcObj, idx)
 }
 
 // ReturnReadPaths returns the field paths read from funcObj's result at idx.
@@ -64,7 +64,7 @@ func (e *BoundaryFieldEffects) ReturnReadPaths(funcObj *types.Func, idx int) []s
 	if e == nil {
 		return nil
 	}
-	return fieldPathsForIndex(e.ReturnReads, funcObj, idx)
+	return fieldPathsForIndex(e.returnReads, funcObj, idx)
 }
 
 // ReturnEffectPaths returns the field paths that are provably nil in funcObj's result at idx.
@@ -72,7 +72,7 @@ func (e *BoundaryFieldEffects) ReturnEffectPaths(funcObj *types.Func, idx int) [
 	if e == nil {
 		return nil
 	}
-	return fieldPathsForIndex(e.ReturnEffects, funcObj, idx)
+	return fieldPathsForIndex(e.returnEffects, funcObj, idx)
 }
 
 // ParamWritePaths returns the field paths written through funcObj's parameter or receiver at idx.
@@ -80,7 +80,7 @@ func (e *BoundaryFieldEffects) ParamWritePaths(funcObj *types.Func, idx int) []s
 	if e == nil {
 		return nil
 	}
-	return fieldPathsForIndex(e.ParamWrites, funcObj, idx)
+	return fieldPathsForIndex(e.paramWrites, funcObj, idx)
 }
 
 func fieldPathsForIndex(effects fieldEffects, funcObj *types.Func, idx int) []string {
@@ -98,9 +98,9 @@ func fieldPathsForIndex(effects fieldEffects, funcObj *types.Func, idx int) []st
 }
 
 func (c *collectedFieldEffects) close() *BoundaryFieldEffects {
-	closeParamFieldSets(c.summary.ParamWrites, c.paramForwardingEdges)
-	closeParamFieldSets(c.summary.ParamReads, c.paramForwardingEdges)
-	closeReturnEffects(c.summary.ReturnEffects, c.returnForwardingEdges)
+	closeParamFieldSets(c.summary.paramWrites, c.paramForwardingEdges)
+	closeParamFieldSets(c.summary.paramReads, c.paramForwardingEdges)
+	closeReturnEffects(c.summary.returnEffects, c.returnForwardingEdges)
 	c.dropMixedResultParamSources()
 	return c.summary
 }

--- a/assertion/function/structfieldeffects/effects_test.go
+++ b/assertion/function/structfieldeffects/effects_test.go
@@ -88,10 +88,10 @@ func TestComputeBoundaryFieldEffects(t *testing.T) {
 			}
 		}
 
-		requireEffects(t, effects.ParamReads, wantParam)
-		requireEffects(t, effects.ReturnReads, wantReturn)
-		requireEffects(t, effects.ParamWrites, wantWrites)
-		requireEffects(t, effects.ReturnEffects, wantReturnEffects)
+		requireEffects(t, effects.paramReads, wantParam)
+		requireEffects(t, effects.returnReads, wantReturn)
+		requireEffects(t, effects.paramWrites, wantWrites)
+		requireEffects(t, effects.returnEffects, wantReturnEffects)
 		requireParamSources(t, effects, wantSources)
 	}
 }

--- a/assertion/function/structfieldeffects/fact_test.go
+++ b/assertion/function/structfieldeffects/fact_test.go
@@ -46,12 +46,12 @@ func TestFact(t *testing.T) { //nolint:paralleltest
 
 		localReads := make(fieldEffects)
 		localWrites := make(fieldEffects)
-		for funcObj, reads := range effects.Res.ParamReads {
+		for funcObj, reads := range effects.Res.paramReads {
 			if funcObj.Pkg() == pass.Pkg {
 				localReads[funcObj] = reads
 			}
 		}
-		for funcObj, writes := range effects.Res.ParamWrites {
+		for funcObj, writes := range effects.Res.paramWrites {
 			if funcObj.Pkg() == pass.Pkg {
 				localWrites[funcObj] = writes
 			}


### PR DESCRIPTION
The four field-effect sets of BoundaryFieldEffects were exported while every consumer outside the package already goes through the sorted accessor methods (ParamReadPaths, ReturnReadPaths, ParamWritePaths, ReturnEffectPaths). The map-backed sets must never be read in map iteration order — the accessors own the deterministic ordering — so the fields become unexported to make the accessors the only interface, matching returnParamSources.