### PR TITLE
Fail golden tests on internal panics

### DIFF
--- a/accumulation/analyzer.go
+++ b/accumulation/analyzer.go
@@ -83,7 +83,10 @@ func run(p *analysis.Pass) (result interface{}, _ error) {
 			// Deferred functions are executed after a result is generated, so here we modify the
 			// return value `result` in-place.
 			// Diagnostics with invalid positions (<= 0) will be silently suppressed, so here we use 1.
-			d := analysis.Diagnostic{Pos: 1, Message: fmt.Sprintf("INTERNAL PANIC: %s\n%s", r, string(debug.Stack()))}
+			d := analysis.Diagnostic{
+				Pos:     1,
+				Message: fmt.Sprintf("%s: %s\n%s", config.InternalPanicString, r, string(debug.Stack())),
+			}
 			if diagnostics, ok := result.([]analysis.Diagnostic); ok {
 				result = append(diagnostics, d)
 			} else {

--- a/accumulation/analyzer.go
+++ b/accumulation/analyzer.go
@@ -85,7 +85,7 @@ func run(p *analysis.Pass) (result interface{}, _ error) {
 			// Diagnostics with invalid positions (<= 0) will be silently suppressed, so here we use 1.
 			d := analysis.Diagnostic{
 				Pos:     1,
-				Message: fmt.Sprintf("%s: %s\n%s", config.InternalPanicString, r, string(debug.Stack())),
+				Message: fmt.Sprintf("%s: %s\n%s", config.InternalPanicPrefix, r, string(debug.Stack())),
 			}
 			if diagnostics, ok := result.([]analysis.Diagnostic); ok {
 				result = append(diagnostics, d)

--- a/annotation/analyzer_test.go
+++ b/annotation/analyzer_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
+	"go.uber.org/nilaway/config"
 	"go.uber.org/nilaway/util/analysishelper"
 )
 
@@ -29,7 +30,7 @@ func TestAnalyzer(t *testing.T) {
 	// and convert it to an error via the result struct.
 	r, err := Analyzer.Run(nil /* pass */)
 	require.NoError(t, err)
-	require.ErrorContains(t, r.(*analysishelper.Result[*ObservedMap]).Err, "INTERNAL PANIC")
+	require.ErrorContains(t, r.(*analysishelper.Result[*ObservedMap]).Err, config.InternalPanicString)
 }
 
 func TestMain(m *testing.M) {

--- a/annotation/analyzer_test.go
+++ b/annotation/analyzer_test.go
@@ -30,7 +30,7 @@ func TestAnalyzer(t *testing.T) {
 	// and convert it to an error via the result struct.
 	r, err := Analyzer.Run(nil /* pass */)
 	require.NoError(t, err)
-	require.ErrorContains(t, r.(*analysishelper.Result[*ObservedMap]).Err, config.InternalPanicString)
+	require.ErrorContains(t, r.(*analysishelper.Result[*ObservedMap]).Err, config.InternalPanicPrefix)
 }
 
 func TestMain(m *testing.M) {

--- a/assertion/affiliation/analyzer_test.go
+++ b/assertion/affiliation/analyzer_test.go
@@ -35,7 +35,7 @@ func TestAnalyzer(t *testing.T) {
 	// and convert it to an error via the result struct.
 	r, err := Analyzer.Run(nil /* pass */)
 	require.NoError(t, err)
-	require.ErrorContains(t, r.(*analysishelper.Result[[]annotation.FullTrigger]).Err, config.InternalPanicString)
+	require.ErrorContains(t, r.(*analysishelper.Result[[]annotation.FullTrigger]).Err, config.InternalPanicPrefix)
 }
 
 func TestFact_Codec(t *testing.T) {

--- a/assertion/affiliation/analyzer_test.go
+++ b/assertion/affiliation/analyzer_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 	"go.uber.org/nilaway/annotation"
+	"go.uber.org/nilaway/config"
 	"go.uber.org/nilaway/util/analysishelper"
 	"go.uber.org/nilaway/util/orderedmap"
 )
@@ -34,7 +35,7 @@ func TestAnalyzer(t *testing.T) {
 	// and convert it to an error via the result struct.
 	r, err := Analyzer.Run(nil /* pass */)
 	require.NoError(t, err)
-	require.ErrorContains(t, r.(*analysishelper.Result[[]annotation.FullTrigger]).Err, "INTERNAL PANIC")
+	require.ErrorContains(t, r.(*analysishelper.Result[[]annotation.FullTrigger]).Err, config.InternalPanicString)
 }
 
 func TestFact_Codec(t *testing.T) {

--- a/assertion/analyzer_test.go
+++ b/assertion/analyzer_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 	"go.uber.org/nilaway/annotation"
+	"go.uber.org/nilaway/config"
 	"go.uber.org/nilaway/util/analysishelper"
 )
 
@@ -30,7 +31,7 @@ func TestAnalyzer(t *testing.T) {
 	// and convert it to an error via the result struct.
 	r, err := Analyzer.Run(nil /* pass */)
 	require.NoError(t, err)
-	require.ErrorContains(t, r.(*analysishelper.Result[[]annotation.FullTrigger]).Err, "INTERNAL PANIC")
+	require.ErrorContains(t, r.(*analysishelper.Result[[]annotation.FullTrigger]).Err, config.InternalPanicString)
 }
 
 func TestMain(m *testing.M) {

--- a/assertion/analyzer_test.go
+++ b/assertion/analyzer_test.go
@@ -31,7 +31,7 @@ func TestAnalyzer(t *testing.T) {
 	// and convert it to an error via the result struct.
 	r, err := Analyzer.Run(nil /* pass */)
 	require.NoError(t, err)
-	require.ErrorContains(t, r.(*analysishelper.Result[[]annotation.FullTrigger]).Err, config.InternalPanicString)
+	require.ErrorContains(t, r.(*analysishelper.Result[[]annotation.FullTrigger]).Err, config.InternalPanicPrefix)
 }
 
 func TestMain(m *testing.M) {

--- a/assertion/anonymousfunc/analyzer_test.go
+++ b/assertion/anonymousfunc/analyzer_test.go
@@ -39,7 +39,7 @@ func TestAnalyzer(t *testing.T) {
 	// and convert it to an error via the result struct.
 	r, err := Analyzer.Run(nil /* pass */)
 	require.NoError(t, err)
-	require.ErrorContains(t, r.(*analysishelper.Result[map[*ast.FuncLit]*FuncLitInfo]).Err, config.InternalPanicString)
+	require.ErrorContains(t, r.(*analysishelper.Result[map[*ast.FuncLit]*FuncLitInfo]).Err, config.InternalPanicPrefix)
 }
 
 func TestClosureCollection(t *testing.T) {

--- a/assertion/anonymousfunc/analyzer_test.go
+++ b/assertion/anonymousfunc/analyzer_test.go
@@ -39,7 +39,7 @@ func TestAnalyzer(t *testing.T) {
 	// and convert it to an error via the result struct.
 	r, err := Analyzer.Run(nil /* pass */)
 	require.NoError(t, err)
-	require.ErrorContains(t, r.(*analysishelper.Result[map[*ast.FuncLit]*FuncLitInfo]).Err, "INTERNAL PANIC")
+	require.ErrorContains(t, r.(*analysishelper.Result[map[*ast.FuncLit]*FuncLitInfo]).Err, config.InternalPanicString)
 }
 
 func TestClosureCollection(t *testing.T) {

--- a/assertion/function/analyzer.go
+++ b/assertion/function/analyzer.go
@@ -454,7 +454,7 @@ func analyzeFunc(
 	// As a last resort, convert the panics into errors and return.
 	defer func() {
 		if r := recover(); r != nil {
-			e := fmt.Errorf("%s: %s\n%s", config.InternalPanicString, r, string(debug.Stack()))
+			e := fmt.Errorf("%s: %s\n%s", config.InternalPanicPrefix, r, string(debug.Stack()))
 			funcChan <- functionResult{err: e, index: index, funcDecl: funcDecl}
 		}
 	}()

--- a/assertion/function/analyzer.go
+++ b/assertion/function/analyzer.go
@@ -454,7 +454,7 @@ func analyzeFunc(
 	// As a last resort, convert the panics into errors and return.
 	defer func() {
 		if r := recover(); r != nil {
-			e := fmt.Errorf("INTERNAL PANIC: %s\n%s", r, string(debug.Stack()))
+			e := fmt.Errorf("%s: %s\n%s", config.InternalPanicString, r, string(debug.Stack()))
 			funcChan <- functionResult{err: e, index: index, funcDecl: funcDecl}
 		}
 	}()

--- a/assertion/function/analyzer_test.go
+++ b/assertion/function/analyzer_test.go
@@ -49,7 +49,7 @@ func TestAnalyzer(t *testing.T) {
 	// and convert it to an error via the result struct.
 	r, err := Analyzer.Run(nil /* pass */)
 	require.NoError(t, err)
-	require.ErrorContains(t, r.(*analysishelper.Result[[]annotation.FullTrigger]).Err, config.InternalPanicString)
+	require.ErrorContains(t, r.(*analysishelper.Result[[]annotation.FullTrigger]).Err, config.InternalPanicPrefix)
 }
 
 func TestCancelledContext(t *testing.T) {

--- a/assertion/function/analyzer_test.go
+++ b/assertion/function/analyzer_test.go
@@ -29,6 +29,7 @@ import (
 	"go.uber.org/nilaway/assertion/anonymousfunc"
 	"go.uber.org/nilaway/assertion/function/assertiontree"
 	"go.uber.org/nilaway/assertion/function/functioncontracts"
+	"go.uber.org/nilaway/config"
 	"go.uber.org/nilaway/nilawaytest"
 	"go.uber.org/nilaway/util/analysishelper"
 	"golang.org/x/tools/go/analysis"
@@ -48,7 +49,7 @@ func TestAnalyzer(t *testing.T) {
 	// and convert it to an error via the result struct.
 	r, err := Analyzer.Run(nil /* pass */)
 	require.NoError(t, err)
-	require.ErrorContains(t, r.(*analysishelper.Result[[]annotation.FullTrigger]).Err, "INTERNAL PANIC")
+	require.ErrorContains(t, r.(*analysishelper.Result[[]annotation.FullTrigger]).Err, config.InternalPanicString)
 }
 
 func TestCancelledContext(t *testing.T) {

--- a/assertion/function/functioncontracts/analyzer.go
+++ b/assertion/function/functioncontracts/analyzer.go
@@ -204,7 +204,7 @@ func collectFunctionContracts(pass *analysishelper.EnhancedPass) (Map, error) {
 				// As a last resort, convert the panics into errors and return.
 				defer func() {
 					if r := recover(); r != nil {
-						e := fmt.Errorf("INTERNAL PANIC: %s\n%s", r, string(debug.Stack()))
+						e := fmt.Errorf("%s: %s\n%s", config.InternalPanicString, r, string(debug.Stack()))
 						funcChan <- functionResult{err: e, funcObj: funcObj}
 					}
 				}()

--- a/assertion/function/functioncontracts/analyzer.go
+++ b/assertion/function/functioncontracts/analyzer.go
@@ -204,7 +204,7 @@ func collectFunctionContracts(pass *analysishelper.EnhancedPass) (Map, error) {
 				// As a last resort, convert the panics into errors and return.
 				defer func() {
 					if r := recover(); r != nil {
-						e := fmt.Errorf("%s: %s\n%s", config.InternalPanicString, r, string(debug.Stack()))
+						e := fmt.Errorf("%s: %s\n%s", config.InternalPanicPrefix, r, string(debug.Stack()))
 						funcChan <- functionResult{err: e, funcObj: funcObj}
 					}
 				}()

--- a/assertion/function/functioncontracts/analyzer_test.go
+++ b/assertion/function/functioncontracts/analyzer_test.go
@@ -36,7 +36,7 @@ func TestAnalyzer(t *testing.T) {
 	// and convert it to an error via the result struct.
 	r, err := Analyzer.Run(nil /* pass */)
 	require.NoError(t, err)
-	require.ErrorContains(t, r.(*analysishelper.Result[Map]).Err, config.InternalPanicString)
+	require.ErrorContains(t, r.(*analysishelper.Result[Map]).Err, config.InternalPanicPrefix)
 }
 
 func TestContractCollection(t *testing.T) {

--- a/assertion/function/functioncontracts/analyzer_test.go
+++ b/assertion/function/functioncontracts/analyzer_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
+	"go.uber.org/nilaway/config"
 	"go.uber.org/nilaway/util/analysishelper"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/analysistest"
@@ -35,7 +36,7 @@ func TestAnalyzer(t *testing.T) {
 	// and convert it to an error via the result struct.
 	r, err := Analyzer.Run(nil /* pass */)
 	require.NoError(t, err)
-	require.ErrorContains(t, r.(*analysishelper.Result[Map]).Err, "INTERNAL PANIC")
+	require.ErrorContains(t, r.(*analysishelper.Result[Map]).Err, config.InternalPanicString)
 }
 
 func TestContractCollection(t *testing.T) {

--- a/assertion/global/analyzer_test.go
+++ b/assertion/global/analyzer_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 	"go.uber.org/nilaway/annotation"
+	"go.uber.org/nilaway/config"
 	"go.uber.org/nilaway/util/analysishelper"
 )
 
@@ -30,7 +31,7 @@ func TestAnalyzer(t *testing.T) {
 	// and convert it to an error via the result struct.
 	r, err := Analyzer.Run(nil /* pass */)
 	require.NoError(t, err)
-	require.ErrorContains(t, r.(*analysishelper.Result[[]annotation.FullTrigger]).Err, "INTERNAL PANIC")
+	require.ErrorContains(t, r.(*analysishelper.Result[[]annotation.FullTrigger]).Err, config.InternalPanicString)
 }
 
 func TestMain(m *testing.M) {

--- a/assertion/global/analyzer_test.go
+++ b/assertion/global/analyzer_test.go
@@ -31,7 +31,7 @@ func TestAnalyzer(t *testing.T) {
 	// and convert it to an error via the result struct.
 	r, err := Analyzer.Run(nil /* pass */)
 	require.NoError(t, err)
-	require.ErrorContains(t, r.(*analysishelper.Result[[]annotation.FullTrigger]).Err, config.InternalPanicString)
+	require.ErrorContains(t, r.(*analysishelper.Result[[]annotation.FullTrigger]).Err, config.InternalPanicPrefix)
 }
 
 func TestMain(m *testing.M) {

--- a/assertion/structfield/analyzer_test.go
+++ b/assertion/structfield/analyzer_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
+	"go.uber.org/nilaway/config"
 	"go.uber.org/nilaway/util/analysishelper"
 )
 
@@ -29,7 +30,7 @@ func TestAnalyzer(t *testing.T) {
 	// and convert it to an error via the result struct.
 	r, err := Analyzer.Run(nil /* pass */)
 	require.NoError(t, err)
-	require.ErrorContains(t, r.(*analysishelper.Result[*FieldContext]).Err, "INTERNAL PANIC")
+	require.ErrorContains(t, r.(*analysishelper.Result[*FieldContext]).Err, config.InternalPanicString)
 }
 
 func TestMain(m *testing.M) {

--- a/assertion/structfield/analyzer_test.go
+++ b/assertion/structfield/analyzer_test.go
@@ -30,7 +30,7 @@ func TestAnalyzer(t *testing.T) {
 	// and convert it to an error via the result struct.
 	r, err := Analyzer.Run(nil /* pass */)
 	require.NoError(t, err)
-	require.ErrorContains(t, r.(*analysishelper.Result[*FieldContext]).Err, config.InternalPanicString)
+	require.ErrorContains(t, r.(*analysishelper.Result[*FieldContext]).Err, config.InternalPanicPrefix)
 }
 
 func TestMain(m *testing.M) {

--- a/config/const.go
+++ b/config/const.go
@@ -29,6 +29,9 @@ const StableRoundLimit = 5
 // NilAway from inferring the annotations for that package - this is useful for unit tests
 const NilAwayNoInferString = "<nilaway no inference>"
 
+// InternalPanicString identifies diagnostics emitted when NilAway recovers from an internal panic.
+const InternalPanicString = "INTERNAL PANIC"
+
 const uberPkgPathPrefix = "go.uber.org"
 
 // NilAwayPkgPathPrefix is the package prefix for NilAway.

--- a/config/const.go
+++ b/config/const.go
@@ -29,8 +29,8 @@ const StableRoundLimit = 5
 // NilAway from inferring the annotations for that package - this is useful for unit tests
 const NilAwayNoInferString = "<nilaway no inference>"
 
-// InternalPanicString identifies diagnostics emitted when NilAway recovers from an internal panic.
-const InternalPanicString = "INTERNAL PANIC"
+// InternalPanicPrefix identifies diagnostics emitted when NilAway recovers from an internal panic.
+const InternalPanicPrefix = "INTERNAL PANIC"
 
 const uberPkgPathPrefix = "go.uber.org"
 

--- a/tools/cmd/golden-test/main.go
+++ b/tools/cmd/golden-test/main.go
@@ -43,6 +43,8 @@ type Diagnostic struct {
 	Message string `json:"message"`
 }
 
+const internalPanicDiagnostic = "INTERNAL PANIC"
+
 // BranchResult stores the information about a branch, and the diagnostics reported on that branch.
 type BranchResult struct {
 	// Name is the friendly name of the branch (if available and not "HEAD", otherwise it is equal
@@ -154,7 +156,7 @@ func Run(writer io.Writer, baseBranch, testBranch string) error {
 	}
 
 	WriteDiff(writer, branches)
-	return nil
+	return checkInternalPanics(branches)
 }
 
 // ParseDiagnostics parses the diagnostics from the raw JSON output of NilAway and returns the
@@ -178,6 +180,32 @@ func ParseDiagnostics(reader io.Reader) (map[Diagnostic]bool, error) {
 	}
 
 	return allDiagnostics, nil
+}
+
+// checkInternalPanics returns an error if NilAway reported an internal panic on either branch.
+func checkInternalPanics(branches [2]*BranchResult) error {
+	var affectedBranches []string
+	for _, branch := range branches {
+		count := 0
+		for diagnostic := range branch.Result {
+			if isInternalPanic(diagnostic) {
+				count++
+			}
+		}
+		if count > 0 {
+			affectedBranches = append(affectedBranches,
+				fmt.Sprintf("%s (%s): %d", branch.Name, branch.ShortSHA, count))
+		}
+	}
+	if len(affectedBranches) == 0 {
+		return nil
+	}
+	return fmt.Errorf("%s diagnostic(s) reported on %s",
+		internalPanicDiagnostic, strings.Join(affectedBranches, ", "))
+}
+
+func isInternalPanic(diagnostic Diagnostic) bool {
+	return strings.Contains(diagnostic.Message, internalPanicDiagnostic)
 }
 
 // WriteDiff writes the summary and the diff (if the base and test are different) between the base
@@ -233,20 +261,27 @@ func WriteDiff(writer io.Writer, branches [2]*BranchResult) {
 	MustFprint(fmt.Fprintf(writer, "\n<details>\n"))
 	MustFprint(fmt.Fprintf(writer, "<summary>Diffs</summary>\n\n"))
 	MustFprint(fmt.Fprintf(writer, "```diff\n"))
-	for i, diff := range [...][]Diagnostic{pluses, minuses} {
-		prefix, c := "+", color.FgGreen
-		if i == 1 {
-			prefix, c = "-", color.FgRed
-		}
-		for _, d := range diff {
-			lines := strings.Split(strings.TrimSpace(d.Message), "\n")
-			// Add Posn to the first line and prefix to each line for diff formatting.
-			lines[0] = d.Posn + ": " + lines[0]
-			for i := range lines {
-				lines[i] = prefix + " " + lines[i]
+	// Print internal panics before other diagnostics so they remain visible if the output is
+	// truncated. Preserve the usual additions-before-removals ordering within each group.
+	for _, printInternalPanics := range [...]bool{true, false} {
+		for i, diff := range [...][]Diagnostic{pluses, minuses} {
+			prefix, c := "+", color.FgGreen
+			if i == 1 {
+				prefix, c = "-", color.FgRed
 			}
-			output := strings.Join(lines, "\n") + "\n"
-			MustFprint(color.New(c).Fprint(writer, output))
+			for _, d := range diff {
+				if isInternalPanic(d) != printInternalPanics {
+					continue
+				}
+				lines := strings.Split(strings.TrimSpace(d.Message), "\n")
+				// Add Posn to the first line and prefix to each line for diff formatting.
+				lines[0] = d.Posn + ": " + lines[0]
+				for i := range lines {
+					lines[i] = prefix + " " + lines[i]
+				}
+				output := strings.Join(lines, "\n") + "\n"
+				MustFprint(color.New(c).Fprint(writer, output))
+			}
 		}
 	}
 	MustFprint(fmt.Fprintf(writer, "```\n\n"))
@@ -264,6 +299,12 @@ func Diff(first, second map[Diagnostic]bool) []Diagnostic {
 	}
 	// Sort the diff such that we have stable ordering for the same runs.
 	slices.SortFunc(diff, func(i, j Diagnostic) int {
+		if iPanic, jPanic := isInternalPanic(i), isInternalPanic(j); iPanic != jPanic {
+			if iPanic {
+				return -1
+			}
+			return 1
+		}
 		if n := cmp.Compare(i.Posn, j.Posn); n != 0 {
 			return n
 		}

--- a/tools/cmd/golden-test/main.go
+++ b/tools/cmd/golden-test/main.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	"github.com/fatih/color"
+	"go.uber.org/nilaway/config"
 )
 
 // Diagnostic is the diagnostic reported by NilAway.
@@ -42,8 +43,6 @@ type Diagnostic struct {
 	// Message is the message reported by NilAway.
 	Message string `json:"message"`
 }
-
-const internalPanicDiagnostic = "INTERNAL PANIC"
 
 // BranchResult stores the information about a branch, and the diagnostics reported on that branch.
 type BranchResult struct {
@@ -201,11 +200,11 @@ func checkInternalPanics(branches [2]*BranchResult) error {
 		return nil
 	}
 	return fmt.Errorf("%s diagnostic(s) reported on %s",
-		internalPanicDiagnostic, strings.Join(affectedBranches, ", "))
+		config.InternalPanicString, strings.Join(affectedBranches, ", "))
 }
 
 func isInternalPanic(diagnostic Diagnostic) bool {
-	return strings.Contains(diagnostic.Message, internalPanicDiagnostic)
+	return strings.Contains(diagnostic.Message, config.InternalPanicString)
 }
 
 // WriteDiff writes the summary and the diff (if the base and test are different) between the base

--- a/tools/cmd/golden-test/main.go
+++ b/tools/cmd/golden-test/main.go
@@ -200,11 +200,11 @@ func checkInternalPanics(branches [2]*BranchResult) error {
 		return nil
 	}
 	return fmt.Errorf("%s diagnostic(s) reported on %s",
-		config.InternalPanicString, strings.Join(affectedBranches, ", "))
+		config.InternalPanicPrefix, strings.Join(affectedBranches, ", "))
 }
 
 func isInternalPanic(diagnostic Diagnostic) bool {
-	return strings.Contains(diagnostic.Message, config.InternalPanicString)
+	return strings.Contains(diagnostic.Message, config.InternalPanicPrefix)
 }
 
 // WriteDiff writes the summary and the diff (if the base and test are different) between the base

--- a/tools/cmd/golden-test/main.go
+++ b/tools/cmd/golden-test/main.go
@@ -261,27 +261,20 @@ func WriteDiff(writer io.Writer, branches [2]*BranchResult) {
 	MustFprint(fmt.Fprintf(writer, "\n<details>\n"))
 	MustFprint(fmt.Fprintf(writer, "<summary>Diffs</summary>\n\n"))
 	MustFprint(fmt.Fprintf(writer, "```diff\n"))
-	// Print internal panics before other diagnostics so they remain visible if the output is
-	// truncated. Preserve the usual additions-before-removals ordering within each group.
-	for _, printInternalPanics := range [...]bool{true, false} {
-		for i, diff := range [...][]Diagnostic{pluses, minuses} {
-			prefix, c := "+", color.FgGreen
-			if i == 1 {
-				prefix, c = "-", color.FgRed
+	for i, diff := range [...][]Diagnostic{pluses, minuses} {
+		prefix, c := "+", color.FgGreen
+		if i == 1 {
+			prefix, c = "-", color.FgRed
+		}
+		for _, d := range diff {
+			lines := strings.Split(strings.TrimSpace(d.Message), "\n")
+			// Add Posn to the first line and prefix to each line for diff formatting.
+			lines[0] = d.Posn + ": " + lines[0]
+			for i := range lines {
+				lines[i] = prefix + " " + lines[i]
 			}
-			for _, d := range diff {
-				if d.IsInternalPanic() != printInternalPanics {
-					continue
-				}
-				lines := strings.Split(strings.TrimSpace(d.Message), "\n")
-				// Add Posn to the first line and prefix to each line for diff formatting.
-				lines[0] = d.Posn + ": " + lines[0]
-				for i := range lines {
-					lines[i] = prefix + " " + lines[i]
-				}
-				output := strings.Join(lines, "\n") + "\n"
-				MustFprint(color.New(c).Fprint(writer, output))
-			}
+			output := strings.Join(lines, "\n") + "\n"
+			MustFprint(color.New(c).Fprint(writer, output))
 		}
 	}
 	MustFprint(fmt.Fprintf(writer, "```\n\n"))

--- a/tools/cmd/golden-test/main.go
+++ b/tools/cmd/golden-test/main.go
@@ -44,6 +44,11 @@ type Diagnostic struct {
 	Message string `json:"message"`
 }
 
+// IsInternalPanic returns whether this diagnostic is an internal panic.
+func (d *Diagnostic) IsInternalPanic() bool {
+	return strings.Contains(d.Message, config.InternalPanicPrefix)
+}
+
 // BranchResult stores the information about a branch, and the diagnostics reported on that branch.
 type BranchResult struct {
 	// Name is the friendly name of the branch (if available and not "HEAD", otherwise it is equal
@@ -155,7 +160,7 @@ func Run(writer io.Writer, baseBranch, testBranch string) error {
 	}
 
 	WriteDiff(writer, branches)
-	return checkInternalPanics(branches)
+	return CheckInternalPanics(branches)
 }
 
 // ParseDiagnostics parses the diagnostics from the raw JSON output of NilAway and returns the
@@ -181,13 +186,13 @@ func ParseDiagnostics(reader io.Reader) (map[Diagnostic]bool, error) {
 	return allDiagnostics, nil
 }
 
-// checkInternalPanics returns an error if NilAway reported an internal panic on either branch.
-func checkInternalPanics(branches [2]*BranchResult) error {
+// CheckInternalPanics returns an error if NilAway reported an internal panic on either branch.
+func CheckInternalPanics(branches [2]*BranchResult) error {
 	var affectedBranches []string
 	for _, branch := range branches {
 		count := 0
 		for diagnostic := range branch.Result {
-			if isInternalPanic(diagnostic) {
+			if diagnostic.IsInternalPanic() {
 				count++
 			}
 		}
@@ -201,10 +206,6 @@ func checkInternalPanics(branches [2]*BranchResult) error {
 	}
 	return fmt.Errorf("%s diagnostic(s) reported on %s",
 		config.InternalPanicPrefix, strings.Join(affectedBranches, ", "))
-}
-
-func isInternalPanic(diagnostic Diagnostic) bool {
-	return strings.Contains(diagnostic.Message, config.InternalPanicPrefix)
 }
 
 // WriteDiff writes the summary and the diff (if the base and test are different) between the base
@@ -269,7 +270,7 @@ func WriteDiff(writer io.Writer, branches [2]*BranchResult) {
 				prefix, c = "-", color.FgRed
 			}
 			for _, d := range diff {
-				if isInternalPanic(d) != printInternalPanics {
+				if d.IsInternalPanic() != printInternalPanics {
 					continue
 				}
 				lines := strings.Split(strings.TrimSpace(d.Message), "\n")
@@ -298,7 +299,7 @@ func Diff(first, second map[Diagnostic]bool) []Diagnostic {
 	}
 	// Sort the diff such that we have stable ordering for the same runs.
 	slices.SortFunc(diff, func(i, j Diagnostic) int {
-		if iPanic, jPanic := isInternalPanic(i), isInternalPanic(j); iPanic != jPanic {
+		if iPanic, jPanic := i.IsInternalPanic(), j.IsInternalPanic(); iPanic != jPanic {
 			if iPanic {
 				return -1
 			}

--- a/tools/cmd/golden-test/main_test.go
+++ b/tools/cmd/golden-test/main_test.go
@@ -17,7 +17,6 @@ package main
 import (
 	"bytes"
 	"errors"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -70,7 +69,7 @@ func TestWriteDiff(t *testing.T) {
 	require.Contains(t, buf.String(), "## Golden Test") // Must contain the title.
 	require.Contains(t, buf.String(), "are **identical**")
 
-	// Add two different diagnostics to base and test and check that they are reported.
+	// Add different diagnostics to base and test and check that they are reported.
 	base[Diagnostic{Posn: "src/file2:10:2", Message: "nil pointer dereference"}] = true
 	base[Diagnostic{Posn: "src/z:10:2", Message: config.InternalPanicPrefix + ": boom"}] = true
 	test[Diagnostic{Posn: "src/file4:10:2", Message: "bar error"}] = true
@@ -81,11 +80,7 @@ func TestWriteDiff(t *testing.T) {
 	require.Contains(t, s, "are **different**")
 	require.Contains(t, s, "- src/file2:10:2: nil pointer dereference")
 	require.Contains(t, s, "+ src/file4:10:2: bar error")
-	panicIndex := strings.Index(s, "- src/z:10:2: "+config.InternalPanicPrefix+": boom")
-	normalIndex := strings.Index(s, "+ src/file4:10:2: bar error")
-	require.NotEqual(t, -1, panicIndex)
-	require.NotEqual(t, -1, normalIndex)
-	require.Less(t, panicIndex, normalIndex)
+	require.Contains(t, s, "- src/z:10:2: "+config.InternalPanicPrefix+": boom")
 }
 
 func TestDiff(t *testing.T) {

--- a/tools/cmd/golden-test/main_test.go
+++ b/tools/cmd/golden-test/main_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
+	"go.uber.org/nilaway/config"
 )
 
 func TestParseDiagnostics(t *testing.T) {
@@ -71,7 +72,7 @@ func TestWriteDiff(t *testing.T) {
 
 	// Add two different diagnostics to base and test and check that they are reported.
 	base[Diagnostic{Posn: "src/file2:10:2", Message: "nil pointer dereference"}] = true
-	base[Diagnostic{Posn: "src/z:10:2", Message: "INTERNAL PANIC: boom"}] = true
+	base[Diagnostic{Posn: "src/z:10:2", Message: config.InternalPanicString + ": boom"}] = true
 	test[Diagnostic{Posn: "src/file4:10:2", Message: "bar error"}] = true
 	buf.Reset()
 	WriteDiff(&buf, branches)
@@ -80,7 +81,7 @@ func TestWriteDiff(t *testing.T) {
 	require.Contains(t, s, "are **different**")
 	require.Contains(t, s, "- src/file2:10:2: nil pointer dereference")
 	require.Contains(t, s, "+ src/file4:10:2: bar error")
-	panicIndex := strings.Index(s, "- src/z:10:2: INTERNAL PANIC: boom")
+	panicIndex := strings.Index(s, "- src/z:10:2: "+config.InternalPanicString+": boom")
 	normalIndex := strings.Index(s, "+ src/file4:10:2: bar error")
 	require.NotEqual(t, -1, panicIndex)
 	require.NotEqual(t, -1, normalIndex)
@@ -94,7 +95,7 @@ func TestDiff(t *testing.T) {
 		// Same in both.
 		{Posn: "src/file1:10:2", Message: "nil pointer dereference"}: true,
 		// Internal panics must be ordered first regardless of position.
-		{Posn: "src/z:10:2", Message: "INTERNAL PANIC: boom"}: true,
+		{Posn: "src/z:10:2", Message: config.InternalPanicString + ": boom"}: true,
 		// Differs in position.
 		{Posn: "src/file2:10:2", Message: "nil pointer dereference"}: true,
 		// Differs in message.
@@ -112,7 +113,7 @@ func TestDiff(t *testing.T) {
 	minuses := Diff(base, test)
 	require.Equal(t, []Diagnostic{
 		// Internal panic.
-		{Posn: "src/z:10:2", Message: "INTERNAL PANIC: boom"},
+		{Posn: "src/z:10:2", Message: config.InternalPanicString + ": boom"},
 		// Differs in position.
 		{Posn: "src/file2:10:2", Message: "nil pointer dereference"},
 		// Differs in message.
@@ -139,9 +140,11 @@ func TestCheckInternalPanics(t *testing.T) {
 	}
 	require.NoError(t, checkInternalPanics(branches))
 
-	branches[1].Result[Diagnostic{Message: "INTERNAL ERROR(s):\nINTERNAL PANIC from analyzer"}] = true
+	branches[1].Result[Diagnostic{
+		Message: "INTERNAL ERROR(s):\n" + config.InternalPanicString + " from analyzer",
+	}] = true
 	err := checkInternalPanics(branches)
-	require.ErrorContains(t, err, "INTERNAL PANIC diagnostic(s)")
+	require.ErrorContains(t, err, config.InternalPanicString+" diagnostic(s)")
 	require.ErrorContains(t, err, "test (456789): 1")
 }
 

--- a/tools/cmd/golden-test/main_test.go
+++ b/tools/cmd/golden-test/main_test.go
@@ -72,7 +72,7 @@ func TestWriteDiff(t *testing.T) {
 
 	// Add two different diagnostics to base and test and check that they are reported.
 	base[Diagnostic{Posn: "src/file2:10:2", Message: "nil pointer dereference"}] = true
-	base[Diagnostic{Posn: "src/z:10:2", Message: config.InternalPanicString + ": boom"}] = true
+	base[Diagnostic{Posn: "src/z:10:2", Message: config.InternalPanicPrefix + ": boom"}] = true
 	test[Diagnostic{Posn: "src/file4:10:2", Message: "bar error"}] = true
 	buf.Reset()
 	WriteDiff(&buf, branches)
@@ -81,7 +81,7 @@ func TestWriteDiff(t *testing.T) {
 	require.Contains(t, s, "are **different**")
 	require.Contains(t, s, "- src/file2:10:2: nil pointer dereference")
 	require.Contains(t, s, "+ src/file4:10:2: bar error")
-	panicIndex := strings.Index(s, "- src/z:10:2: "+config.InternalPanicString+": boom")
+	panicIndex := strings.Index(s, "- src/z:10:2: "+config.InternalPanicPrefix+": boom")
 	normalIndex := strings.Index(s, "+ src/file4:10:2: bar error")
 	require.NotEqual(t, -1, panicIndex)
 	require.NotEqual(t, -1, normalIndex)
@@ -95,7 +95,7 @@ func TestDiff(t *testing.T) {
 		// Same in both.
 		{Posn: "src/file1:10:2", Message: "nil pointer dereference"}: true,
 		// Internal panics must be ordered first regardless of position.
-		{Posn: "src/z:10:2", Message: config.InternalPanicString + ": boom"}: true,
+		{Posn: "src/z:10:2", Message: config.InternalPanicPrefix + ": boom"}: true,
 		// Differs in position.
 		{Posn: "src/file2:10:2", Message: "nil pointer dereference"}: true,
 		// Differs in message.
@@ -113,7 +113,7 @@ func TestDiff(t *testing.T) {
 	minuses := Diff(base, test)
 	require.Equal(t, []Diagnostic{
 		// Internal panic.
-		{Posn: "src/z:10:2", Message: config.InternalPanicString + ": boom"},
+		{Posn: "src/z:10:2", Message: config.InternalPanicPrefix + ": boom"},
 		// Differs in position.
 		{Posn: "src/file2:10:2", Message: "nil pointer dereference"},
 		// Differs in message.
@@ -141,10 +141,10 @@ func TestCheckInternalPanics(t *testing.T) {
 	require.NoError(t, checkInternalPanics(branches))
 
 	branches[1].Result[Diagnostic{
-		Message: "INTERNAL ERROR(s):\n" + config.InternalPanicString + " from analyzer",
+		Message: "INTERNAL ERROR(s):\n" + config.InternalPanicPrefix + " from analyzer",
 	}] = true
 	err := checkInternalPanics(branches)
-	require.ErrorContains(t, err, config.InternalPanicString+" diagnostic(s)")
+	require.ErrorContains(t, err, config.InternalPanicPrefix+" diagnostic(s)")
 	require.ErrorContains(t, err, "test (456789): 1")
 }
 

--- a/tools/cmd/golden-test/main_test.go
+++ b/tools/cmd/golden-test/main_test.go
@@ -17,6 +17,7 @@ package main
 import (
 	"bytes"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -70,6 +71,7 @@ func TestWriteDiff(t *testing.T) {
 
 	// Add two different diagnostics to base and test and check that they are reported.
 	base[Diagnostic{Posn: "src/file2:10:2", Message: "nil pointer dereference"}] = true
+	base[Diagnostic{Posn: "src/z:10:2", Message: "INTERNAL PANIC: boom"}] = true
 	test[Diagnostic{Posn: "src/file4:10:2", Message: "bar error"}] = true
 	buf.Reset()
 	WriteDiff(&buf, branches)
@@ -78,6 +80,11 @@ func TestWriteDiff(t *testing.T) {
 	require.Contains(t, s, "are **different**")
 	require.Contains(t, s, "- src/file2:10:2: nil pointer dereference")
 	require.Contains(t, s, "+ src/file4:10:2: bar error")
+	panicIndex := strings.Index(s, "- src/z:10:2: INTERNAL PANIC: boom")
+	normalIndex := strings.Index(s, "+ src/file4:10:2: bar error")
+	require.NotEqual(t, -1, panicIndex)
+	require.NotEqual(t, -1, normalIndex)
+	require.Less(t, panicIndex, normalIndex)
 }
 
 func TestDiff(t *testing.T) {
@@ -86,6 +93,8 @@ func TestDiff(t *testing.T) {
 	base := map[Diagnostic]bool{
 		// Same in both.
 		{Posn: "src/file1:10:2", Message: "nil pointer dereference"}: true,
+		// Internal panics must be ordered first regardless of position.
+		{Posn: "src/z:10:2", Message: "INTERNAL PANIC: boom"}: true,
 		// Differs in position.
 		{Posn: "src/file2:10:2", Message: "nil pointer dereference"}: true,
 		// Differs in message.
@@ -102,6 +111,8 @@ func TestDiff(t *testing.T) {
 
 	minuses := Diff(base, test)
 	require.Equal(t, []Diagnostic{
+		// Internal panic.
+		{Posn: "src/z:10:2", Message: "INTERNAL PANIC: boom"},
 		// Differs in position.
 		{Posn: "src/file2:10:2", Message: "nil pointer dereference"},
 		// Differs in message.
@@ -115,6 +126,23 @@ func TestDiff(t *testing.T) {
 		// Differs in message.
 		{Posn: "src/file4:10:2", Message: "bar error"},
 	}, pluses)
+}
+
+func TestCheckInternalPanics(t *testing.T) {
+	t.Parallel()
+
+	branches := [2]*BranchResult{
+		{Name: "base", ShortSHA: "123456", Result: map[Diagnostic]bool{
+			{Message: "nil pointer dereference"}: true,
+		}},
+		{Name: "test", ShortSHA: "456789", Result: map[Diagnostic]bool{}},
+	}
+	require.NoError(t, checkInternalPanics(branches))
+
+	branches[1].Result[Diagnostic{Message: "INTERNAL ERROR(s):\nINTERNAL PANIC from analyzer"}] = true
+	err := checkInternalPanics(branches)
+	require.ErrorContains(t, err, "INTERNAL PANIC diagnostic(s)")
+	require.ErrorContains(t, err, "test (456789): 1")
 }
 
 func TestMustFprint(t *testing.T) {

--- a/tools/cmd/golden-test/main_test.go
+++ b/tools/cmd/golden-test/main_test.go
@@ -138,12 +138,12 @@ func TestCheckInternalPanics(t *testing.T) {
 		}},
 		{Name: "test", ShortSHA: "456789", Result: map[Diagnostic]bool{}},
 	}
-	require.NoError(t, checkInternalPanics(branches))
+	require.NoError(t, CheckInternalPanics(branches))
 
 	branches[1].Result[Diagnostic{
 		Message: "INTERNAL ERROR(s):\n" + config.InternalPanicPrefix + " from analyzer",
 	}] = true
-	err := checkInternalPanics(branches)
+	err := CheckInternalPanics(branches)
 	require.ErrorContains(t, err, config.InternalPanicPrefix+" diagnostic(s)")
 	require.ErrorContains(t, err, "test (456789): 1")
 }

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -6,12 +6,12 @@ require (
 	github.com/fatih/color v1.19.0
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/goleak v1.3.0
+	go.uber.org/nilaway v0.0.0
 	golang.org/x/tools v0.45.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
@@ -20,3 +20,5 @@ require (
 	golang.org/x/sys v0.44.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace go.uber.org/nilaway => ..

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -1,10 +1,9 @@
-github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
 github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=
-github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
-github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/util/analysishelper/analyzer.go
+++ b/util/analysishelper/analyzer.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"runtime/debug"
 
+	"go.uber.org/nilaway/config"
 	"golang.org/x/tools/go/analysis"
 )
 
@@ -47,7 +48,8 @@ func WrapRun[T any](f func(*analysis.Pass) (T, error)) func(*analysis.Pass) (any
 		}
 		defer func() {
 			if r := recover(); r != nil {
-				result.(*Result[T]).Err = fmt.Errorf("INTERNAL PANIC from %q: %s\n%s", analyzerName, r, string(debug.Stack()))
+				result.(*Result[T]).Err = fmt.Errorf("%s from %q: %s\n%s",
+					config.InternalPanicString, analyzerName, r, string(debug.Stack()))
 			}
 		}()
 

--- a/util/analysishelper/analyzer.go
+++ b/util/analysishelper/analyzer.go
@@ -49,7 +49,7 @@ func WrapRun[T any](f func(*analysis.Pass) (T, error)) func(*analysis.Pass) (any
 		defer func() {
 			if r := recover(); r != nil {
 				result.(*Result[T]).Err = fmt.Errorf("%s from %q: %s\n%s",
-					config.InternalPanicString, analyzerName, r, string(debug.Stack()))
+					config.InternalPanicPrefix, analyzerName, r, string(debug.Stack()))
 			}
 		}()
 

--- a/util/analysishelper/analyzer_test.go
+++ b/util/analysishelper/analyzer_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/nilaway/config"
 	"golang.org/x/tools/go/analysis"
 )
 
@@ -35,7 +36,7 @@ func TestWrapPanic_Panic(t *testing.T) {
 
 	require.IsType(t, &Result[int]{}, r)
 	require.Empty(t, r.(*Result[int]).Res)
-	require.ErrorContains(t, r.(*Result[int]).Err, "INTERNAL PANIC")
+	require.ErrorContains(t, r.(*Result[int]).Err, config.InternalPanicString)
 }
 
 func TestWrapPanic_Error(t *testing.T) {

--- a/util/analysishelper/analyzer_test.go
+++ b/util/analysishelper/analyzer_test.go
@@ -36,7 +36,7 @@ func TestWrapPanic_Panic(t *testing.T) {
 
 	require.IsType(t, &Result[int]{}, r)
 	require.Empty(t, r.(*Result[int]).Res)
-	require.ErrorContains(t, r.(*Result[int]).Err, config.InternalPanicString)
+	require.ErrorContains(t, r.(*Result[int]).Err, config.InternalPanicPrefix)
 }
 
 func TestWrapPanic_Error(t *testing.T) {


### PR DESCRIPTION
- Fail golden tests when either branch reports an `INTERNAL PANIC` diagnostic.
- Print internal panic diagnostics first so they remain visible in truncated output.