### PR TITLE
fix(struct-init-v2): keep address-of field writes non-nil at the pointer level

### DIFF
--- a/assertion/function/assertiontree/backprop.go
+++ b/assertion/function/assertiontree/backprop.go
@@ -714,6 +714,23 @@ buildShadowMask:
 							}
 						}
 
+						if rootNode.functionContext.functionConfig.EnableStructInitV2 {
+							if u, ok := ast.Unparen(rhsVal).(*ast.UnaryExpr); ok && u.Op == token.AND {
+								// The address is non-nil, while its fields still land on the pointee below.
+								producer := &annotation.ProduceTrigger{
+									Annotation: &annotation.ProduceTriggerNever{},
+									Expr:       rhsVal,
+								}
+								for _, consumer := range lhsNode.ConsumeTriggers() {
+									rootNode.AddNewTriggers(annotation.FullTrigger{
+										Producer: producer,
+										Consumer: consumer,
+									})
+								}
+								lhsNode.SetConsumeTriggers(nil)
+							}
+						}
+
 						// If the lhsVal path is not only trackable but tracked, we add it as
 						// a deferred landing
 						landings = append(landings, deferredLanding{

--- a/assertion/function/assertiontree/structinitv2.go
+++ b/assertion/function/assertiontree/structinitv2.go
@@ -154,14 +154,9 @@ func (r *RootAssertionNode) addFieldProducers(structType *types.Struct, fieldIni
 	}
 }
 
-// isLocalRootedValue reports whether expr is a function-local variable, a field chain rooted
-// at one, or the address of either. Locals have no boundary annotation to snapshot statically, so
-// callers must resolve them through their flow-sensitive producers instead. Address-of is
-// unwrapped because even a proven-non-nil pointer snapshot carries no pointee field shape.
+// isLocalRootedValue reports whether expr is a function-local variable or a field chain rooted
+// at one. Locals have no boundary annotation and must be resolved through flow-sensitive producers.
 func (r *RootAssertionNode) isLocalRootedValue(expr ast.Expr) bool {
-	if u, ok := ast.Unparen(expr).(*ast.UnaryExpr); ok && u.Op == token.AND {
-		expr = u.X
-	}
 	base, _ := asthelper.SplitFieldChain(expr)
 	if base == nil {
 		return false

--- a/testdata/src/go.uber.org/structinitv2/paramsideeffect/addrofpointerlevel.go
+++ b/testdata/src/go.uber.org/structinitv2/paramsideeffect/addrofpointerlevel.go
@@ -1,0 +1,138 @@
+//  Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Tests that a field write whose RHS is an address-of expression (`x.f = &local`) is non-nil at
+// the pointer level, no matter how the pointee's value was produced. In particular, storing the
+// address of an error-returning call's value result BEFORE the error check (a common
+// code-generation pattern: `mr, err := f(); data.resp = &mr; if err != nil { return err }`) must
+// not blame the guarded call result for the pointer-level read: `&mr` can never be nil. The
+// pointee's field-level nilability must still flow (a nil field of the pointee stays reported).
+
+package paramsideeffect
+
+import "errors"
+
+type payload struct {
+	x   int
+	ptr *int
+}
+
+type box struct {
+	resp *payload
+}
+
+// makePayload is an error-returning function with a struct value result: on failure the value
+// result is meaningless, but its ADDRESS is still a valid non-nil pointer.
+func makePayload(fail bool) (payload, error) {
+	if fail {
+		return payload{}, errors.New("failed")
+	}
+	return payload{x: 1, ptr: new(int)}, nil
+}
+
+// Case 1 — the code-generation shape: store `&mr` before the error check, then a callee derefs
+// the written field. The pointer-level deref is safe.
+func storeAddrThenCheck(b *box, fail bool) error {
+	mr, err := makePayload(fail)
+	b.resp = &mr // stored pointer is non-nil even on the error path
+	if err != nil {
+		return err
+	}
+	return useBox(b)
+}
+
+func useBox(b *box) error {
+	b.resp.x = 2 // safe: b.resp was assigned the address of a local
+	return nil
+}
+
+// Case 2 — post-call read in the caller (param-out summary): the written field is non-nil after
+// the call regardless of the returned error.
+func readAfterStore() int {
+	b := &box{}
+	_ = storeAddrThenCheck(b, true)
+	return b.resp.x // safe: storeAddrThenCheck unconditionally stores a non-nil pointer
+}
+
+// Case 3 — the pointee's FIELD-level nilability still flows: a nil field of the local reaching a
+// callee's deref stays reported.
+func storeAddrWithNilField(b *box) {
+	mr := payload{} // ptr left nil
+	b.resp = &mr
+	derefPayloadPtr(b)
+}
+
+func derefPayloadPtr(b *box) int {
+	return *b.resp.ptr //want "dereferenced"
+}
+
+// Case 4 — over-discharge guard: a genuinely nil field write must still be reported at the
+// pointer level.
+func clearResp(b *box) {
+	b.resp = nil
+}
+
+func readCleared() int {
+	b := &box{resp: &payload{}}
+	clearResp(b)
+	return b.resp.x //want "field `resp` of param 0 of `clearResp`"
+}
+
+// Case 5 — local alias of the address: `resp := &mr` before the error check, deref after. The
+// deref is of the alias (a non-nil address), not of the call result.
+func aliasAddrOf(fail bool) int {
+	mr, err := makePayload(fail)
+	resp := &mr
+	if err != nil {
+		return 0
+	}
+	return resp.x // safe: resp is the address of a local
+}
+
+// Case 6 — address of a field chain rooted at a local: still a non-nil pointer.
+type holder struct {
+	inner payload
+}
+
+func storeAddrOfFieldChain(b *box) {
+	h := holder{inner: payload{x: 3, ptr: new(int)}}
+	b.resp = &h.inner
+	_ = useBox(b)
+}
+
+// Case 7 — boundary of this fix (pre-existing behavior, unaffected): a POINTER-typed result
+// stored before the error check is not an address-of — the stored value really is the call
+// result, which is nil on the error path. The store-site read is unguarded, so the flow is
+// reported at the callee's deref. (Correlating "the deref only happens on the success path"
+// through a field store is a separate, unimplemented refinement.)
+func makePayloadPtr(fail bool) (*payload, error) {
+	if fail {
+		return nil, errors.New("failed")
+	}
+	return &payload{x: 1}, nil
+}
+
+func storePtrThenCheck(b *box, fail bool) error {
+	mrp, err := makePayloadPtr(fail)
+	b.resp = mrp
+	if err != nil {
+		return err
+	}
+	return useBoxPtrResult(b)
+}
+
+func useBoxPtrResult(b *box) error {
+	b.resp.x = 2 //want "lacking guarding"
+	return nil
+}


### PR DESCRIPTION
Address-of assignments such as `d.resp = &mr` incorrectly re-keyed the destination pointer obligation onto the pointee producer in both intra-procedural backpropagation and parameter-output summaries. That produced a false positive when `mr` came from a guarded result even though `&mr` is always non-nil; preserving the address expression as a never-nil shallow producer removes the pointer-level error while retaining pointee field flows.

Changes
- Match direct LHS consumers with a never-nil producer before the case-C landing so child obligations continue through the pointee and still report nil fields.
- Exclude address-of expressions from `isLocalRootedValue` so `bindParamFieldWriteToContext` snapshots their always-non-nil shallow producer instead of associating the `PARAM_OUT` supply with the pointee.
- Add `paramsideeffect` coverage for store-before-check flows, caller reads, nil pointee fields, genuinely nil writes, local aliases, field chains, and nilable pointer results.