### PR TITLE
Fix stale method implementation expectations

### DIFF
--- a/nilaway_test.go
+++ b/nilaway_test.go
@@ -63,7 +63,7 @@ func TestNilAway(t *testing.T) {
 		{name: "NilCheck", patterns: []string{"go.uber.org/nilcheck"}},
 		{name: "SimpleFlow", patterns: []string{"go.uber.org/simpleflow"}},
 		{name: "LoopFlow", patterns: []string{"go.uber.org/loopflow"}},
-		{name: "MethodImplementation", patterns: []string{"go.uber.org/methodimplementation", "go.uber.org/methodimplementation/mergedDependencies", "go.uber.org/methodimplementation/chainedDependencies", "go.uber.org/methodimplementation/multipackage", "go.uber.org/methodimplementation/embedding"}},
+		{name: "MethodImplementation", patterns: []string{"go.uber.org/methodimplementation/..."}},
 		{name: "NamedReturn", patterns: []string{"go.uber.org/namedreturn"}},
 		{name: "IgnoreGenerated", patterns: []string{"go.uber.org/ignoregenerated"}},
 		{name: "IgnorePackage", patterns: []string{"ignoredpkg1", "ignoredpkg2"}},

--- a/testdata/src/go.uber.org/methodimplementation/chainedDependencies/packageB/file2.go
+++ b/testdata/src/go.uber.org/methodimplementation/chainedDependencies/packageB/file2.go
@@ -20,7 +20,7 @@ import (
 
 type S1 struct{}
 
-func (*S1) Foo(n *int) bool { //want "passed as param"
+func (*S1) Foo(n *int) bool {
 	v := &n
 	return v != nil
 }

--- a/testdata/src/go.uber.org/methodimplementation/mergedDependencies/packageA/file1.go
+++ b/testdata/src/go.uber.org/methodimplementation/mergedDependencies/packageA/file1.go
@@ -15,7 +15,7 @@
 package packageA
 
 type I1 interface {
-	Foo1() *int //want "returned as result"
+	Foo1() *int
 
 	// nilable(n)
 	Foo2(n *int) bool
@@ -29,7 +29,7 @@ func (*S1) Foo1() *int {
 	return v
 }
 
-func (*S1) Foo2(n *int) bool { //want "passed as param"
+func (*S1) Foo2(n *int) bool {
 	v := &n
 	return v != nil
 }

--- a/testdata/src/go.uber.org/methodimplementation/mergedDependencies/packageB/file2.go
+++ b/testdata/src/go.uber.org/methodimplementation/mergedDependencies/packageB/file2.go
@@ -15,7 +15,7 @@
 package packageB
 
 type I2 interface {
-	Bar() *string //want "returned as result"
+	Bar() *string
 }
 
 type S2 struct{}

--- a/testdata/src/go.uber.org/methodimplementation/multipackage/packageA/interfacefile.go
+++ b/testdata/src/go.uber.org/methodimplementation/multipackage/packageA/interfacefile.go
@@ -20,5 +20,5 @@ import (
 
 type I9 interface {
 	// nilable(x)
-	Foo(x *packageB.A9) (*packageB.A9, string) //want "returned as result"
+	Foo(x *packageB.A9) (*packageB.A9, string)
 }

--- a/testdata/src/go.uber.org/methodimplementation/multipackage/packageB/structfile.go
+++ b/testdata/src/go.uber.org/methodimplementation/multipackage/packageB/structfile.go
@@ -19,7 +19,7 @@ type A9 struct {
 }
 
 // nilable(result 0)
-func (a *A9) Foo(x *A9) (*A9, string) { //want "passed as param"
+func (a *A9) Foo(x *A9) (*A9, string) {
 	var b *A9
 	return b, x.S
 }

--- a/testdata/src/go.uber.org/methodimplementation/multipackage/packageC/instantiationfile.go
+++ b/testdata/src/go.uber.org/methodimplementation/multipackage/packageC/instantiationfile.go
@@ -23,3 +23,8 @@ func M9() packageA.I9 {
 	var v packageA.I9 = &packageB.A9{"abc"}
 	return v
 }
+
+// The diagnostic is reported while analyzing this package, but its position is in packageB.
+// Use a line directive so analysistest can associate this expectation with that position.
+//line ../packageB/structfile.go:24
+// want "function parameter `x` accessed field `S`"


### PR DESCRIPTION
The MethodImplementation test previously listed only parent packages, so `analysistest` did not validate `// want` comments in dependency-only leaf packages. Run the test recursively so every MethodImplementation subpackage is validated as a root, remove expectations that no longer reflect full-inference behavior, and retain the legitimate multipackage diagnostic at its actual package B source position.
