### PR TITLE
feat(struct-init-v2): sever caller-dependent results from shared return sites

### DIFF
--- a/assertion/function/assertiontree/func_assertion_node.go
+++ b/assertion/function/assertiontree/func_assertion_node.go
@@ -41,6 +41,13 @@ func (f *funcAssertionNode) DefaultTrigger() annotation.ProducingAnnotationTrigg
 		panic("only functions with singular result should be entered into the assertion tree")
 	}
 
+	// A result value supplied by a caller argument must not be read from the shared declaration
+	// return, which merges unrelated callers (see getFuncReturnProducers).
+	if root := f.Root(); root != nil && root.functionContext.functionConfig.EnableStructInitV2 &&
+		root.resultValueHasParamSource(f.decl, 0) {
+		return &annotation.ProduceTriggerNever{}
+	}
+
 	if f.decl.Type().(*types.Signature).Recv() != nil {
 		return &annotation.MethodReturn{
 			TriggerIfNilable: &annotation.TriggerIfNilable{

--- a/assertion/function/assertiontree/parse_expr_producer.go
+++ b/assertion/function/assertiontree/parse_expr_producer.go
@@ -573,20 +573,29 @@ func (r *RootAssertionNode) getFuncReturnProducers(ident *ast.Ident, expr *ast.C
 			fieldProducers = r.getFieldProducersForFuncReturns(funcObj, i)
 		}
 
+		var shallowAnnotation annotation.ProducingAnnotationTrigger = &annotation.FuncReturn{
+			TriggerIfNilable: &annotation.TriggerIfNilable{
+				Ann: retKey,
+
+				// for an error-returning function, all but the last result are guarded
+				// TODO: add an annotation that allows more results to escape from guarding
+				// such as "error-nonnil" or "always-nonnil"
+				NeedsGuard: (isErrReturning || isOkReturning) && i != numResults-1,
+			},
+			IsFromRichCheckEffectFunc: isErrReturning || isOkReturning,
+		}
+		// A result value supplied by a caller argument must not be read from the shared
+		// declaration return, which merges unrelated callers. This revision produces
+		// "no evidence of nil" instead (a documented under-report; the per-call resolution lands
+		// in the following revisions).
+		if r.functionContext.functionConfig.EnableStructInitV2 && r.resultValueHasParamSource(funcObj, i) {
+			shallowAnnotation = &annotation.ProduceTriggerNever{}
+		}
+
 		producers[i] = producer.DeepParsedProducer{
 			ShallowProducer: &annotation.ProduceTrigger{
-				Annotation: &annotation.FuncReturn{
-					TriggerIfNilable: &annotation.TriggerIfNilable{
-						Ann: retKey,
-
-						// for an error-returning function, all but the last result are guarded
-						// TODO: add an annotation that allows more results to escape from guarding
-						// such as "error-nonnil" or "always-nonnil"
-						NeedsGuard: (isErrReturning || isOkReturning) && i != numResults-1,
-					},
-					IsFromRichCheckEffectFunc: isErrReturning || isOkReturning,
-				},
-				Expr: expr,
+				Annotation: shallowAnnotation,
+				Expr:       expr,
 			},
 			DeepProducer: &annotation.ProduceTrigger{
 				Annotation: annotation.DeepNilabilityOfFuncRet(funcObj, i),

--- a/assertion/function/assertiontree/structinitv2.go
+++ b/assertion/function/assertiontree/structinitv2.go
@@ -18,10 +18,12 @@ import (
 	"go/ast"
 	"go/token"
 	"go/types"
+	"slices"
 	"sort"
 	"strings"
 
 	"go.uber.org/nilaway/annotation"
+	"go.uber.org/nilaway/assertion/function/structfieldeffects"
 	"go.uber.org/nilaway/guard"
 	"go.uber.org/nilaway/util/asthelper"
 	"go.uber.org/nilaway/util/typeshelper"
@@ -84,6 +86,22 @@ func (r *RootAssertionNode) addAllocationFieldProducers(lhsVal, rhsVal ast.Expr)
 			}
 		}
 	}
+}
+
+// resultPathHasParamSource reports whether funcObj's (resultIdx, resultPath) is supplied by a
+// caller argument.
+func (r *RootAssertionNode) resultPathHasParamSource(funcObj *types.Func, resultIdx int, resultPath string) bool {
+	sources := r.functionContext.boundaryFieldEffects.ReturnParamSources(funcObj)
+	return slices.ContainsFunc(sources, func(src structfieldeffects.ReturnParamSource) bool {
+		return src.SuppliesResultPath(resultIdx, resultPath)
+	})
+}
+
+// resultValueHasParamSource reports whether funcObj's resultIdx-th result value itself (not a
+// field of it) is supplied by a caller argument — a whole-result source from `return p` or
+// `return p.x`.
+func (r *RootAssertionNode) resultValueHasParamSource(funcObj *types.Func, resultIdx int) bool {
+	return r.resultPathHasParamSource(funcObj, resultIdx, "")
 }
 
 // getShallowExprNilabilityProducer returns the producer encoding the nilability of the value of expr: an
@@ -225,6 +243,11 @@ func (r *RootAssertionNode) addContextFieldProducers(_ *types.Struct, base ast.E
 		}
 	}
 	for _, p := range paths {
+		// A param-sourced return path is caller-dependent and is never solved on the shared
+		// return sites
+		if kind == annotation.StructFieldReturnContext && r.resultPathHasParamSource(funcObj, index, p.path) {
+			continue
+		}
 		site := &annotation.StructFieldContextSite{
 			FuncObj: funcObj, Kind: kind, Index: index, Path: p.path,
 		}
@@ -274,6 +297,11 @@ func (r *RootAssertionNode) bindReturnFieldsToContext(node *ast.ReturnStmt) {
 	for retIdx, retExpr := range node.Results {
 		structType := typeshelper.AsDeeplyStruct(sig.Results().At(retIdx).Type())
 		if structType == nil {
+			continue
+		}
+		// A result value supplied by a caller argument is resolved at each call site from that
+		// argument.
+		if r.resultValueHasParamSource(r.FuncObj(), retIdx) {
 			continue
 		}
 		r.bindValueFieldsToContext(r.FuncObj(), retExpr, structType, annotation.StructFieldReturnContext, retIdx)
@@ -373,6 +401,11 @@ func (r *RootAssertionNode) bindCallResultFieldsToContext(call *ast.CallExpr, va
 	}
 	sort.Strings(paths)
 	for _, fieldPath := range paths {
+		// Param-sourced paths of the callee are caller-dependent: forwarding them
+		// through the shared return sites would merge callers.
+		if r.resultPathHasParamSource(source.Origin, 0, fieldPath) {
+			continue
+		}
 		site := &annotation.StructFieldContextSite{FuncObj: targetFunc, Kind: kind, Index: index, Path: fieldPath}
 		srcSite := &annotation.StructFieldContextSite{
 			FuncObj: source.Origin, Kind: annotation.StructFieldReturnContext, Index: 0, Path: fieldPath,

--- a/assertion/function/structfieldeffects/analyzer.go
+++ b/assertion/function/structfieldeffects/analyzer.go
@@ -68,6 +68,9 @@ func run(p *analysis.Pass) (*BoundaryFieldEffects, error) {
 	for funcObj := range packageSummary.returnEffects {
 		funcs[funcObj] = true
 	}
+	for funcObj := range packageSummary.returnParamSources {
+		funcs[funcObj] = true
+	}
 	for funcObj := range funcs {
 		if funcObj.Pkg() != pass.Pkg || !funcObj.Exported() {
 			continue
@@ -77,7 +80,8 @@ func run(p *analysis.Pass) (*BoundaryFieldEffects, error) {
 		reads := packageSummary.paramReads.sortedPaths(funcObj)
 		writes := packageSummary.paramWrites.sortedPaths(funcObj)
 		returnEffects := packageSummary.returnEffects.sortedPaths(funcObj)
-		if len(reads) == 0 && len(writes) == 0 && len(returnEffects) == 0 {
+		sources := packageSummary.returnParamSources.sortedSources(funcObj)
+		if len(reads) == 0 && len(writes) == 0 && len(returnEffects) == 0 && len(sources) == 0 {
 			continue
 		}
 		path, err := encoder.For(funcObj)
@@ -89,6 +93,7 @@ func run(p *analysis.Pass) (*BoundaryFieldEffects, error) {
 			ParamReads:         reads,
 			ParamWrites:        writes,
 			ReturnEffects:      returnEffects,
+			ReturnParamSources: sources,
 		})
 	}
 	if len(fact.Functions) > 0 {
@@ -134,6 +139,9 @@ func importUsedParamEffects(pass *analysishelper.EnhancedPass, effects *Boundary
 				seedImportedParamEffects(effects.paramReads, callee, fact.Functions[index].ParamReads)
 				seedImportedParamEffects(effects.paramWrites, callee, fact.Functions[index].ParamWrites)
 				seedImportedParamEffects(effects.returnEffects, callee, fact.Functions[index].ReturnEffects)
+				for _, source := range fact.Functions[index].ReturnParamSources {
+					effects.returnParamSources.add(callee, source)
+				}
 			}
 		}
 	}

--- a/assertion/function/structfieldeffects/fact.go
+++ b/assertion/function/structfieldeffects/fact.go
@@ -30,4 +30,5 @@ type FunctionFieldEffects struct {
 	ParamReads         []IndexedFieldPath
 	ParamWrites        []IndexedFieldPath
 	ReturnEffects      []IndexedFieldPath
+	ReturnParamSources []ReturnParamSource
 }

--- a/assertion/function/structfieldeffects/fact_test.go
+++ b/assertion/function/structfieldeffects/fact_test.go
@@ -71,7 +71,7 @@ func TestBoundaryFieldEffectsPackageFactCodec(t *testing.T) {
 		require.NoError(t, gob.NewEncoder(&buf).Encode(fact))
 		encoded := append([]byte(nil), buf.Bytes()...)
 		require.NotEmpty(t, encoded)
-		require.Less(t, len(encoded), 15_000,
+		require.Less(t, len(encoded), 20_000,
 			"encoded facts contribute to artifact size; increase this cap only with justification")
 
 		var decoded BoundaryFieldEffectsPackageFact
@@ -178,6 +178,12 @@ func newFact(functionCount int) *BoundaryFieldEffectsPackageFact {
 			},
 			ReturnEffects: []IndexedFieldPath{
 				{Idx: 0, Path: "Result"},
+			},
+			ReturnParamSources: []ReturnParamSource{
+				{
+					Result: IndexedFieldPath{Idx: 0, Path: "Result.Child"},
+					Param:  IndexedFieldPath{Idx: 1, Path: "Child"},
+				},
 			},
 		}
 	}

--- a/assertion/function/structfieldeffects/return_contracts.go
+++ b/assertion/function/structfieldeffects/return_contracts.go
@@ -26,6 +26,7 @@ import (
 	"go/token"
 	"go/types"
 	"slices"
+	"strings"
 
 	"go.uber.org/nilaway/util/asthelper"
 )
@@ -43,6 +44,20 @@ type ReturnParamSource struct {
 	Param  IndexedFieldPath
 }
 
+// SuppliesResultPath reports whether s supplies the value at (resultIdx, resultPath): a
+// whole-result source (empty result path) supplies every path of that result, and a field-level
+// source supplies its exact path and everything beneath it. The prefix match is per segment —
+// source `Mid` supplies `Mid.Child` but not the sibling field `Middle`.
+func (s ReturnParamSource) SuppliesResultPath(resultIdx int, resultPath string) bool {
+	if s.Result.Idx != resultIdx {
+		return false
+	}
+	if s.Result.Path == "" {
+		return true
+	}
+	return resultPath == s.Result.Path || strings.HasPrefix(resultPath, s.Result.Path+".")
+}
+
 // returnParamSourceSet maps each function to its set of return param sources.
 type returnParamSourceSet map[*types.Func]map[ReturnParamSource]bool
 
@@ -54,15 +69,15 @@ func (s returnParamSourceSet) add(funcObj *types.Func, source ReturnParamSource)
 	s[funcObj][source] = true
 }
 
-// ReturnParamSources returns funcObj's return param sources in a deterministic order. The sources come
+// sortedSources returns funcObj's return param sources in a deterministic order. The sources come
 // from a map-backed set and reach an exported fact and trigger emission, so map iteration order
 // must not affect either.
-func (e *BoundaryFieldEffects) ReturnParamSources(funcObj *types.Func) []ReturnParamSource {
-	if e == nil || len(e.returnParamSources[funcObj]) == 0 {
+func (s returnParamSourceSet) sortedSources(funcObj *types.Func) []ReturnParamSource {
+	if len(s[funcObj]) == 0 {
 		return nil
 	}
-	sources := make([]ReturnParamSource, 0, len(e.returnParamSources[funcObj]))
-	for c := range e.returnParamSources[funcObj] {
+	sources := make([]ReturnParamSource, 0, len(s[funcObj]))
+	for c := range s[funcObj] {
 		sources = append(sources, c)
 	}
 	slices.SortFunc(sources, func(a, b ReturnParamSource) int {
@@ -72,6 +87,14 @@ func (e *BoundaryFieldEffects) ReturnParamSources(funcObj *types.Func) []ReturnP
 		)
 	})
 	return sources
+}
+
+// ReturnParamSources returns funcObj's return param sources in the sortedSources order.
+func (e *BoundaryFieldEffects) ReturnParamSources(funcObj *types.Func) []ReturnParamSource {
+	if e == nil {
+		return nil
+	}
+	return e.returnParamSources.sortedSources(funcObj)
 }
 
 // collectWholeResultParamSource records the whole-result param source of one return operand: a

--- a/nilaway_test.go
+++ b/nilaway_test.go
@@ -125,6 +125,8 @@ func TestStructInitV2(t *testing.T) { //nolint:paralleltest
 		"go.uber.org/structinitv2/paramsideeffect",
 		"go.uber.org/structinitv2/returnlocal",
 		"go.uber.org/structinitv2/returnzerovalue/app",
+		// go.uber.org/structinitv2/returnshape/app asserts the per-call resolution of
+		// param-sourced results; enable it when call-site sensitivity of param-sourced results lands.
 	)
 }
 

--- a/testdata/src/go.uber.org/structinitv2/crosspkg/app/fieldvalueescape.go
+++ b/testdata/src/go.uber.org/structinitv2/crosspkg/app/fieldvalueescape.go
@@ -22,7 +22,10 @@ import "go.uber.org/structinitv2/crosspkg/shared"
 
 func unsafeFieldValueEscape() {
 	a := &shared.A{}
-	usePtr(shared.Get(a).Ptr) //want "uninitialized field `Aptr`"
+	// Temporarily silent: shared.Get carries a whole-result param source (imported through the
+	// effects fact), so its result is severed from the shared return summary; flips back to a
+	// per-call report when call-site resolution lands.
+	usePtr(shared.Get(a).Ptr)
 }
 
 func safeFieldValueEscape() {

--- a/testdata/src/go.uber.org/structinitv2/paramfield/fieldvalueescape.go
+++ b/testdata/src/go.uber.org/structinitv2/paramfield/fieldvalueescape.go
@@ -35,7 +35,11 @@ func escapeDirect(b *escapeBox) *escapeLeaf {
 
 func useEscapeDirectUnsafe() {
 	b := &escapeBox{}
-	print(escapeDirect(b).ptr) //want "uninitialized field `inner`"
+	// Temporarily silent: `return b.inner` is a whole-result param source, so the result is
+	// severed from the shared return summary (which would merge this nil flow into
+	// useEscapeDirectSafe below). Flips back to a per-call report when call-site resolution
+	// lands.
+	print(escapeDirect(b).ptr)
 }
 
 func useEscapeDirectSafe() {
@@ -60,13 +64,15 @@ func useEscapeSnapshotSafe() {
 }
 
 // The same value demand applies to a method receiver boundary. No safe negative control here:
-// the method's shared return site currently merges all callers, so a safe caller of innerValue
-// would inherit this caller's nil flow (context-insensitive return merge).
+// before the param-source sever, the method's shared return site merged all callers, so a safe
+// caller of innerValue would have inherited this caller's nil flow.
 func (b *escapeBox) innerValue() *escapeLeaf {
 	return b.inner
 }
 
 func useReceiverEscapeUnsafe() {
 	b := &escapeBox{}
-	print(b.innerValue().ptr) //want "uninitialized field `inner`"
+	// Temporarily silent: receiver-projection param sources sever the result from the shared summary;
+	// flips back to a per-call report when call-site resolution lands.
+	print(b.innerValue().ptr)
 }


### PR DESCRIPTION
Shared return summaries conflate param-sourced results across callers, causing false positives when a nil argument from one caller taints a result for another. Sever those result paths from context-insensitive reads and writes; this deliberately under-reports until subsequent per-call resolution restores caller-specific true positives.

Changes
- Export `ReturnParamSources` through package facts and cover the complete fact schema in the deterministic codec test.
- Skip governed paths in call-result reads, forwarding links, and callee return bindings, including shallow declaration-return reads.
- Update staged integration expectations to pin safe, no-poison, and temporarily silent unsafe scenarios.