### PR TITLE
refactor(struct-init-v2): make field paths an opaque comparable type

### DIFF
--- a/annotation/fieldpath.go
+++ b/annotation/fieldpath.go
@@ -1,0 +1,110 @@
+//  Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package annotation
+
+import (
+	"cmp"
+	"strings"
+)
+
+// FieldPath is an opaque, comparable chain of struct field selections below a boundary value (a
+// parameter, receiver, or result). The zero value denotes the boundary value itself.
+type FieldPath struct {
+	// dotted is the field-name segments joined with ".". Field names are identifiers and cannot
+	// contain the separator, and a single string keeps FieldPath usable as a map key.
+	dotted string
+}
+
+// NewFieldPath builds the path selecting segments in order below a boundary value.
+func NewFieldPath(segments ...string) FieldPath {
+	return FieldPath{dotted: strings.Join(segments, ".")}
+}
+
+// IsRoot reports whether p is the boundary value itself.
+func (p FieldPath) IsRoot() bool {
+	return p.dotted == ""
+}
+
+// Child returns the path selecting field below p.
+func (p FieldPath) Child(field string) FieldPath {
+	if p.dotted == "" {
+		return FieldPath{dotted: field}
+	}
+	return FieldPath{dotted: p.dotted + "." + field}
+}
+
+// Join concatenates two paths: the result selects p's segments, then sub's.
+func (p FieldPath) Join(sub FieldPath) FieldPath {
+	switch {
+	case p.dotted == "":
+		return sub
+	case sub.dotted == "":
+		return p
+	}
+	return FieldPath{dotted: p.dotted + "." + sub.dotted}
+}
+
+// TrimPrefix is Join's inverse: prefix.Join(sub) == p iff p.TrimPrefix(prefix) == (sub, true).
+// The match is per segment (`Middle` is not below `Mid`); ok is false when prefix does not cover p.
+func (p FieldPath) TrimPrefix(prefix FieldPath) (sub FieldPath, ok bool) {
+	switch {
+	case prefix.dotted == "":
+		return p, true
+	case p.dotted == prefix.dotted:
+		return FieldPath{}, true
+	case strings.HasPrefix(p.dotted, prefix.dotted+"."):
+		return FieldPath{dotted: p.dotted[len(prefix.dotted)+1:]}, true
+	default:
+		return FieldPath{}, false
+	}
+}
+
+// Segments returns p's field names in selection order; nil for the root path.
+func (p FieldPath) Segments() []string {
+	if p.dotted == "" {
+		return nil
+	}
+	return strings.Split(p.dotted, ".")
+}
+
+// NumSegments returns the number of field selections in p.
+func (p FieldPath) NumSegments() int {
+	if p.dotted == "" {
+		return 0
+	}
+	return strings.Count(p.dotted, ".") + 1
+}
+
+// Compare lexicographically orders paths for deterministic output.
+func (p FieldPath) Compare(other FieldPath) int {
+	return cmp.Compare(p.dotted, other.dotted)
+}
+
+// String renders p for diagnostics, e.g. "Mid.Child"; the root path renders empty.
+func (p FieldPath) String() string {
+	return p.dotted
+}
+
+// GobEncode implements gob.GobEncoder: FieldPath appears in exported analysis facts, and gob
+// cannot see the unexported representation.
+func (p FieldPath) GobEncode() ([]byte, error) {
+	return []byte(p.dotted), nil
+}
+
+// GobDecode implements gob.GobDecoder.
+func (p *FieldPath) GobDecode(data []byte) error {
+	p.dotted = string(data)
+	return nil
+}

--- a/annotation/fieldpath_test.go
+++ b/annotation/fieldpath_test.go
@@ -1,0 +1,130 @@
+//  Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package annotation
+
+import (
+	"bytes"
+	"encoding/gob"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFieldPathConstruction(t *testing.T) {
+	t.Parallel()
+
+	root := FieldPath{}
+	require.True(t, root.IsRoot())
+	require.Equal(t, "", root.String())
+	require.Nil(t, root.Segments())
+	require.Equal(t, 0, root.NumSegments())
+	require.Equal(t, root, NewFieldPath())
+
+	deep := NewFieldPath("Mid", "Child")
+	require.False(t, deep.IsRoot())
+	require.Equal(t, "Mid.Child", deep.String())
+	require.Equal(t, []string{"Mid", "Child"}, deep.Segments())
+	require.Equal(t, 2, deep.NumSegments())
+
+	require.Equal(t, deep, root.Child("Mid").Child("Child"))
+	require.Equal(t, deep, NewFieldPath("Mid").Child("Child"))
+}
+
+func TestFieldPathJoin(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		prefix, sub FieldPath
+		want        FieldPath
+	}{
+		{name: "root and root", prefix: FieldPath{}, sub: FieldPath{}, want: FieldPath{}},
+		{name: "root prefix is identity", prefix: FieldPath{}, sub: NewFieldPath("f"), want: NewFieldPath("f")},
+		{name: "root sub is identity", prefix: NewFieldPath("inner"), sub: FieldPath{}, want: NewFieldPath("inner")},
+		{name: "both non-root", prefix: NewFieldPath("inner"), sub: NewFieldPath("f"), want: NewFieldPath("inner", "f")},
+		{name: "deep both sides", prefix: NewFieldPath("a", "b"), sub: NewFieldPath("c", "d"), want: NewFieldPath("a", "b", "c", "d")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, tt.prefix.Join(tt.sub))
+		})
+	}
+}
+
+func TestFieldPathTrimPrefix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		path, prefix FieldPath
+		want         FieldPath
+		wantOK       bool
+	}{
+		{name: "root prefix is identity", path: NewFieldPath("Mid", "Child"), prefix: FieldPath{}, want: NewFieldPath("Mid", "Child"), wantOK: true},
+		{name: "exact match trims to root", path: NewFieldPath("Mid"), prefix: NewFieldPath("Mid"), want: FieldPath{}, wantOK: true},
+		{name: "proper prefix", path: NewFieldPath("Mid", "Child"), prefix: NewFieldPath("Mid"), want: NewFieldPath("Child"), wantOK: true},
+		{name: "segment boundary respected", path: NewFieldPath("Middle"), prefix: NewFieldPath("Mid"), wantOK: false},
+		{name: "prefix longer than path", path: NewFieldPath("Mid"), prefix: NewFieldPath("Mid", "Child"), wantOK: false},
+		{name: "disjoint", path: NewFieldPath("Other"), prefix: NewFieldPath("Mid"), wantOK: false},
+		{name: "root path under non-root prefix", path: FieldPath{}, prefix: NewFieldPath("Mid"), wantOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			sub, ok := tt.path.TrimPrefix(tt.prefix)
+			require.Equal(t, tt.wantOK, ok)
+			require.Equal(t, tt.want, sub)
+		})
+	}
+}
+
+// TestFieldPathJoinTrimRoundTrip pins the inverse contract: prefix.Join(sub).TrimPrefix(prefix)
+// recovers sub for every combination of root and non-root operands.
+func TestFieldPathJoinTrimRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	paths := []FieldPath{{}, NewFieldPath("a"), NewFieldPath("a", "b")}
+	for _, prefix := range paths {
+		for _, sub := range paths {
+			got, ok := prefix.Join(sub).TrimPrefix(prefix)
+			require.True(t, ok)
+			require.Equal(t, sub, got)
+		}
+	}
+}
+
+func TestFieldPathCompare(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, 0, NewFieldPath("a", "b").Compare(NewFieldPath("a", "b")))
+	require.Negative(t, FieldPath{}.Compare(NewFieldPath("a")))
+	require.Positive(t, NewFieldPath("b").Compare(NewFieldPath("a")))
+}
+
+func TestFieldPathGobRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	type carrier struct {
+		Path  FieldPath
+		Other FieldPath
+	}
+	want := carrier{Path: NewFieldPath("Mid", "Child")}
+	var buf bytes.Buffer
+	require.NoError(t, gob.NewEncoder(&buf).Encode(want))
+	var got carrier
+	require.NoError(t, gob.NewDecoder(bytes.NewReader(buf.Bytes())).Decode(&got))
+	require.Equal(t, want, got)
+}

--- a/annotation/structinitv2.go
+++ b/annotation/structinitv2.go
@@ -99,9 +99,9 @@ type StructFieldContextSite struct {
 	FuncObj *types.Func
 	Kind    StructFieldContextKind
 	Index   int
-	// Path is the dotted field path from the boundary value to the tracked field (e.g. "aptr").
-	// Empty for a site describing the boundary value itself.
-	Path string
+	// Path is the field path from the boundary value to the tracked field. The zero value
+	// denotes a site describing the boundary value itself.
+	Path FieldPath
 	// Location is set for a call-site-scoped field site: return param sources are instantiated per call
 	// site, so each call gets its own site and one caller's argument cannot poison another
 	// caller's result. The zero value denotes the ordinary formal function-boundary site shared
@@ -138,7 +138,7 @@ func (s *StructFieldContextSite) String() string {
 	// post-call state. The call-site location keeps call-site-scoped sites of different calls
 	// distinct.
 	subject := fmt.Sprintf("field `%s`", s.Path)
-	if s.Path == "" {
+	if s.Path.IsRoot() {
 		subject = "value"
 	}
 	if s.Location.IsValid() {
@@ -163,7 +163,7 @@ func (s *StructFieldFromContext) equals(other ProducingAnnotationTrigger) bool {
 // Repr returns this StructFieldFromContext as a fmt.Stringer.
 func (s *StructFieldFromContext) Repr() fmt.Stringer {
 	site := s.Ann.(*StructFieldContextSite)
-	return StructFieldFromContextRepr{Path: site.Path, Kind: site.Kind, Index: site.Index, FuncName: site.FuncObj.Name()}
+	return StructFieldFromContextRepr{Path: site.Path.String(), Kind: site.Kind, Index: site.Index, FuncName: site.FuncObj.Name()}
 }
 
 // StructFieldFromContextRepr is the compact encoding of a StructFieldFromContext.
@@ -205,7 +205,7 @@ func (s *StructFieldToContext) Copy() ConsumingAnnotationTrigger {
 // Repr returns this StructFieldToContext as a fmt.Stringer.
 func (s *StructFieldToContext) Repr() fmt.Stringer {
 	site := s.Ann.(*StructFieldContextSite)
-	return StructFieldToContextRepr{Path: site.Path, Kind: site.Kind, Index: site.Index, FuncName: site.FuncObj.Name()}
+	return StructFieldToContextRepr{Path: site.Path.String(), Kind: site.Kind, Index: site.Index, FuncName: site.FuncObj.Name()}
 }
 
 // StructFieldToContextRepr is the compact encoding of a StructFieldToContext.

--- a/assertion/function/assertiontree/structinitv2.go
+++ b/assertion/function/assertiontree/structinitv2.go
@@ -20,7 +20,6 @@ import (
 	"go/types"
 	"slices"
 	"sort"
-	"strings"
 
 	"go.uber.org/nilaway/annotation"
 	"go.uber.org/nilaway/assertion/function/structfieldeffects"
@@ -90,7 +89,7 @@ func (r *RootAssertionNode) addAllocationFieldProducers(lhsVal, rhsVal ast.Expr)
 
 // resultPathHasParamSource reports whether funcObj's (resultIdx, resultPath) is supplied by a
 // caller argument.
-func (r *RootAssertionNode) resultPathHasParamSource(funcObj *types.Func, resultIdx int, resultPath string) bool {
+func (r *RootAssertionNode) resultPathHasParamSource(funcObj *types.Func, resultIdx int, resultPath annotation.FieldPath) bool {
 	sources := r.functionContext.boundaryFieldEffects.ReturnParamSources(funcObj)
 	return slices.ContainsFunc(sources, func(src structfieldeffects.ReturnParamSource) bool {
 		return src.SuppliesResultPath(resultIdx, resultPath)
@@ -101,7 +100,7 @@ func (r *RootAssertionNode) resultPathHasParamSource(funcObj *types.Func, result
 // field of it) is supplied by a caller argument — a whole-result source from `return p` or
 // `return p.x`.
 func (r *RootAssertionNode) resultValueHasParamSource(funcObj *types.Func, resultIdx int) bool {
-	return r.resultPathHasParamSource(funcObj, resultIdx, "")
+	return r.resultPathHasParamSource(funcObj, resultIdx, annotation.FieldPath{})
 }
 
 // addCallResultFieldProducers attaches producers for the accessed fields of a call result bound
@@ -114,9 +113,9 @@ func (r *RootAssertionNode) addCallResultFieldProducers(base ast.Expr, funcObj *
 		return
 	}
 	var paths []accessedFieldPath
-	r.collectAccessedFieldPaths(node, base, "", make(map[*types.Struct]bool), &paths)
+	r.collectAccessedFieldPaths(node, base, annotation.FieldPath{}, make(map[*types.Struct]bool), &paths)
 
-	returnEffects := make(map[string]bool)
+	returnEffects := make(map[annotation.FieldPath]bool)
 	// Error-returning functions are skipped for now: correlating the fields with the error result
 	// to be added in the future.
 	if !typeshelper.FuncIsErrReturning(funcObj.Signature()) {
@@ -143,12 +142,12 @@ func (r *RootAssertionNode) addCallResultFieldProducers(base ast.Expr, funcObj *
 		// If the callee's known return effects prove this path nil (e.g. `return &T{}`),
 		// additionally seed the context site with a definite nil here at the caller.
 		if returnEffects[p.path] {
-			parts := strings.Split(p.path, ".")
+			segments := p.path.Segments()
 			r.AddNewTriggers(annotation.FullTrigger{
 				Producer: &annotation.ProduceTrigger{
 					Annotation: &annotation.StructFieldNil{
 						ProduceTriggerTautology: &annotation.ProduceTriggerTautology{},
-						FieldName:               parts[len(parts)-1],
+						FieldName:               segments[len(segments)-1],
 					},
 					Expr: p.sel,
 				},
@@ -249,12 +248,12 @@ func (r *RootAssertionNode) isLocalRootedValue(expr ast.Expr) bool {
 // selector expression that reaches it.
 type accessedFieldPath struct {
 	sel  ast.Expr
-	path string
+	path annotation.FieldPath
 }
 
 // collectAccessedFieldPaths walks the live assertion subtree under node and collects accessed nilable
-// field paths, deepest path first. prefix is the dotted path from the boundary value to node.
-func (r *RootAssertionNode) collectAccessedFieldPaths(node AssertionNode, base ast.Expr, prefix string, seen map[*types.Struct]bool, out *[]accessedFieldPath) {
+// field paths, deepest path first. prefix is the field path from the boundary value to node.
+func (r *RootAssertionNode) collectAccessedFieldPaths(node AssertionNode, base ast.Expr, prefix annotation.FieldPath, seen map[*types.Struct]bool, out *[]accessedFieldPath) {
 	for _, child := range node.Children() {
 		fldNode, ok := child.(*fldAssertionNode)
 		if !ok {
@@ -262,10 +261,7 @@ func (r *RootAssertionNode) collectAccessedFieldPaths(node AssertionNode, base a
 		}
 		field := fldNode.decl
 		sel := r.getSelectorExpr(field, base)
-		path := field.Name()
-		if prefix != "" {
-			path = prefix + "." + field.Name()
-		}
+		path := prefix.Child(field.Name())
 		if inner := typeshelper.AsDeeplyStruct(field.Type()); inner == nil || !seen[inner] {
 			if inner != nil {
 				seen[inner] = true
@@ -322,7 +318,7 @@ func (r *RootAssertionNode) bindValueFieldsToContext(targetFunc *types.Func, val
 
 	allocType, fieldInits, isAlloc := r.asStructAllocation(valExpr)
 	if isAlloc {
-		r.bindAllocationFieldsToContext(allocType, fieldInits, valExpr, "", funcObj, kind, index)
+		r.bindAllocationFieldsToContext(allocType, fieldInits, valExpr, annotation.FieldPath{}, funcObj, kind, index)
 		return
 	}
 
@@ -358,7 +354,7 @@ func (r *RootAssertionNode) bindValueFieldsToContext(targetFunc *types.Func, val
 // boundaryReadPaths returns the field paths that are read through the boundary context site of
 // funcObj at (kind, index): the callee's param read-set for an argument or receiver, or the
 // callers' return read-set for a return value.
-func (r *RootAssertionNode) boundaryReadPaths(funcObj *types.Func, kind annotation.StructFieldContextKind, index int) []string {
+func (r *RootAssertionNode) boundaryReadPaths(funcObj *types.Func, kind annotation.StructFieldContextKind, index int) []annotation.FieldPath {
 	switch kind {
 	case annotation.StructFieldParamContext:
 		return r.functionContext.boundaryFieldEffects.ParamReadPaths(funcObj, index)
@@ -390,18 +386,18 @@ func (r *RootAssertionNode) bindCallResultFieldsToContext(call *ast.CallExpr, va
 	if sourceType == nil {
 		return
 	}
-	pathSet := make(map[string]bool)
+	pathSet := make(map[annotation.FieldPath]bool)
 	for _, path := range r.functionContext.boundaryFieldEffects.ReturnEffectPaths(source.Origin, 0) {
 		pathSet[path] = true
 	}
 	for _, path := range r.boundaryReadPaths(targetFunc, kind, index) {
 		pathSet[path] = true
 	}
-	paths := make([]string, 0, len(pathSet))
+	paths := make([]annotation.FieldPath, 0, len(pathSet))
 	for path := range pathSet {
 		paths = append(paths, path)
 	}
-	sort.Strings(paths)
+	slices.SortFunc(paths, annotation.FieldPath.Compare)
 	for _, fieldPath := range paths {
 		// Param-sourced paths of the callee are caller-dependent: forwarding them
 		// through the shared return sites would merge callers.
@@ -428,16 +424,13 @@ func (r *RootAssertionNode) bindCallResultFieldsToContext(call *ast.CallExpr, va
 
 // bindAllocationFieldsToContext binds the per-field nilability of an inline struct allocation to
 // the boundary context site of funcObj at (kind, index).
-func (r *RootAssertionNode) bindAllocationFieldsToContext(structType *types.Struct, fieldInits []ast.Expr, valExpr ast.Expr, prefix string, funcObj *types.Func, kind annotation.StructFieldContextKind, index int) {
+func (r *RootAssertionNode) bindAllocationFieldsToContext(structType *types.Struct, fieldInits []ast.Expr, valExpr ast.Expr, prefix annotation.FieldPath, funcObj *types.Func, kind annotation.StructFieldContextKind, index int) {
 	numFields := structType.NumFields()
 	for i := range numFields {
 		field := structType.Field(i)
 		fieldVal := asthelper.GetFieldVal(fieldInits, field.Name(), numFields, i)
 		nilable := !typeshelper.TypeBarsNilness(field.Type())
-		path := field.Name()
-		if prefix != "" {
-			path = prefix + "." + field.Name()
-		}
+		path := prefix.Child(field.Name())
 
 		switch {
 		case fieldVal != nil:
@@ -529,7 +522,7 @@ func (r *RootAssertionNode) addParamFieldProducers(builtExpr ast.Expr) {
 		return
 	}
 	var paths []accessedFieldPath
-	r.collectAccessedFieldPaths(node, builtExpr, "", make(map[*types.Struct]bool), &paths)
+	r.collectAccessedFieldPaths(node, builtExpr, annotation.FieldPath{}, make(map[*types.Struct]bool), &paths)
 	for _, p := range paths {
 		site := &annotation.StructFieldContextSite{
 			FuncObj: r.FuncObj(), Kind: annotation.StructFieldParamContext, Index: idx, Path: p.path,
@@ -544,11 +537,11 @@ func (r *RootAssertionNode) addParamFieldProducers(builtExpr ast.Expr) {
 }
 
 // buildFieldPathSelector builds the selector expression reaching base.<path>, where path is a
-// dotted field path under base's struct type.
-func (r *RootAssertionNode) buildFieldPathSelector(base ast.Expr, structType *types.Struct, path string) (ast.Expr, bool) {
+// field path under base's struct type.
+func (r *RootAssertionNode) buildFieldPathSelector(base ast.Expr, structType *types.Struct, path annotation.FieldPath) (ast.Expr, bool) {
 	cur := base
 	curStruct := structType
-	for _, name := range strings.Split(path, ".") {
+	for _, name := range path.Segments() {
 		if curStruct == nil {
 			return nil, false
 		}
@@ -600,7 +593,7 @@ func (r *RootAssertionNode) addCallParamOutFieldProducers(call *ast.CallExpr, ta
 		paths := r.functionContext.boundaryFieldEffects.ParamWritePaths(target.Origin, index)
 		// AddProduction detaches a matched subtree, so nested paths must be produced first.
 		sort.SliceStable(paths, func(i, j int) bool {
-			return strings.Count(paths[i], ".") > strings.Count(paths[j], ".")
+			return paths[i].NumSegments() > paths[j].NumSegments()
 		})
 		for _, fieldPath := range paths {
 			fieldExpr, ok := r.buildFieldPathSelector(arg, structType, fieldPath)
@@ -641,15 +634,16 @@ func (r *RootAssertionNode) addCallParamOutFieldProducers(call *ast.CallExpr, ta
 
 // bindForwardedParamOut connects a callee's output summary to a forwarder's output summary. For
 // `func g(p *A) { f(p) }`, when f's parameter 0 may write b.c, it adds
-// `PARAM_OUT(f, 0, "b.c") -> PARAM_OUT(g, 0, "b.c")`. A field prefix is retained, so passing
-// p.inner to f instead targets `PARAM_OUT(g, 0, "inner.b.c")`. The write summary is already closed
+// `PARAM_OUT(f, 0, b.c) -> PARAM_OUT(g, 0, b.c)`. A field prefix is retained, so passing
+// p.inner to f instead targets `PARAM_OUT(g, 0, inner.b.c)`. The write summary is already closed
 // over these edges; this supplies each inherited path's context value.
 func (r *RootAssertionNode) bindForwardedParamOut(call *ast.CallExpr, target typeshelper.StaticCallTarget) {
 	link := func(calleeIndex int, arg ast.Expr) {
-		base, prefix := asthelper.SplitFieldChain(arg)
+		base, prefixSegments := asthelper.SplitFieldChain(arg)
 		if base == nil {
 			return
 		}
+		prefix := annotation.NewFieldPath(prefixSegments...)
 		param, ok := r.ObjectOf(base).(*types.Var)
 		if !ok {
 			return
@@ -659,10 +653,7 @@ func (r *RootAssertionNode) bindForwardedParamOut(call *ast.CallExpr, target typ
 			return
 		}
 		for _, calleePath := range r.functionContext.boundaryFieldEffects.ParamWritePaths(target.Origin, calleeIndex) {
-			fieldPath := calleePath
-			if prefix != "" {
-				fieldPath = prefix + "." + fieldPath
-			}
+			fieldPath := prefix.Join(calleePath)
 			source := &annotation.StructFieldContextSite{
 				FuncObj: target.Origin, Kind: annotation.StructFieldParamOutContext, Index: calleeIndex, Path: calleePath,
 			}
@@ -702,10 +693,11 @@ func (r *RootAssertionNode) bindForwardedParamOut(call *ast.CallExpr, target typ
 // ordinary intraprocedural flow supplies the context. The write-summary check excludes local field
 // assignments from this boundary.
 func (r *RootAssertionNode) bindParamFieldWriteToContext(lhs, rhs ast.Expr) {
-	base, fieldPath := asthelper.SplitFieldChain(lhs)
-	if base == nil || fieldPath == "" {
+	base, segments := asthelper.SplitFieldChain(lhs)
+	if base == nil || len(segments) == 0 {
 		return
 	}
+	fieldPath := annotation.NewFieldPath(segments...)
 	param, ok := r.ObjectOf(base).(*types.Var)
 	if !ok {
 		return

--- a/assertion/function/structfieldeffects/collector.go
+++ b/assertion/function/structfieldeffects/collector.go
@@ -509,7 +509,7 @@ func (fc *functionCollector) collectStableStructVars() map[*types.Var]bool {
 func (fc *functionCollector) collectReturnSiteEffect(resultIdx int, resultExpr ast.Expr) {
 	if source, ok := staticStructAllocation(fc.pass, resultExpr); ok {
 		fc.collected.markResultWithConstructSite(fc.funcObj, resultIdx)
-		fc.enumerateConcreteReturnEffects(resultIdx, source.structType, source.fieldInits, "")
+		fc.enumerateConcreteReturnEffects(resultIdx, source.structType, source.fieldInits, annotation.FieldPath{})
 		return
 	}
 	if call, ok := ast.Unparen(resultExpr).(*ast.CallExpr); ok {
@@ -529,7 +529,7 @@ func (fc *functionCollector) collectReturnSiteEffect(resultIdx int, resultExpr a
 	}
 	if source, ok := fc.allocationVars[v]; ok {
 		fc.collected.markResultWithConstructSite(fc.funcObj, resultIdx)
-		fc.enumerateConcreteReturnEffects(resultIdx, source.structType, source.fieldInits, "")
+		fc.enumerateConcreteReturnEffects(resultIdx, source.structType, source.fieldInits, annotation.FieldPath{})
 		return
 	}
 	if source, ok := fc.resultVars[v]; ok {
@@ -556,10 +556,10 @@ func (fc *functionCollector) addReturnEdge(callerResultIdx int, target typeshelp
 
 // enumerateConcreteReturnEffects records omitted and explicitly nil fields from one allocation,
 // and the field-level param sources of fields initialized from parameters (recordFieldParamSource).
-func (fc *functionCollector) enumerateConcreteReturnEffects(resultIdx int, structType *types.Struct, fieldInits []ast.Expr, prefix string) {
+func (fc *functionCollector) enumerateConcreteReturnEffects(resultIdx int, structType *types.Struct, fieldInits []ast.Expr, prefix annotation.FieldPath) {
 	for i := range structType.NumFields() {
 		field := structType.Field(i)
-		path := joinFieldPath(prefix, field.Name())
+		path := prefix.Child(field.Name())
 		fieldVal := asthelper.GetFieldVal(fieldInits, field.Name(), structType.NumFields(), i)
 		nilable := !typeshelper.TypeBarsNilness(field.Type())
 		switch {
@@ -597,10 +597,11 @@ func (fc *functionCollector) enumerateConcreteReturnEffects(resultIdx int, struc
 // roots at a local bound from a struct-returning call (resultVars) it goes to ReturnReads,
 // attributed to that callee's result.
 func (fc *functionCollector) collectFieldReadDemand(sel *ast.SelectorExpr, skipValueDemand bool) {
-	record := func(base *ast.Ident, path string) {
-		if base == nil || path == "" {
+	record := func(base *ast.Ident, segments []string) {
+		if base == nil || len(segments) == 0 {
 			return
 		}
+		path := annotation.NewFieldPath(segments...)
 		v, ok := fc.pass.TypesInfo.ObjectOf(base).(*types.Var)
 		if !ok {
 			return
@@ -642,10 +643,11 @@ func (fc *functionCollector) collectParamFieldWrites(assign *ast.AssignStmt) {
 		if !ok || typeshelper.TypeBarsNilness(field.Type()) {
 			continue
 		}
-		base, path := asthelper.SplitFieldChain(lhs)
-		if base == nil || path == "" {
+		base, segments := asthelper.SplitFieldChain(lhs)
+		if base == nil || len(segments) == 0 {
 			continue
 		}
+		path := annotation.NewFieldPath(segments...)
 		param, ok := fc.pass.TypesInfo.ObjectOf(base).(*types.Var)
 		if !ok {
 			continue
@@ -688,7 +690,7 @@ func (fc *functionCollector) collectParamForwardEdges(call *ast.CallExpr) *types
 		}
 		fc.collected.addParamForwardEdge(fc.funcObj, paramFieldForwardEdge{
 			callerParamIdx: callerIdx,
-			callerPrefix:   prefix,
+			callerPrefix:   annotation.NewFieldPath(prefix...),
 			callee:         target.Origin,
 			calleeParamIdx: calleeIdx,
 		})

--- a/assertion/function/structfieldeffects/effects.go
+++ b/assertion/function/structfieldeffects/effects.go
@@ -18,8 +18,6 @@ import (
 	"cmp"
 	"go/types"
 	"slices"
-	"sort"
-	"strings"
 
 	"go.uber.org/nilaway/annotation"
 	"go.uber.org/nilaway/util/typeshelper"
@@ -52,7 +50,7 @@ type BoundaryFieldEffects struct {
 }
 
 // ParamReadPaths returns the field paths read from funcObj's parameter or receiver at idx.
-func (e *BoundaryFieldEffects) ParamReadPaths(funcObj *types.Func, idx int) []string {
+func (e *BoundaryFieldEffects) ParamReadPaths(funcObj *types.Func, idx int) []annotation.FieldPath {
 	if e == nil {
 		return nil
 	}
@@ -60,7 +58,7 @@ func (e *BoundaryFieldEffects) ParamReadPaths(funcObj *types.Func, idx int) []st
 }
 
 // ReturnReadPaths returns the field paths read from funcObj's result at idx.
-func (e *BoundaryFieldEffects) ReturnReadPaths(funcObj *types.Func, idx int) []string {
+func (e *BoundaryFieldEffects) ReturnReadPaths(funcObj *types.Func, idx int) []annotation.FieldPath {
 	if e == nil {
 		return nil
 	}
@@ -68,7 +66,7 @@ func (e *BoundaryFieldEffects) ReturnReadPaths(funcObj *types.Func, idx int) []s
 }
 
 // ReturnEffectPaths returns the field paths that are provably nil in funcObj's result at idx.
-func (e *BoundaryFieldEffects) ReturnEffectPaths(funcObj *types.Func, idx int) []string {
+func (e *BoundaryFieldEffects) ReturnEffectPaths(funcObj *types.Func, idx int) []annotation.FieldPath {
 	if e == nil {
 		return nil
 	}
@@ -76,24 +74,24 @@ func (e *BoundaryFieldEffects) ReturnEffectPaths(funcObj *types.Func, idx int) [
 }
 
 // ParamWritePaths returns the field paths written through funcObj's parameter or receiver at idx.
-func (e *BoundaryFieldEffects) ParamWritePaths(funcObj *types.Func, idx int) []string {
+func (e *BoundaryFieldEffects) ParamWritePaths(funcObj *types.Func, idx int) []annotation.FieldPath {
 	if e == nil {
 		return nil
 	}
 	return fieldPathsForIndex(e.paramWrites, funcObj, idx)
 }
 
-func fieldPathsForIndex(effects fieldEffects, funcObj *types.Func, idx int) []string {
+func fieldPathsForIndex(effects fieldEffects, funcObj *types.Func, idx int) []annotation.FieldPath {
 	fields := effects[funcObj]
-	paths := make([]string, 0, len(fields))
+	paths := make([]annotation.FieldPath, 0, len(fields))
 	for key := range fields {
-		if key.Idx == idx && key.Path != "" {
+		if key.Idx == idx && !key.Path.IsRoot() {
 			paths = append(paths, key.Path)
 		}
 	}
 
 	// Sort paths so diagnostics at the same source location have a deterministic order.
-	sort.Strings(paths)
+	slices.SortFunc(paths, annotation.FieldPath.Compare)
 	return paths
 }
 
@@ -108,7 +106,7 @@ func (c *collectedFieldEffects) close() *BoundaryFieldEffects {
 // seedImportedParamEffects merges an imported callee's parameter effects before closure runs.
 func seedImportedParamEffects(effects fieldEffects, funcObj *types.Func, paths []IndexedFieldPath) {
 	for _, path := range paths {
-		if path.Path == "" {
+		if path.Path.IsRoot() {
 			continue
 		}
 		effects.add(funcObj, path)
@@ -132,10 +130,10 @@ func (e fieldEffects) sortedPaths(funcObj *types.Func) []IndexedFieldPath {
 
 // IndexedFieldPath identifies a boundary value by parameter/result index and field path.
 // For example, in an access to `a.b.c` where `a` is the first parameter, {Idx: 0,
-// Path: "b"} represents the read demand on that parameter's `b` field.
+// Path: NewFieldPath("b")} represents the read demand on that parameter's `b` field.
 type IndexedFieldPath struct {
 	Idx  int
-	Path string
+	Path annotation.FieldPath
 }
 
 // compare orders IndexedFieldPaths by index, then path. The boundary summaries are map-backed
@@ -144,7 +142,7 @@ type IndexedFieldPath struct {
 func (p IndexedFieldPath) compare(other IndexedFieldPath) int {
 	return cmp.Or(
 		cmp.Compare(p.Idx, other.Idx),
-		cmp.Compare(p.Path, other.Path),
+		p.Path.Compare(other.Path),
 	)
 }
 
@@ -165,13 +163,13 @@ func (e fieldEffects) add(funcObj *types.Func, key IndexedFieldPath) bool {
 }
 
 // paramFieldForwardEdge records that the caller passes its own parameter/receiver (callerParamIdx) — possibly
-// at a nested field prefix callerPrefix (e.g. "inner" for g(x.inner)) — as the calleeParamIdx-th
+// at a nested field prefix callerPrefix (e.g. `inner` for g(x.inner)) — as the calleeParamIdx-th
 // parameter (or receiver) of callee. It is the unit of the transitive field-effect closure: if
 // callee has effect (calleeParamIdx, p), the caller inherits effect
-// (callerParamIdx, callerPrefix+"."+p).
+// (callerParamIdx, callerPrefix.Join(p)).
 type paramFieldForwardEdge struct {
 	callerParamIdx int
-	callerPrefix   string
+	callerPrefix   annotation.FieldPath
 	callee         *types.Func
 	calleeParamIdx int
 }
@@ -213,7 +211,7 @@ func closeParamFieldSets(fields fieldEffects, edges map[*types.Func][]paramField
 				if ck.Idx != e.calleeParamIdx {
 					continue
 				}
-				path := joinFieldPath(e.callerPrefix, ck.Path)
+				path := e.callerPrefix.Join(ck.Path)
 				// Skip recursive field paths; otherwise forwarding can keep growing paths like
 				// inner.f, inner.inner.f, ...
 				if !paramFieldPathIsAcyclic(f, e.callerParamIdx, path) {
@@ -277,35 +275,7 @@ func closeReturnEffects(effects fieldEffects, edges map[*types.Func][]returnForw
 	}
 }
 
-// joinFieldPath concatenates two (possibly empty) dotted field paths: join("", p) = p,
-// join("inner", "f") = "inner.f", join("inner", "") = "inner".
-func joinFieldPath(prefix, sub string) string {
-	if prefix == "" {
-		return sub
-	}
-	if sub == "" {
-		return prefix
-	}
-	return prefix + "." + sub
-}
-
-// trimFieldPathPrefix is joinFieldPath's inverse: it returns the remainder of path below prefix —
-// trim("Mid.Child", "Mid") = "Child", trim(p, "") = p, trim(p, p) = "". The match is per segment,
-// so ok is false when prefix does not cover path (`Middle` is not below `Mid`).
-func trimFieldPathPrefix(path, prefix string) (sub string, ok bool) {
-	switch {
-	case prefix == "":
-		return path, true
-	case path == prefix:
-		return "", true
-	case strings.HasPrefix(path, prefix+"."):
-		return path[len(prefix)+1:], true
-	default:
-		return "", false
-	}
-}
-
-func paramFieldPathIsAcyclic(fn *types.Func, paramIdx int, path string) bool {
+func paramFieldPathIsAcyclic(fn *types.Func, paramIdx int, path annotation.FieldPath) bool {
 	sig := fn.Signature()
 	if paramIdx == annotation.ReceiverParamIndex {
 		if sig.Recv() == nil {
@@ -319,7 +289,7 @@ func paramFieldPathIsAcyclic(fn *types.Func, paramIdx int, path string) bool {
 	return fieldPathIsAcyclic(sig.Params().At(paramIdx).Type(), path)
 }
 
-func resultFieldPathIsAcyclic(fn *types.Func, resultIdx int, path string) bool {
+func resultFieldPathIsAcyclic(fn *types.Func, resultIdx int, path annotation.FieldPath) bool {
 	sig := fn.Signature()
 	if resultIdx < 0 || resultIdx >= sig.Results().Len() {
 		return false
@@ -329,7 +299,7 @@ func resultFieldPathIsAcyclic(fn *types.Func, resultIdx int, path string) bool {
 
 // fieldPathIsAcyclic reports whether path can be followed without re-entering a struct type already
 // seen on the chain. Recursive paths are skipped so forwarding fixpoints remain finite.
-func fieldPathIsAcyclic(boundaryType types.Type, path string) bool {
+func fieldPathIsAcyclic(boundaryType types.Type, path annotation.FieldPath) bool {
 	// AsDeeplyStruct unwraps at most one pointer, but forwarded field paths can be rooted at
 	// boundary values with multiple pointer layers.
 	for {
@@ -346,7 +316,7 @@ func fieldPathIsAcyclic(boundaryType types.Type, path string) bool {
 	// Seed seen with the boundary struct type so a field that points back to it (a self-recursive
 	// field such as `A.inner *A`) is treated as recursive and skipped.
 	seen := map[*types.Struct]bool{st: true}
-	segs := strings.Split(path, ".")
+	segs := path.Segments()
 	for i, name := range segs {
 		var field *types.Var
 		for k := range st.NumFields() {

--- a/assertion/function/structfieldeffects/effects_test.go
+++ b/assertion/function/structfieldeffects/effects_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/nilaway/annotation"
 	"go.uber.org/nilaway/config"
 	"go.uber.org/nilaway/nilawaytest"
 	"go.uber.org/nilaway/util/analysishelper"
@@ -110,8 +111,8 @@ func parseExpectedParamSource(t *testing.T, token string) (ReturnParamSource, bo
 	paramIdx, err := strconv.Atoi(parts[3])
 	require.NoErrorf(t, err, "malformed param index in return_param_source token %q", token)
 	return ReturnParamSource{
-		Result: IndexedFieldPath{Idx: resultIdx, Path: parts[2]},
-		Param:  IndexedFieldPath{Idx: paramIdx, Path: parts[4]},
+		Result: IndexedFieldPath{Idx: resultIdx, Path: fieldPathFromDotted(parts[2])},
+		Param:  IndexedFieldPath{Idx: paramIdx, Path: fieldPathFromDotted(parts[4])},
 	}, true
 }
 
@@ -121,7 +122,16 @@ func parseExpectedEffect(t *testing.T, token string) (string, IndexedFieldPath) 
 	require.Lenf(t, parts, 3, "malformed expect_effects token %q", token)
 	idx, err := strconv.Atoi(parts[1])
 	require.NoErrorf(t, err, "malformed index in expect_effects token %q", token)
-	return parts[0], IndexedFieldPath{Idx: idx, Path: parts[2]}
+	return parts[0], IndexedFieldPath{Idx: idx, Path: fieldPathFromDotted(parts[2])}
+}
+
+// fieldPathFromDotted converts a fixture token's dotted path into a FieldPath; the empty token
+// denotes the boundary value itself.
+func fieldPathFromDotted(dotted string) annotation.FieldPath {
+	if dotted == "" {
+		return annotation.FieldPath{}
+	}
+	return annotation.NewFieldPath(strings.Split(dotted, ".")...)
 }
 
 // requireEffects asserts the computed effect set matches want for every function in either map. so

--- a/assertion/function/structfieldeffects/fact_test.go
+++ b/assertion/function/structfieldeffects/fact_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/nilaway/annotation"
 	"go.uber.org/nilaway/config"
 	"go.uber.org/nilaway/nilawaytest"
 	"go.uber.org/nilaway/util/analysishelper"
@@ -165,24 +166,24 @@ func newFact(functionCount int) *BoundaryFieldEffectsPackageFact {
 		functions[i] = FunctionFieldEffects{
 			FunctionObjectPath: objectpath.Path(fmt.Sprintf("Function%03d", i)),
 			ParamReads: []IndexedFieldPath{
-				{Idx: -1, Path: "Receiver"},
-				{Idx: 0, Path: "Child"},
-				{Idx: 0, Path: "Child.Leaf"},
-				{Idx: 1, Path: fmt.Sprintf("Argument%d.Field", i)},
+				{Idx: -1, Path: annotation.NewFieldPath("Receiver")},
+				{Idx: 0, Path: annotation.NewFieldPath("Child")},
+				{Idx: 0, Path: annotation.NewFieldPath("Child", "Leaf")},
+				{Idx: 1, Path: annotation.NewFieldPath(fmt.Sprintf("Argument%d", i), "Field")},
 			},
 			ParamWrites: []IndexedFieldPath{
-				{Idx: -1, Path: "Receiver.Child"},
-				{Idx: 0, Path: "Child"},
-				{Idx: 0, Path: "Child.Leaf"},
-				{Idx: 1, Path: fmt.Sprintf("Argument%d.Field", i)},
+				{Idx: -1, Path: annotation.NewFieldPath("Receiver", "Child")},
+				{Idx: 0, Path: annotation.NewFieldPath("Child")},
+				{Idx: 0, Path: annotation.NewFieldPath("Child", "Leaf")},
+				{Idx: 1, Path: annotation.NewFieldPath(fmt.Sprintf("Argument%d", i), "Field")},
 			},
 			ReturnEffects: []IndexedFieldPath{
-				{Idx: 0, Path: "Result"},
+				{Idx: 0, Path: annotation.NewFieldPath("Result")},
 			},
 			ReturnParamSources: []ReturnParamSource{
 				{
-					Result: IndexedFieldPath{Idx: 0, Path: "Result.Child"},
-					Param:  IndexedFieldPath{Idx: 1, Path: "Child"},
+					Result: IndexedFieldPath{Idx: 0, Path: annotation.NewFieldPath("Result", "Child")},
+					Param:  IndexedFieldPath{Idx: 1, Path: annotation.NewFieldPath("Child")},
 				},
 			},
 		}

--- a/assertion/function/structfieldeffects/return_contracts.go
+++ b/assertion/function/structfieldeffects/return_contracts.go
@@ -27,13 +27,14 @@ import (
 	"go/types"
 	"slices"
 
+	"go.uber.org/nilaway/annotation"
 	"go.uber.org/nilaway/util/asthelper"
 )
 
 // ReturnParamSource records a result (or result field) whose value is the caller's own argument:
 // the Result endpoint is supplied by the Param endpoint (the receiver uses
-// annotation.ReceiverParamIndex). An empty Result path denotes the whole result value
-// (`return p`, `return p.x`); an empty Param path the bare parameter. Collection is syntactic
+// annotation.ReceiverParamIndex). A root Result path denotes the whole result value
+// (`return p`, `return p.x`); a root Param path the bare parameter. Collection is syntactic
 // and conservative: a source is recorded only when the relation holds on every path to the return
 // (see the drops in collectUnstableParamVars and dropMixedResultParamSources). Collected so later
 // revisions can resolve param-sourced results from the actual argument at each call site instead of the
@@ -44,10 +45,10 @@ type ReturnParamSource struct {
 }
 
 // SuppliesResultPath reports whether s supplies the value at (resultIdx, resultPath): a
-// whole-result source (empty result path) supplies every path of that result, and a field-level
+// whole-result source (root result path) supplies every path of that result, and a field-level
 // source supplies its exact path and everything beneath it. The prefix match is per segment —
 // source `Mid` supplies `Mid.Child` but not the sibling field `Middle`.
-func (s ReturnParamSource) SuppliesResultPath(resultIdx int, resultPath string) bool {
+func (s ReturnParamSource) SuppliesResultPath(resultIdx int, resultPath annotation.FieldPath) bool {
 	_, ok := s.ResolveResultPath(resultIdx, resultPath)
 	return ok
 }
@@ -57,15 +58,15 @@ func (s ReturnParamSource) SuppliesResultPath(resultIdx int, resultPath string) 
 // `Mid <- p.inner` resolves result path `Mid.Child` to param path `inner.Child`, and a
 // whole-result source re-roots the full path. ok reports whether s supplies the path at all
 // (see SuppliesResultPath).
-func (s ReturnParamSource) ResolveResultPath(resultIdx int, resultPath string) (param IndexedFieldPath, ok bool) {
+func (s ReturnParamSource) ResolveResultPath(resultIdx int, resultPath annotation.FieldPath) (param IndexedFieldPath, ok bool) {
 	if s.Result.Idx != resultIdx {
 		return IndexedFieldPath{}, false
 	}
-	suffix, ok := trimFieldPathPrefix(resultPath, s.Result.Path)
+	suffix, ok := resultPath.TrimPrefix(s.Result.Path)
 	if !ok {
 		return IndexedFieldPath{}, false
 	}
-	return IndexedFieldPath{Idx: s.Param.Idx, Path: joinFieldPath(s.Param.Path, suffix)}, true
+	return IndexedFieldPath{Idx: s.Param.Idx, Path: s.Param.Path.Join(suffix)}, true
 }
 
 // returnParamSourceSet maps each function to its set of return param sources.
@@ -130,13 +131,13 @@ func (fc *functionCollector) collectWholeResultParamSource(resultIdx int, expr a
 // (`return &T{f: p.x}` records result field `f` as supplied by param field `x`). Sources are
 // recorded for any field, not just nilable ones: a source on a value-struct field re-roots deeper
 // accesses (`result.V.Child` under source `V <- p.node` resolves to `p.node.Child`).
-func (fc *functionCollector) recordFieldParamSource(resultIdx int, path string, fieldVal ast.Expr) {
+func (fc *functionCollector) recordFieldParamSource(resultIdx int, path annotation.FieldPath, fieldVal ast.Expr) {
 	source, ok := fc.resolveReturnParamSource(fieldVal)
 	if !ok {
 		return
 	}
 	if !resultFieldPathIsAcyclic(fc.funcObj, resultIdx, path) ||
-		(source.Path != "" && !paramFieldPathIsAcyclic(fc.funcObj, source.Idx, source.Path)) {
+		(!source.Path.IsRoot() && !paramFieldPathIsAcyclic(fc.funcObj, source.Idx, source.Path)) {
 		return
 	}
 	fc.collected.addReturnParamSource(fc.funcObj, ReturnParamSource{
@@ -154,7 +155,7 @@ func (c *collectedFieldEffects) dropMixedResultParamSources() {
 		for idx := range results {
 			mixed := false
 			for source := range c.summary.returnParamSources[fn] {
-				if source.Result.Idx == idx && source.Result.Path == "" {
+				if source.Result.Idx == idx && source.Result.Path.IsRoot() {
 					mixed = true
 					break
 				}
@@ -175,11 +176,11 @@ func (c *collectedFieldEffects) dropReturnParamSources(fn *types.Func, result in
 }
 
 // resolveReturnParamSource resolves expr as a stable parameter or a field chain rooted at one,
-// yielding the parameter (or receiver) endpoint: the parameter index and the dotted path within
-// it ("" for the bare parameter). An unstable parameter (reassigned or address-taken) resolves
-// to nothing: its value at the return may not be the caller's argument.
+// yielding the parameter (or receiver) endpoint: the parameter index and the field path within
+// it (the root path for the bare parameter). An unstable parameter (reassigned or address-taken)
+// resolves to nothing: its value at the return may not be the caller's argument.
 func (fc *functionCollector) resolveReturnParamSource(expr ast.Expr) (IndexedFieldPath, bool) {
-	base, path := asthelper.SplitFieldChain(expr)
+	base, segments := asthelper.SplitFieldChain(expr)
 	if base == nil {
 		return IndexedFieldPath{}, false
 	}
@@ -191,7 +192,7 @@ func (fc *functionCollector) resolveReturnParamSource(expr ast.Expr) (IndexedFie
 	if !ok || fc.unstableParams[v] {
 		return IndexedFieldPath{}, false
 	}
-	return IndexedFieldPath{Idx: idx, Path: path}, true
+	return IndexedFieldPath{Idx: idx, Path: annotation.NewFieldPath(segments...)}, true
 }
 
 // collectUnstableParamVars returns the parameters (and receiver) whose value at a return

--- a/assertion/function/structfieldeffects/return_contracts_test.go
+++ b/assertion/function/structfieldeffects/return_contracts_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/nilaway/annotation"
 )
 
 func TestResolveResultPath(t *testing.T) {
@@ -27,62 +28,62 @@ func TestResolveResultPath(t *testing.T) {
 		name       string
 		source     ReturnParamSource
 		resultIdx  int
-		resultPath string
+		resultPath annotation.FieldPath
 		wantParam  IndexedFieldPath
 		wantOK     bool
 	}{
 		{
 			name:       "field-level source at its exact path",
-			source:     ReturnParamSource{Result: IndexedFieldPath{Idx: 0, Path: "Mid"}, Param: IndexedFieldPath{Idx: 1, Path: "inner"}},
+			source:     ReturnParamSource{Result: IndexedFieldPath{Idx: 0, Path: annotation.NewFieldPath("Mid")}, Param: IndexedFieldPath{Idx: 1, Path: annotation.NewFieldPath("inner")}},
 			resultIdx:  0,
-			resultPath: "Mid",
-			wantParam:  IndexedFieldPath{Idx: 1, Path: "inner"},
+			resultPath: annotation.NewFieldPath("Mid"),
+			wantParam:  IndexedFieldPath{Idx: 1, Path: annotation.NewFieldPath("inner")},
 			wantOK:     true,
 		},
 		{
 			name:       "field-level source re-roots a deeper path",
-			source:     ReturnParamSource{Result: IndexedFieldPath{Idx: 0, Path: "Mid"}, Param: IndexedFieldPath{Idx: 1, Path: "inner"}},
+			source:     ReturnParamSource{Result: IndexedFieldPath{Idx: 0, Path: annotation.NewFieldPath("Mid")}, Param: IndexedFieldPath{Idx: 1, Path: annotation.NewFieldPath("inner")}},
 			resultIdx:  0,
-			resultPath: "Mid.Child",
-			wantParam:  IndexedFieldPath{Idx: 1, Path: "inner.Child"},
+			resultPath: annotation.NewFieldPath("Mid", "Child"),
+			wantParam:  IndexedFieldPath{Idx: 1, Path: annotation.NewFieldPath("inner", "Child")},
 			wantOK:     true,
 		},
 		{
 			name:       "bare-param source keeps the bare param at the exact path",
-			source:     ReturnParamSource{Result: IndexedFieldPath{Idx: 0, Path: "Existing"}, Param: IndexedFieldPath{Idx: 0}},
+			source:     ReturnParamSource{Result: IndexedFieldPath{Idx: 0, Path: annotation.NewFieldPath("Existing")}, Param: IndexedFieldPath{Idx: 0}},
 			resultIdx:  0,
-			resultPath: "Existing",
+			resultPath: annotation.NewFieldPath("Existing"),
 			wantParam:  IndexedFieldPath{Idx: 0},
 			wantOK:     true,
 		},
 		{
 			name:       "whole-result source re-roots the full path",
-			source:     ReturnParamSource{Result: IndexedFieldPath{Idx: 0}, Param: IndexedFieldPath{Idx: 0, Path: "inner"}},
+			source:     ReturnParamSource{Result: IndexedFieldPath{Idx: 0}, Param: IndexedFieldPath{Idx: 0, Path: annotation.NewFieldPath("inner")}},
 			resultIdx:  0,
-			resultPath: "Mid.Child",
-			wantParam:  IndexedFieldPath{Idx: 0, Path: "inner.Mid.Child"},
+			resultPath: annotation.NewFieldPath("Mid", "Child"),
+			wantParam:  IndexedFieldPath{Idx: 0, Path: annotation.NewFieldPath("inner", "Mid", "Child")},
 			wantOK:     true,
 		},
 		{
 			name:       "whole-result source at the result value itself",
-			source:     ReturnParamSource{Result: IndexedFieldPath{Idx: 0}, Param: IndexedFieldPath{Idx: 0, Path: "inner"}},
+			source:     ReturnParamSource{Result: IndexedFieldPath{Idx: 0}, Param: IndexedFieldPath{Idx: 0, Path: annotation.NewFieldPath("inner")}},
 			resultIdx:  0,
-			resultPath: "",
-			wantParam:  IndexedFieldPath{Idx: 0, Path: "inner"},
+			resultPath: annotation.FieldPath{},
+			wantParam:  IndexedFieldPath{Idx: 0, Path: annotation.NewFieldPath("inner")},
 			wantOK:     true,
 		},
 		{
 			name:       "sibling field sharing the source prefix is not supplied",
-			source:     ReturnParamSource{Result: IndexedFieldPath{Idx: 0, Path: "Mid"}, Param: IndexedFieldPath{Idx: 1, Path: "inner"}},
+			source:     ReturnParamSource{Result: IndexedFieldPath{Idx: 0, Path: annotation.NewFieldPath("Mid")}, Param: IndexedFieldPath{Idx: 1, Path: annotation.NewFieldPath("inner")}},
 			resultIdx:  0,
-			resultPath: "Middle",
+			resultPath: annotation.NewFieldPath("Middle"),
 			wantOK:     false,
 		},
 		{
 			name:       "different result index is not supplied",
-			source:     ReturnParamSource{Result: IndexedFieldPath{Idx: 0, Path: "Mid"}, Param: IndexedFieldPath{Idx: 1, Path: "inner"}},
+			source:     ReturnParamSource{Result: IndexedFieldPath{Idx: 0, Path: annotation.NewFieldPath("Mid")}, Param: IndexedFieldPath{Idx: 1, Path: annotation.NewFieldPath("inner")}},
 			resultIdx:  1,
-			resultPath: "Mid",
+			resultPath: annotation.NewFieldPath("Mid"),
 			wantOK:     false,
 		},
 	}

--- a/util/asthelper/asthelper.go
+++ b/util/asthelper/asthelper.go
@@ -186,30 +186,27 @@ func IsFieldSelectorChain(expr ast.Expr) bool {
 	}
 }
 
-// SplitFieldChain decomposes a field-chain expression into its base identifier and the dotted
-// field prefix from that base: `x` -> (x, ""), `x.a` -> (x, "a"), `x.a.b` -> (x, "a.b"). Pointer
-// dereferences are transparent, so `(*x).a` -> (x, "a") and `*x` -> (x, ""). It returns (nil, "")
-// for anything whose innermost base is not a bare identifier, such as `f().a`.
-func SplitFieldChain(expr ast.Expr) (*ast.Ident, string) {
+// SplitFieldChain decomposes a field-chain expression into its base identifier and the field-name
+// segments selected from that base: `x` -> (x, nil), `x.a` -> (x, [a]), `x.a.b` -> (x, [a, b]).
+// Pointer dereferences are transparent, so `(*x).a` -> (x, [a]) and `*x` -> (x, nil). It returns
+// (nil, nil) for anything whose innermost base is not a bare identifier, such as `f().a`.
+func SplitFieldChain(expr ast.Expr) (*ast.Ident, []string) {
 	expr = ast.Unparen(expr)
 	var parts []string
 	for {
 		switch e := expr.(type) {
 		case *ast.Ident:
-			if len(parts) == 0 {
-				return e, ""
-			}
 			for i, j := 0, len(parts)-1; i < j; i, j = i+1, j-1 {
 				parts[i], parts[j] = parts[j], parts[i]
 			}
-			return e, strings.Join(parts, ".")
+			return e, parts
 		case *ast.SelectorExpr:
 			parts = append(parts, e.Sel.Name)
 			expr = ast.Unparen(e.X)
 		case *ast.StarExpr:
 			expr = ast.Unparen(e.X)
 		default:
-			return nil, ""
+			return nil, nil
 		}
 	}
 }

--- a/util/asthelper/asthelper_test.go
+++ b/util/asthelper/asthelper_test.go
@@ -107,19 +107,19 @@ func TestSplitFieldChain(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
-		expr       string
-		wantBase   string
-		wantPrefix string
+		name     string
+		expr     string
+		wantBase string
+		wantSegs []string
 	}{
-		{name: "Ident", expr: "x", wantBase: "x", wantPrefix: ""},
-		{name: "SingleSelector", expr: "x.a", wantBase: "x", wantPrefix: "a"},
-		{name: "NestedSelector", expr: "x.a.b", wantBase: "x", wantPrefix: "a.b"},
-		{name: "ParenthesizedSelector", expr: "(x.a).b", wantBase: "x", wantPrefix: "a.b"},
-		{name: "PointerBase", expr: "(*x).a", wantBase: "x", wantPrefix: "a"},
-		{name: "PointerBaseNested", expr: "(*x).a.b", wantBase: "x", wantPrefix: "a.b"},
-		{name: "TopLevelDeref", expr: "*x", wantBase: "x", wantPrefix: ""},
-		{name: "CallBase", expr: "f().a", wantBase: "", wantPrefix: ""},
+		{name: "Ident", expr: "x", wantBase: "x"},
+		{name: "SingleSelector", expr: "x.a", wantBase: "x", wantSegs: []string{"a"}},
+		{name: "NestedSelector", expr: "x.a.b", wantBase: "x", wantSegs: []string{"a", "b"}},
+		{name: "ParenthesizedSelector", expr: "(x.a).b", wantBase: "x", wantSegs: []string{"a", "b"}},
+		{name: "PointerBase", expr: "(*x).a", wantBase: "x", wantSegs: []string{"a"}},
+		{name: "PointerBaseNested", expr: "(*x).a.b", wantBase: "x", wantSegs: []string{"a", "b"}},
+		{name: "TopLevelDeref", expr: "*x", wantBase: "x"},
+		{name: "CallBase", expr: "f().a", wantBase: ""},
 	}
 
 	for _, tt := range tests {
@@ -130,13 +130,13 @@ func TestSplitFieldChain(t *testing.T) {
 			expr, err := parser.ParseExpr(tt.expr)
 			require.NoError(t, err)
 
-			gotBase, gotPrefix := SplitFieldChain(expr)
+			gotBase, gotSegs := SplitFieldChain(expr)
 			if tt.wantBase == "" {
 				require.Nil(t, gotBase)
 			} else {
 				require.Equal(t, tt.wantBase, gotBase.Name)
 			}
-			require.Equal(t, tt.wantPrefix, gotPrefix)
+			require.Equal(t, tt.wantSegs, gotSegs)
 		})
 	}
 }


### PR DESCRIPTION
Struct field paths were represented as dotted strings, requiring callers to duplicate joining, splitting, and root handling. Introduce annotation.FieldPath to centralize these operations while preserving the existing comparable string encoding. No behavior change.
Changes
- Add and test annotation.FieldPath, including fact serialization.
- Migrate struct-field effects and assertion-tree consumers to FieldPath.
- Return field-name segments from asthelper.SplitFieldChain instead of a dotted string.