### PR TITLE
refactor(struct-init-v2): split addContextFieldProducers by caller

### DIFF
--- a/assertion/function/assertiontree/backprop.go
+++ b/assertion/function/assertiontree/backprop.go
@@ -846,8 +846,8 @@ func backpropAcrossManyToOneAssignment(rootNode *RootAssertionNode, lhs, rhs []a
 			if funcObj := typeutil.StaticCallee(rootNode.Pass().TypesInfo, rhsVal); funcObj != nil {
 				sig := funcObj.Type().(*types.Signature)
 				if i < sig.Results().Len() {
-					if st := typeshelper.AsDeeplyStruct(sig.Results().At(i).Type()); st != nil {
-						rootNode.addContextFieldProducers(st, lhsVal, funcObj, annotation.StructFieldReturnContext, i)
+					if typeshelper.AsDeeplyStruct(sig.Results().At(i).Type()) != nil {
+						rootNode.addCallResultFieldProducers(lhsVal, funcObj, i)
 					}
 				}
 			}

--- a/assertion/function/assertiontree/structinitv2.go
+++ b/assertion/function/assertiontree/structinitv2.go
@@ -104,12 +104,9 @@ func (r *RootAssertionNode) resultValueHasParamSource(funcObj *types.Func, resul
 	return r.resultPathHasParamSource(funcObj, resultIdx, "")
 }
 
-// addCallResultFieldProducers attaches producers for the accessed fields of a single call result
-// bound to base: each accessed path reads the shared return context site of funcObj's
-// resultIdx-th result, seeded with the callee's concrete return effects, and param-sourced paths
-// stay severed (never solved on the shared sites). It is the single entry point for both the
-// one-result and the many-result assignment paths, so per-call resolution of param-sourced paths
-// can land in one place.
+// addCallResultFieldProducers attaches producers for the accessed fields of a call result bound
+// to base: each path reads the shared return context site of funcObj's resultIdx-th result,
+// seeded with the callee's concrete return effects.
 func (r *RootAssertionNode) addCallResultFieldProducers(base ast.Expr, funcObj *types.Func, resultIdx int) {
 	path, _ := r.ParseExprAsProducer(base, false)
 	node, _ := r.lookupPath(path)
@@ -281,30 +278,6 @@ func (r *RootAssertionNode) collectAccessedFieldPaths(node AssertionNode, base a
 		if !typeshelper.TypeBarsNilness(field.Type()) {
 			*out = append(*out, accessedFieldPath{sel: sel, path: path})
 		}
-	}
-}
-
-// addParamContextFieldProducers attaches, for each accessed nilable field path under base, a
-// producer making `base.<path>` nil iff the corresponding parameter context site of funcObj is
-// inferred nilable.
-func (r *RootAssertionNode) addParamContextFieldProducers(base ast.Expr, funcObj *types.Func, paramIdx int) {
-	path, _ := r.ParseExprAsProducer(base, false)
-	node, _ := r.lookupPath(path)
-	if node == nil {
-		return
-	}
-	var paths []accessedFieldPath
-	r.collectAccessedFieldPaths(node, base, "", make(map[*types.Struct]bool), &paths)
-	for _, p := range paths {
-		site := &annotation.StructFieldContextSite{
-			FuncObj: funcObj, Kind: annotation.StructFieldParamContext, Index: paramIdx, Path: p.path,
-		}
-		r.AddProduction(&annotation.ProduceTrigger{
-			Annotation: &annotation.StructFieldFromContext{
-				TriggerIfNilable: &annotation.TriggerIfNilable{Ann: site},
-			},
-			Expr: p.sel,
-		})
 	}
 }
 
@@ -550,7 +523,24 @@ func (r *RootAssertionNode) addParamFieldProducers(builtExpr ast.Expr) {
 	if typeshelper.AsDeeplyStruct(v.Type()) == nil {
 		return
 	}
-	r.addParamContextFieldProducers(builtExpr, r.FuncObj(), idx)
+	path, _ := r.ParseExprAsProducer(builtExpr, false)
+	node, _ := r.lookupPath(path)
+	if node == nil {
+		return
+	}
+	var paths []accessedFieldPath
+	r.collectAccessedFieldPaths(node, builtExpr, "", make(map[*types.Struct]bool), &paths)
+	for _, p := range paths {
+		site := &annotation.StructFieldContextSite{
+			FuncObj: r.FuncObj(), Kind: annotation.StructFieldParamContext, Index: idx, Path: p.path,
+		}
+		r.AddProduction(&annotation.ProduceTrigger{
+			Annotation: &annotation.StructFieldFromContext{
+				TriggerIfNilable: &annotation.TriggerIfNilable{Ann: site},
+			},
+			Expr: p.sel,
+		})
+	}
 }
 
 // buildFieldPathSelector builds the selector expression reaching base.<path>, where path is a

--- a/assertion/function/assertiontree/structinitv2.go
+++ b/assertion/function/assertiontree/structinitv2.go
@@ -66,7 +66,7 @@ func (r *RootAssertionNode) asStructAllocation(expr ast.Expr) (*types.Struct, []
 //     `new(A)`, nil for an explicit `nil`)
 //
 // If the RHS is instead a call to a struct-returning function, the value's fields are bound,
-// symbolically, to that function's return context sites (see addContextFieldProducers), so
+// symbolically, to that function's return context sites (see addCallResultFieldProducers), so
 // the nilability flows interprocedurally through inference.
 //
 // It must be called before the generic assignment handling produces lhsVal itself, because the
@@ -81,8 +81,8 @@ func (r *RootAssertionNode) addAllocationFieldProducers(lhsVal, rhsVal ast.Expr)
 	// context sites. (Multi-return calls are handled by the many-to-one assignment path.)
 	if call, ok := ast.Unparen(rhsVal).(*ast.CallExpr); ok {
 		if target, ok := typeshelper.ResolveStaticCallTarget(r.Pass().TypesInfo, call); ok && target.Signature.Results().Len() == 1 {
-			if structType := typeshelper.AsDeeplyStruct(target.Signature.Results().At(0).Type()); structType != nil {
-				r.addContextFieldProducers(structType, lhsVal, target.Origin, annotation.StructFieldReturnContext, 0)
+			if typeshelper.AsDeeplyStruct(target.Signature.Results().At(0).Type()) != nil {
+				r.addCallResultFieldProducers(lhsVal, target.Origin, 0)
 			}
 		}
 	}
@@ -102,6 +102,67 @@ func (r *RootAssertionNode) resultPathHasParamSource(funcObj *types.Func, result
 // `return p.x`.
 func (r *RootAssertionNode) resultValueHasParamSource(funcObj *types.Func, resultIdx int) bool {
 	return r.resultPathHasParamSource(funcObj, resultIdx, "")
+}
+
+// addCallResultFieldProducers attaches producers for the accessed fields of a single call result
+// bound to base: each accessed path reads the shared return context site of funcObj's
+// resultIdx-th result, seeded with the callee's concrete return effects, and param-sourced paths
+// stay severed (never solved on the shared sites). It is the single entry point for both the
+// one-result and the many-result assignment paths, so per-call resolution of param-sourced paths
+// can land in one place.
+func (r *RootAssertionNode) addCallResultFieldProducers(base ast.Expr, funcObj *types.Func, resultIdx int) {
+	path, _ := r.ParseExprAsProducer(base, false)
+	node, _ := r.lookupPath(path)
+	if node == nil {
+		return
+	}
+	var paths []accessedFieldPath
+	r.collectAccessedFieldPaths(node, base, "", make(map[*types.Struct]bool), &paths)
+
+	returnEffects := make(map[string]bool)
+	// Error-returning functions are skipped for now: correlating the fields with the error result
+	// to be added in the future.
+	if !typeshelper.FuncIsErrReturning(funcObj.Signature()) {
+		for _, fieldPath := range r.functionContext.boundaryFieldEffects.ReturnEffectPaths(funcObj, resultIdx) {
+			returnEffects[fieldPath] = true
+		}
+	}
+
+	for _, p := range paths {
+		// A param-sourced return path is caller-dependent and is never solved on the shared
+		// return sites
+		if r.resultPathHasParamSource(funcObj, resultIdx, p.path) {
+			continue
+		}
+		site := &annotation.StructFieldContextSite{
+			FuncObj: funcObj, Kind: annotation.StructFieldReturnContext, Index: resultIdx, Path: p.path,
+		}
+		r.AddProduction(&annotation.ProduceTrigger{
+			Annotation: &annotation.StructFieldFromContext{
+				TriggerIfNilable: &annotation.TriggerIfNilable{Ann: site},
+			},
+			Expr: p.sel,
+		})
+		// If the callee's known return effects prove this path nil (e.g. `return &T{}`),
+		// additionally seed the context site with a definite nil here at the caller.
+		if returnEffects[p.path] {
+			parts := strings.Split(p.path, ".")
+			r.AddNewTriggers(annotation.FullTrigger{
+				Producer: &annotation.ProduceTrigger{
+					Annotation: &annotation.StructFieldNil{
+						ProduceTriggerTautology: &annotation.ProduceTriggerTautology{},
+						FieldName:               parts[len(parts)-1],
+					},
+					Expr: p.sel,
+				},
+				Consumer: &annotation.ConsumeTrigger{
+					Annotation: &annotation.StructFieldToContext{TriggerIfNonNil: &annotation.TriggerIfNonNil{Ann: site}},
+					Expr:       p.sel,
+					Guards:     guard.NoGuards(),
+				},
+			})
+		}
+	}
 }
 
 // getShallowExprNilabilityProducer returns the producer encoding the nilability of the value of expr: an
@@ -223,10 +284,10 @@ func (r *RootAssertionNode) collectAccessedFieldPaths(node AssertionNode, base a
 	}
 }
 
-// addContextFieldProducers attaches, for each accessed nilable field path under base, a producer
-// making `base.<path>` nil iff the corresponding return/param context site of funcObj is inferred
-// nilable.
-func (r *RootAssertionNode) addContextFieldProducers(_ *types.Struct, base ast.Expr, funcObj *types.Func, kind annotation.StructFieldContextKind, index int) {
+// addParamContextFieldProducers attaches, for each accessed nilable field path under base, a
+// producer making `base.<path>` nil iff the corresponding parameter context site of funcObj is
+// inferred nilable.
+func (r *RootAssertionNode) addParamContextFieldProducers(base ast.Expr, funcObj *types.Func, paramIdx int) {
 	path, _ := r.ParseExprAsProducer(base, false)
 	node, _ := r.lookupPath(path)
 	if node == nil {
@@ -234,22 +295,9 @@ func (r *RootAssertionNode) addContextFieldProducers(_ *types.Struct, base ast.E
 	}
 	var paths []accessedFieldPath
 	r.collectAccessedFieldPaths(node, base, "", make(map[*types.Struct]bool), &paths)
-	returnEffects := make(map[string]bool)
-	// Error-returning functions are skipped for now: correlating the fields with the error result to be added
-	// in the future.
-	if kind == annotation.StructFieldReturnContext && !typeshelper.FuncIsErrReturning(funcObj.Signature()) {
-		for _, fieldPath := range r.functionContext.boundaryFieldEffects.ReturnEffectPaths(funcObj, index) {
-			returnEffects[fieldPath] = true
-		}
-	}
 	for _, p := range paths {
-		// A param-sourced return path is caller-dependent and is never solved on the shared
-		// return sites
-		if kind == annotation.StructFieldReturnContext && r.resultPathHasParamSource(funcObj, index, p.path) {
-			continue
-		}
 		site := &annotation.StructFieldContextSite{
-			FuncObj: funcObj, Kind: kind, Index: index, Path: p.path,
+			FuncObj: funcObj, Kind: annotation.StructFieldParamContext, Index: paramIdx, Path: p.path,
 		}
 		r.AddProduction(&annotation.ProduceTrigger{
 			Annotation: &annotation.StructFieldFromContext{
@@ -257,25 +305,6 @@ func (r *RootAssertionNode) addContextFieldProducers(_ *types.Struct, base ast.E
 			},
 			Expr: p.sel,
 		})
-		// If the callee's known return effects prove this path nil (e.g. `return &T{}`),
-		// additionally seed the context site with a definite nil here at the caller.
-		if returnEffects[p.path] {
-			parts := strings.Split(p.path, ".")
-			r.AddNewTriggers(annotation.FullTrigger{
-				Producer: &annotation.ProduceTrigger{
-					Annotation: &annotation.StructFieldNil{
-						ProduceTriggerTautology: &annotation.ProduceTriggerTautology{},
-						FieldName:               parts[len(parts)-1],
-					},
-					Expr: p.sel,
-				},
-				Consumer: &annotation.ConsumeTrigger{
-					Annotation: &annotation.StructFieldToContext{TriggerIfNonNil: &annotation.TriggerIfNonNil{Ann: site}},
-					Expr:       p.sel,
-					Guards:     guard.NoGuards(),
-				},
-			})
-		}
 	}
 }
 
@@ -518,11 +547,10 @@ func (r *RootAssertionNode) addParamFieldProducers(builtExpr ast.Expr) {
 	if !ok {
 		return
 	}
-	structType := typeshelper.AsDeeplyStruct(v.Type())
-	if structType == nil {
+	if typeshelper.AsDeeplyStruct(v.Type()) == nil {
 		return
 	}
-	r.addContextFieldProducers(structType, builtExpr, r.FuncObj(), annotation.StructFieldParamContext, idx)
+	r.addParamContextFieldProducers(builtExpr, r.FuncObj(), idx)
 }
 
 // buildFieldPathSelector builds the selector expression reaching base.<path>, where path is a


### PR DESCRIPTION
`addContextFieldProducers` did two unrelated jobs behind a `kind` switch: producing fields of a call result read from the callee's return sites, and producing fields of a parameter at function entry read from its param sites. 

It is now split by caller:
- (a) call-result assignments (`lhs := f()` and `a, b := f()`) call `addCallResultFieldProducers`, which owns the return-only logic;
- (b) the parameter-entry path is inlined into its only caller, `addParamFieldProducers`.