### PR TITLE
feat(struct-init-v2): add location-scoped context sites and param-source path resolution

### DIFF
--- a/annotation/structinitv2.go
+++ b/annotation/structinitv2.go
@@ -16,6 +16,7 @@ package annotation
 
 import (
 	"fmt"
+	"go/token"
 	"go/types"
 )
 
@@ -99,7 +100,13 @@ type StructFieldContextSite struct {
 	Kind    StructFieldContextKind
 	Index   int
 	// Path is the dotted field path from the boundary value to the tracked field (e.g. "aptr").
+	// Empty for a site describing the boundary value itself.
 	Path string
+	// Location is set for a call-site-scoped field site: return param sources are instantiated per call
+	// site, so each call gets its own site and one caller's argument cannot poison another
+	// caller's result. The zero value denotes the ordinary formal function-boundary site shared
+	// by all callers.
+	Location token.Position
 }
 
 // Lookup always returns the non-annotated default: these sites carry no syntactic annotation, so
@@ -128,8 +135,16 @@ func (s *StructFieldContextSite) copy() Key {
 func (s *StructFieldContextSite) String() string {
 	// Kind value is included in String to differentiate param-in and param-out site. Without it the two
 	// would collapse into one inference site, conflating a parameter's entry value with its
-	// post-call state.
-	return fmt.Sprintf("field `%s` of kind %d %s", s.Path, s.Kind, boundaryDesc(s.Kind, s.Index, s.FuncObj.Name()))
+	// post-call state. The call-site location keeps call-site-scoped sites of different calls
+	// distinct.
+	subject := fmt.Sprintf("field `%s`", s.Path)
+	if s.Path == "" {
+		subject = "value"
+	}
+	if s.Location.IsValid() {
+		return fmt.Sprintf("%s of kind %d %s at %s", subject, s.Kind, boundaryDesc(s.Kind, s.Index, s.FuncObj.Name()), s.Location.String())
+	}
+	return fmt.Sprintf("%s of kind %d %s", subject, s.Kind, boundaryDesc(s.Kind, s.Index, s.FuncObj.Name()))
 }
 
 // StructFieldFromContext is a producer: the value of a field (read from a boundary, e.g.
@@ -160,6 +175,9 @@ type StructFieldFromContextRepr struct {
 }
 
 func (s StructFieldFromContextRepr) String() string {
+	if s.Path == "" {
+		return boundaryDesc(s.Kind, s.Index, s.FuncName)
+	}
 	return fmt.Sprintf("field `%s` of %s", s.Path, boundaryDesc(s.Kind, s.Index, s.FuncName))
 }
 
@@ -199,5 +217,8 @@ type StructFieldToContextRepr struct {
 }
 
 func (s StructFieldToContextRepr) String() string {
+	if s.Path == "" {
+		return fmt.Sprintf("reaches %s", boundaryDesc(s.Kind, s.Index, s.FuncName))
+	}
 	return fmt.Sprintf("field `%s` reaches %s", s.Path, boundaryDesc(s.Kind, s.Index, s.FuncName))
 }

--- a/assertion/function/structfieldeffects/effects.go
+++ b/assertion/function/structfieldeffects/effects.go
@@ -277,13 +277,32 @@ func closeReturnEffects(effects fieldEffects, edges map[*types.Func][]returnForw
 	}
 }
 
-// joinFieldPath concatenates a (possibly empty) field-path prefix with a sub-path: join("", p) = p,
-// join("inner", "f") = "inner.f".
+// joinFieldPath concatenates two (possibly empty) dotted field paths: join("", p) = p,
+// join("inner", "f") = "inner.f", join("inner", "") = "inner".
 func joinFieldPath(prefix, sub string) string {
 	if prefix == "" {
 		return sub
 	}
+	if sub == "" {
+		return prefix
+	}
 	return prefix + "." + sub
+}
+
+// trimFieldPathPrefix is joinFieldPath's inverse: it returns the remainder of path below prefix —
+// trim("Mid.Child", "Mid") = "Child", trim(p, "") = p, trim(p, p) = "". The match is per segment,
+// so ok is false when prefix does not cover path (`Middle` is not below `Mid`).
+func trimFieldPathPrefix(path, prefix string) (sub string, ok bool) {
+	switch {
+	case prefix == "":
+		return path, true
+	case path == prefix:
+		return "", true
+	case strings.HasPrefix(path, prefix+"."):
+		return path[len(prefix)+1:], true
+	default:
+		return "", false
+	}
 }
 
 func paramFieldPathIsAcyclic(fn *types.Func, paramIdx int, path string) bool {

--- a/assertion/function/structfieldeffects/return_contracts.go
+++ b/assertion/function/structfieldeffects/return_contracts.go
@@ -26,7 +26,6 @@ import (
 	"go/token"
 	"go/types"
 	"slices"
-	"strings"
 
 	"go.uber.org/nilaway/util/asthelper"
 )
@@ -49,13 +48,24 @@ type ReturnParamSource struct {
 // source supplies its exact path and everything beneath it. The prefix match is per segment —
 // source `Mid` supplies `Mid.Child` but not the sibling field `Middle`.
 func (s ReturnParamSource) SuppliesResultPath(resultIdx int, resultPath string) bool {
+	_, ok := s.ResolveResultPath(resultIdx, resultPath)
+	return ok
+}
+
+// ResolveResultPath resolves the param endpoint supplying (resultIdx, resultPath) through s: the
+// remainder of resultPath below s's result path is re-rooted under s's param path — source
+// `Mid <- p.inner` resolves result path `Mid.Child` to param path `inner.Child`, and a
+// whole-result source re-roots the full path. ok reports whether s supplies the path at all
+// (see SuppliesResultPath).
+func (s ReturnParamSource) ResolveResultPath(resultIdx int, resultPath string) (param IndexedFieldPath, ok bool) {
 	if s.Result.Idx != resultIdx {
-		return false
+		return IndexedFieldPath{}, false
 	}
-	if s.Result.Path == "" {
-		return true
+	suffix, ok := trimFieldPathPrefix(resultPath, s.Result.Path)
+	if !ok {
+		return IndexedFieldPath{}, false
 	}
-	return resultPath == s.Result.Path || strings.HasPrefix(resultPath, s.Result.Path+".")
+	return IndexedFieldPath{Idx: s.Param.Idx, Path: joinFieldPath(s.Param.Path, suffix)}, true
 }
 
 // returnParamSourceSet maps each function to its set of return param sources.

--- a/assertion/function/structfieldeffects/return_contracts_test.go
+++ b/assertion/function/structfieldeffects/return_contracts_test.go
@@ -1,0 +1,97 @@
+//  Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package structfieldeffects
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveResultPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		source     ReturnParamSource
+		resultIdx  int
+		resultPath string
+		wantParam  IndexedFieldPath
+		wantOK     bool
+	}{
+		{
+			name:       "field-level source at its exact path",
+			source:     ReturnParamSource{Result: IndexedFieldPath{Idx: 0, Path: "Mid"}, Param: IndexedFieldPath{Idx: 1, Path: "inner"}},
+			resultIdx:  0,
+			resultPath: "Mid",
+			wantParam:  IndexedFieldPath{Idx: 1, Path: "inner"},
+			wantOK:     true,
+		},
+		{
+			name:       "field-level source re-roots a deeper path",
+			source:     ReturnParamSource{Result: IndexedFieldPath{Idx: 0, Path: "Mid"}, Param: IndexedFieldPath{Idx: 1, Path: "inner"}},
+			resultIdx:  0,
+			resultPath: "Mid.Child",
+			wantParam:  IndexedFieldPath{Idx: 1, Path: "inner.Child"},
+			wantOK:     true,
+		},
+		{
+			name:       "bare-param source keeps the bare param at the exact path",
+			source:     ReturnParamSource{Result: IndexedFieldPath{Idx: 0, Path: "Existing"}, Param: IndexedFieldPath{Idx: 0}},
+			resultIdx:  0,
+			resultPath: "Existing",
+			wantParam:  IndexedFieldPath{Idx: 0},
+			wantOK:     true,
+		},
+		{
+			name:       "whole-result source re-roots the full path",
+			source:     ReturnParamSource{Result: IndexedFieldPath{Idx: 0}, Param: IndexedFieldPath{Idx: 0, Path: "inner"}},
+			resultIdx:  0,
+			resultPath: "Mid.Child",
+			wantParam:  IndexedFieldPath{Idx: 0, Path: "inner.Mid.Child"},
+			wantOK:     true,
+		},
+		{
+			name:       "whole-result source at the result value itself",
+			source:     ReturnParamSource{Result: IndexedFieldPath{Idx: 0}, Param: IndexedFieldPath{Idx: 0, Path: "inner"}},
+			resultIdx:  0,
+			resultPath: "",
+			wantParam:  IndexedFieldPath{Idx: 0, Path: "inner"},
+			wantOK:     true,
+		},
+		{
+			name:       "sibling field sharing the source prefix is not supplied",
+			source:     ReturnParamSource{Result: IndexedFieldPath{Idx: 0, Path: "Mid"}, Param: IndexedFieldPath{Idx: 1, Path: "inner"}},
+			resultIdx:  0,
+			resultPath: "Middle",
+			wantOK:     false,
+		},
+		{
+			name:       "different result index is not supplied",
+			source:     ReturnParamSource{Result: IndexedFieldPath{Idx: 0, Path: "Mid"}, Param: IndexedFieldPath{Idx: 1, Path: "inner"}},
+			resultIdx:  1,
+			resultPath: "Mid",
+			wantOK:     false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			param, ok := tt.source.ResolveResultPath(tt.resultIdx, tt.resultPath)
+			require.Equal(t, tt.wantOK, ok)
+			require.Equal(t, tt.wantParam, param)
+		})
+	}
+}


### PR DESCRIPTION
Resolving a param-sourced result per call site needs two pieces the inference layer lacks: a context-site identity that distinguishes one call from another, and a way to map an accessed result path to the parameter path that supplies it. This lands both inert: nothing sets `Location` or calls `ResolveResultPath` yet, so every existing site keeps its exact `String()` rendering and inference identity. No behavior change.

Changes
- Add `StructFieldContextSite.Location`: a valid position marks a call-site-scoped site, giving each call its own inference site so one caller's argument cannot poison another caller's result; the zero value keeps the shared formal-boundary identity.
- Render an empty `Path` as the boundary value itself in `String()` and the trigger `Repr`s, for sites describing the whole result rather than a field of it.
- Add `ReturnParamSource.ResolveResultPath`: re-roots the remainder of a result path under the source's param path (source `Mid <- p.inner` resolves `Mid.Child` to `inner.Child`); unit tests pin the exact-path, deeper-path, bare-param, whole-result, and sibling-prefix shapes.
- Express path coverage through one total primitive, `trimFieldPathPrefix` (`joinFieldPath`'s inverse): `ResolveResultPath` builds on it and `SuppliesResultPath` delegates to `ResolveResultPath`, so the per-segment prefix rule exists once instead of as a boolean test plus a blind trim.
- Make `joinFieldPath("inner", "")` yield `inner` instead of `inner.` — required by the exact-path resolution above; existing callers never pass an empty sub-path.