### PR TITLE
[NilAway] Compare diagnostics across modular analysis drivers

### DIFF
--- a/nilaway_test.go
+++ b/nilaway_test.go
@@ -24,6 +24,7 @@ package nilaway
 import (
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 
@@ -82,43 +83,41 @@ func TestNilAway(t *testing.T) {
 		{name: "TransitiveFacts", patterns: []string{"go.uber.org/transitivefacts/..."}},
 	}
 
-	var modularPatterns []string
-	for _, tt := range tests {
-		if tt.name != "TransitiveFacts" {
-			modularPatterns = append(modularPatterns, tt.patterns...)
-		}
-	}
-	modularDiagnostics := nilawaytest.RunModularAnalysis(t, testdata, modularPatterns...)
-
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			t.Logf("Running test for packages %s", tt.patterns)
 
-			results := analysistest.Run(t, testdata, Analyzer, tt.patterns...)
-			// TODO: Enable modular parity once transitive package facts are propagated across
-			// more than one import hop.
-			if tt.name == "TransitiveFacts" {
-				return
-			}
-
-			packagePaths := make(map[string]struct{}, len(results))
-			for _, result := range results {
-				packagePaths[result.Action.Package.Types.Path()] = struct{}{}
-			}
-			var modular []nilawaytest.Diagnostic
-			for _, diagnostic := range modularDiagnostics {
-				if _, ok := packagePaths[diagnostic.Package]; ok {
-					modular = append(modular, diagnostic)
-				}
-			}
-
-			inProcess := nilawaytest.Diagnostics(testdata, results)
-			if diff := cmp.Diff(inProcess, modular); diff != "" {
-				t.Errorf("modular driver diagnostics differ from analysistest (-analysistest +modular):\n%s", diff)
-			}
+			analysistest.Run(t, testdata, Analyzer, tt.patterns...)
 		})
+	}
+}
+
+func TestModularDriverParity(t *testing.T) {
+	t.Parallel()
+
+	testdata := analysistest.TestData()
+	const pattern = "go.uber.org/..."
+
+	inProcess := nilawaytest.Diagnostics(
+		testdata,
+		analysistest.Run(t, testdata, Analyzer, pattern),
+	)
+	modular := nilawaytest.RunModularAnalysis(t, testdata, pattern)
+
+	// TODO: Enable modular parity for this package once transitive package facts are propagated
+	// across more than one import hop.
+	const transitiveFactsPackage = "go.uber.org/transitivefacts/"
+	inProcess = slices.DeleteFunc(inProcess, func(diagnostic nilawaytest.Diagnostic) bool {
+		return strings.HasPrefix(diagnostic.Package, transitiveFactsPackage)
+	})
+	modular = slices.DeleteFunc(modular, func(diagnostic nilawaytest.Diagnostic) bool {
+		return strings.HasPrefix(diagnostic.Package, transitiveFactsPackage)
+	})
+
+	if diff := cmp.Diff(inProcess, modular); diff != "" {
+		t.Errorf("modular driver diagnostics differ from analysistest (-analysistest +modular):\n%s", diff)
 	}
 }
 

--- a/nilaway_test.go
+++ b/nilaway_test.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 	"go.uber.org/nilaway/config"
@@ -78,6 +79,7 @@ func TestNilAway(t *testing.T) {
 		{name: "NoLint", patterns: []string{"go.uber.org/nolint"}},
 		{name: "Templ", patterns: []string{"go.uber.org/templ"}},
 		{name: "CtrlflowIntrinsic", patterns: []string{"go.uber.org/zap"}},
+		{name: "TransitiveFacts", patterns: []string{"go.uber.org/transitivefacts/..."}},
 	}
 
 	for _, tt := range tests {
@@ -86,7 +88,17 @@ func TestNilAway(t *testing.T) {
 			t.Parallel()
 			t.Logf("Running test for packages %s", tt.patterns)
 
-			analysistest.Run(t, testdata, Analyzer, tt.patterns...)
+			results := analysistest.Run(t, testdata, Analyzer, tt.patterns...)
+			// TODO: Enable modular parity once transitive package facts are propagated across
+			// more than one import hop.
+			if tt.name == "TransitiveFacts" {
+				return
+			}
+			inProcess := nilawaytest.Diagnostics(testdata, results)
+			modular := nilawaytest.RunModularAnalysis(t, testdata, tt.patterns...)
+			if diff := cmp.Diff(inProcess, modular); diff != "" {
+				t.Errorf("modular driver diagnostics differ from analysistest (-analysistest +modular):\n%s", diff)
+			}
 		})
 	}
 }
@@ -271,5 +283,6 @@ func TestMain(m *testing.M) {
 		}
 	}
 
+	nilawaytest.RunAsModularDriver(Analyzer)
 	goleak.VerifyTestMain(m)
 }

--- a/nilaway_test.go
+++ b/nilaway_test.go
@@ -98,13 +98,11 @@ func TestModularDriverParity(t *testing.T) {
 	t.Parallel()
 
 	testdata := analysistest.TestData()
-	const pattern = "go.uber.org/..."
 
-	inProcess := nilawaytest.Diagnostics(
-		testdata,
-		analysistest.Run(t, testdata, Analyzer, pattern),
-	)
-	modular := nilawaytest.RunModularAnalysis(t, testdata, pattern)
+	inProcess := nilawaytest.Diagnostics(testdata, analysistest.Run(t, testdata, Analyzer, "go.uber.org/..."))
+	modular := nilawaytest.RunModularAnalysis(t, testdata, "go.uber.org/...")
+	t.Logf("Total diagnostics from in-process driver: %d", len(inProcess))
+	t.Logf("Total diagnostics from modular driver: %d", len(modular))
 
 	// TODO: Enable modular parity for this package once transitive package facts are propagated
 	// across more than one import hop.

--- a/nilaway_test.go
+++ b/nilaway_test.go
@@ -82,6 +82,14 @@ func TestNilAway(t *testing.T) {
 		{name: "TransitiveFacts", patterns: []string{"go.uber.org/transitivefacts/..."}},
 	}
 
+	var modularPatterns []string
+	for _, tt := range tests {
+		if tt.name != "TransitiveFacts" {
+			modularPatterns = append(modularPatterns, tt.patterns...)
+		}
+	}
+	modularDiagnostics := nilawaytest.RunModularAnalysis(t, testdata, modularPatterns...)
+
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
@@ -94,8 +102,19 @@ func TestNilAway(t *testing.T) {
 			if tt.name == "TransitiveFacts" {
 				return
 			}
+
+			packagePaths := make(map[string]struct{}, len(results))
+			for _, result := range results {
+				packagePaths[result.Action.Package.Types.Path()] = struct{}{}
+			}
+			var modular []nilawaytest.Diagnostic
+			for _, diagnostic := range modularDiagnostics {
+				if _, ok := packagePaths[diagnostic.Package]; ok {
+					modular = append(modular, diagnostic)
+				}
+			}
+
 			inProcess := nilawaytest.Diagnostics(testdata, results)
-			modular := nilawaytest.RunModularAnalysis(t, testdata, tt.patterns...)
 			if diff := cmp.Diff(inProcess, modular); diff != "" {
 				t.Errorf("modular driver diagnostics differ from analysistest (-analysistest +modular):\n%s", diff)
 			}
@@ -283,6 +302,5 @@ func TestMain(m *testing.M) {
 		}
 	}
 
-	nilawaytest.RunAsModularDriver(Analyzer)
 	goleak.VerifyTestMain(m)
 }

--- a/nilawaytest/cmd/nilawaytestvettool/main.go
+++ b/nilawaytest/cmd/nilawaytestvettool/main.go
@@ -1,0 +1,33 @@
+//  Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// nilawaytestvettool is the modular analysis worker used by nilawaytest.
+package main
+
+import (
+	"flag"
+
+	"go.uber.org/nilaway"
+	"go.uber.org/nilaway/config"
+	"golang.org/x/tools/go/analysis/unitchecker"
+)
+
+func main() {
+	// Lift NilAway's configuration flags to the vettool's top-level flag set so the test harness
+	// can pass the same configuration used by the in-process analyzer.
+	config.Analyzer.Flags.VisitAll(func(f *flag.Flag) {
+		flag.Var(f.Value, f.Name, f.Usage)
+	})
+	unitchecker.Main(nilaway.Analyzer)
+}

--- a/nilawaytest/modular_driver.go
+++ b/nilawaytest/modular_driver.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -31,14 +32,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/tools/go/analysis"
+	"go.uber.org/nilaway/config"
 	"golang.org/x/tools/go/analysis/analysistest"
-	"golang.org/x/tools/go/analysis/unitchecker"
 )
 
-// _asVettoolEnvVar, when set, makes the test binary behave as a `go vet -vettool`
-// worker instead of running the test suite.
-const _asVettoolEnvVar = "NILAWAY_AS_VETTOOL"
+const _vettoolPackage = "go.uber.org/nilaway/nilawaytest/cmd/nilawaytestvettool"
 
 var _sourceColumnRegexp = regexp.MustCompile(`(\.go:[0-9]+):[0-9]+`)
 
@@ -46,17 +44,10 @@ var _sourceColumnRegexp = regexp.MustCompile(`(\.go:[0-9]+):[0-9]+`)
 // source positions loaded from export data may not retain accurate column information under
 // modular drivers.
 type Diagnostic struct {
+	Package string
 	File    string
 	Line    int
 	Message string
-}
-
-// RunAsModularDriver calls analyzer as a unitchecker worker when the current test binary was
-// invoked by RunModularAnalysis. It must be called from TestMain before running the test suite.
-func RunAsModularDriver(analyzer *analysis.Analyzer) {
-	if os.Getenv(_asVettoolEnvVar) != "" {
-		unitchecker.Main(analyzer) // calls os.Exit and never returns
-	}
 }
 
 // Diagnostics returns the diagnostics reported by an analysistest run in a stable order.
@@ -64,10 +55,11 @@ func Diagnostics(gopath string, results []*analysistest.Result) []Diagnostic {
 	var diagnostics []Diagnostic
 	for _, result := range results {
 		fset := result.Action.Package.Fset
+		packagePath := result.Action.Package.Types.Path()
 		for _, diag := range result.Action.Diagnostics {
 			position := fset.Position(diag.Pos)
 			diagnostics = append(diagnostics,
-				normalizeDiagnostic(gopath, position.Filename, position.Line, diag.Message))
+				normalizeDiagnostic(gopath, packagePath, position.Filename, position.Line, diag.Message))
 		}
 	}
 	sortDiagnostics(diagnostics)
@@ -77,19 +69,27 @@ func Diagnostics(gopath string, results []*analysistest.Result) []Diagnostic {
 // RunModularAnalysis runs analyzer diagnostics on patterns using `go vet -vettool`. Unlike
 // analysistest, this analyzes each package in a separate process and exchanges facts between
 // packages through serialized fact files, matching modular drivers such as bazel/nogo.
-//
-// The vettool is the current test binary. The package's TestMain must call RunAsModularDriver
-// with the analyzer under test to handle worker invocations.
 func RunModularAnalysis(t *testing.T, gopath string, patterns ...string) []Diagnostic {
 	t.Helper()
 
-	exe, err := os.Executable()
-	require.NoError(t, err)
+	// Build a dedicated worker instead of re-executing the test binary. In particular, this keeps
+	// the many per-package unitchecker processes free of the test binary's race and coverage
+	// instrumentation.
+	vettool := filepath.Join(t.TempDir(), "nilawaytestvettool")
+	build := exec.Command("go", "build", "-o", vettool, _vettoolPackage)
+	var buildOutput bytes.Buffer
+	build.Stdout, build.Stderr = &buildOutput, &buildOutput
+	require.NoErrorf(t, build.Run(), "build modular vettool: %s", buildOutput.String())
 
-	cmd := exec.Command("go", append([]string{"vet", "-vettool=" + exe, "-json"}, patterns...)...)
+	args := []string{"vet", "-vettool=" + vettool, "-json"}
+	config.Analyzer.Flags.VisitAll(func(f *flag.Flag) {
+		args = append(args, "-"+f.Name+"="+f.Value.String())
+	})
+	args = append(args, patterns...)
+
+	cmd := exec.Command("go", args...)
 	// Mirror analysistest's environment for loading packages from testdata.
 	cmd.Env = append(os.Environ(),
-		_asVettoolEnvVar+"=1",
 		"GOPATH="+gopath,
 		"GO111MODULE=off",
 		"GOPROXY=off",
@@ -116,13 +116,13 @@ func RunModularAnalysis(t *testing.T, gopath string, patterns ...string) []Diagn
 		} else if err != nil {
 			t.Fatalf("decode go vet output: %s\noutput: %s", err, output)
 		}
-		for _, analyzers := range result {
+		for packagePath, analyzers := range result {
 			for _, diags := range analyzers {
 				for _, diag := range diags {
 					file, line, err := parseVetPosition(diag.Posn)
 					require.NoError(t, err)
 					diagnostics = append(diagnostics,
-						normalizeDiagnostic(gopath, file, line, diag.Message))
+						normalizeDiagnostic(gopath, packagePath, file, line, diag.Message))
 				}
 			}
 		}
@@ -139,8 +139,9 @@ func stripVetPackageHeadings(output string) string {
 	return strings.Join(lines, "\n")
 }
 
-func normalizeDiagnostic(gopath, file string, line int, message string) Diagnostic {
+func normalizeDiagnostic(gopath, packagePath, file string, line int, message string) Diagnostic {
 	return Diagnostic{
+		Package: packagePath,
 		File:    normalizeFile(gopath, file),
 		Line:    line,
 		Message: _sourceColumnRegexp.ReplaceAllString(message, "$1"),
@@ -200,6 +201,9 @@ func parseVetPosition(position string) (string, int, error) {
 func sortDiagnostics(diagnostics []Diagnostic) {
 	sort.Slice(diagnostics, func(i, j int) bool {
 		left, right := diagnostics[i], diagnostics[j]
+		if left.Package != right.Package {
+			return left.Package < right.Package
+		}
 		if left.File != right.File {
 			return left.File < right.File
 		}

--- a/nilawaytest/modular_driver.go
+++ b/nilawaytest/modular_driver.go
@@ -1,0 +1,211 @@
+//  Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nilawaytest
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/analysistest"
+	"golang.org/x/tools/go/analysis/unitchecker"
+)
+
+// _asVettoolEnvVar, when set, makes the test binary behave as a `go vet -vettool`
+// worker instead of running the test suite.
+const _asVettoolEnvVar = "NILAWAY_AS_VETTOOL"
+
+var _sourceColumnRegexp = regexp.MustCompile(`(\.go:[0-9]+):[0-9]+`)
+
+// Diagnostic is a normalized analysis diagnostic. Columns are intentionally omitted because
+// source positions loaded from export data may not retain accurate column information under
+// modular drivers.
+type Diagnostic struct {
+	File    string
+	Line    int
+	Message string
+}
+
+// RunAsModularDriver calls analyzer as a unitchecker worker when the current test binary was
+// invoked by RunModularAnalysis. It must be called from TestMain before running the test suite.
+func RunAsModularDriver(analyzer *analysis.Analyzer) {
+	if os.Getenv(_asVettoolEnvVar) != "" {
+		unitchecker.Main(analyzer) // calls os.Exit and never returns
+	}
+}
+
+// Diagnostics returns the diagnostics reported by an analysistest run in a stable order.
+func Diagnostics(gopath string, results []*analysistest.Result) []Diagnostic {
+	var diagnostics []Diagnostic
+	for _, result := range results {
+		fset := result.Action.Package.Fset
+		for _, diag := range result.Action.Diagnostics {
+			position := fset.Position(diag.Pos)
+			diagnostics = append(diagnostics,
+				normalizeDiagnostic(gopath, position.Filename, position.Line, diag.Message))
+		}
+	}
+	sortDiagnostics(diagnostics)
+	return diagnostics
+}
+
+// RunModularAnalysis runs analyzer diagnostics on patterns using `go vet -vettool`. Unlike
+// analysistest, this analyzes each package in a separate process and exchanges facts between
+// packages through serialized fact files, matching modular drivers such as bazel/nogo.
+//
+// The vettool is the current test binary. The package's TestMain must call RunAsModularDriver
+// with the analyzer under test to handle worker invocations.
+func RunModularAnalysis(t *testing.T, gopath string, patterns ...string) []Diagnostic {
+	t.Helper()
+
+	exe, err := os.Executable()
+	require.NoError(t, err)
+
+	cmd := exec.Command("go", append([]string{"vet", "-vettool=" + exe, "-json"}, patterns...)...)
+	// Mirror analysistest's environment for loading packages from testdata.
+	cmd.Env = append(os.Environ(),
+		_asVettoolEnvVar+"=1",
+		"GOPATH="+gopath,
+		"GO111MODULE=off",
+		"GOPROXY=off",
+		"GOFLAGS=",
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	require.NoErrorf(t, cmd.Run(), "go vet -vettool: %s", stderr.String())
+
+	// `go vet -json` writes a stream of per-package JSON objects
+	// (package path -> analyzer -> diagnostics) and exits 0 even with findings. Depending on
+	// the Go version, the stream may be written to stdout or stderr; stderr also prefixes each
+	// package's object with a "# package/path" heading.
+	var diagnostics []Diagnostic
+	output := stripVetPackageHeadings(stdout.String() + "\n" + stderr.String())
+	decoder := json.NewDecoder(strings.NewReader(output))
+	for {
+		var result map[string]map[string][]struct {
+			Posn    string `json:"posn"`
+			Message string `json:"message"`
+		}
+		if err := decoder.Decode(&result); errors.Is(err, io.EOF) {
+			break
+		} else if err != nil {
+			t.Fatalf("decode go vet output: %s\noutput: %s", err, output)
+		}
+		for _, analyzers := range result {
+			for _, diags := range analyzers {
+				for _, diag := range diags {
+					file, line, err := parseVetPosition(diag.Posn)
+					require.NoError(t, err)
+					diagnostics = append(diagnostics,
+						normalizeDiagnostic(gopath, file, line, diag.Message))
+				}
+			}
+		}
+	}
+	sortDiagnostics(diagnostics)
+	return diagnostics
+}
+
+func stripVetPackageHeadings(output string) string {
+	lines := strings.Split(output, "\n")
+	lines = slices.DeleteFunc(lines, func(line string) bool {
+		return strings.HasPrefix(line, "# ")
+	})
+	return strings.Join(lines, "\n")
+}
+
+func normalizeDiagnostic(gopath, file string, line int, message string) Diagnostic {
+	return Diagnostic{
+		File:    normalizeFile(gopath, file),
+		Line:    line,
+		Message: _sourceColumnRegexp.ReplaceAllString(message, "$1"),
+	}
+}
+
+func normalizeFile(gopath, file string) string {
+	srcRoot := filepath.Join(gopath, "src")
+	file = filepath.Clean(file)
+	if rel, err := filepath.Rel(srcRoot, file); err == nil && rel != ".." &&
+		!strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return filepath.ToSlash(rel)
+	}
+	if filepath.IsAbs(file) {
+		return filepath.ToSlash(file)
+	}
+
+	// A diagnostic reported while analyzing one package may point into another package. Modular
+	// drivers can reduce that cross-package filename to a relative suffix, so resolve it against
+	// the analysistest GOPATH when the suffix identifies exactly one testdata file.
+	var matches []string
+	_ = filepath.WalkDir(srcRoot, func(path string, entry os.DirEntry, err error) error {
+		if err != nil || entry.IsDir() {
+			return nil
+		}
+		pathSlash := filepath.ToSlash(path)
+		if strings.HasSuffix(pathSlash, "/"+filepath.ToSlash(file)) {
+			matches = append(matches, path)
+		}
+		return nil
+	})
+	if len(matches) == 1 {
+		rel, err := filepath.Rel(srcRoot, matches[0])
+		if err == nil {
+			return filepath.ToSlash(rel)
+		}
+	}
+	return filepath.ToSlash(file)
+}
+
+func parseVetPosition(position string) (string, int, error) {
+	columnSeparator := strings.LastIndexByte(position, ':')
+	if columnSeparator < 0 {
+		return "", 0, fmt.Errorf("malformed position %q", position)
+	}
+	lineSeparator := strings.LastIndexByte(position[:columnSeparator], ':')
+	if lineSeparator < 0 {
+		return "", 0, fmt.Errorf("malformed position %q", position)
+	}
+	line, err := strconv.Atoi(position[lineSeparator+1 : columnSeparator])
+	if err != nil {
+		return "", 0, fmt.Errorf("parse line from position %q: %w", position, err)
+	}
+	return position[:lineSeparator], line, nil
+}
+
+func sortDiagnostics(diagnostics []Diagnostic) {
+	sort.Slice(diagnostics, func(i, j int) bool {
+		left, right := diagnostics[i], diagnostics[j]
+		if left.File != right.File {
+			return left.File < right.File
+		}
+		if left.Line != right.Line {
+			return left.Line < right.Line
+		}
+		return left.Message < right.Message
+	})
+}

--- a/nilawaytest/modular_driver.go
+++ b/nilawaytest/modular_driver.go
@@ -76,7 +76,9 @@ func RunModularAnalysis(t *testing.T, gopath string, patterns ...string) []Diagn
 	// the many per-package unitchecker processes free of the test binary's race and coverage
 	// instrumentation.
 	vettool := filepath.Join(t.TempDir(), "nilawaytestvettool")
-	build := exec.Command("go", "build", "-o", vettool, _vettoolPackage)
+	goTool, err := exec.LookPath("go")
+	require.NoError(t, err, "locate the Go tool used to run the tests")
+	build := exec.Command(goTool, "build", "-o", vettool, _vettoolPackage)
 	var buildOutput bytes.Buffer
 	build.Stdout, build.Stderr = &buildOutput, &buildOutput
 	require.NoErrorf(t, build.Run(), "build modular vettool: %s", buildOutput.String())
@@ -87,7 +89,7 @@ func RunModularAnalysis(t *testing.T, gopath string, patterns ...string) []Diagn
 	})
 	args = append(args, patterns...)
 
-	cmd := exec.Command("go", args...)
+	cmd := exec.Command(goTool, args...)
 	// Mirror analysistest's environment for loading packages from testdata.
 	cmd.Env = append(os.Environ(),
 		"GOPATH="+gopath,

--- a/testdata/src/go.uber.org/transitivefacts/downstream/downstream.go
+++ b/testdata/src/go.uber.org/transitivefacts/downstream/downstream.go
@@ -1,0 +1,33 @@
+//  Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package downstream is the final hop of the transitive-facts chain. It imports ONLY middle —
+// not upstream. Calling Get on the value returned by middle.Make() is legal without importing
+// upstream, but knowing that Get returns nilable requires upstream's inference fact, which must
+// survive transitive re-export through middle for the dereference below to be flagged.
+package downstream
+
+import "go.uber.org/transitivefacts/middle"
+
+func useTransitive() {
+	// Two-hop flow: Get's return was determined nilable in upstream, whose fact must travel
+	// upstream -> middle -> downstream. Drivers pruning imported package facts miss this error.
+	print(*middle.Make().Get()) //want "result 0 of `Get\\(\\)` dereferenced"
+}
+
+func useOneHop() {
+	// One-hop control: NilableFunc's nilability is in middle's own fact, which every driver
+	// reads directly. This error is reported even by fact-pruning drivers.
+	print(*middle.NilableFunc()) //want "result 0 of `NilableFunc\\(\\)` dereferenced"
+}

--- a/testdata/src/go.uber.org/transitivefacts/middle/middle.go
+++ b/testdata/src/go.uber.org/transitivefacts/middle/middle.go
@@ -1,0 +1,37 @@
+//  Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package middle is the intermediate hop of the transitive-facts chain. It re-exposes
+// upstream.S through its own API but crucially never calls, guards, or otherwise mentions
+// upstream's S.Get method. Because InferredMap.Export is incremental (it exports only
+// information not already present in upstream maps), this package's fact therefore carries
+// nothing about S.Get: its return nilability lives solely in upstream's fact, and downstream can
+// only learn it if the driver propagates facts transitively.
+package middle
+
+import "go.uber.org/transitivefacts/upstream"
+
+// Make wraps upstream.NewS, making upstream.S reachable from this package's API so that the
+// downstream package can call its Get method without importing upstream directly.
+func Make() *upstream.S {
+	return upstream.NewS()
+}
+
+// NilableFunc returns nil directly, so its return site is determined nilable in _this_ package's
+// own incremental map. It serves as the one-hop control for the experiment: even fact-pruning
+// drivers report its unchecked dereference in downstream, proving that direct-import facts still
+// flow while the two-hop fact about upstream's S.Get does not.
+func NilableFunc() *int {
+	return nil
+}

--- a/testdata/src/go.uber.org/transitivefacts/upstream/upstream.go
+++ b/testdata/src/go.uber.org/transitivefacts/upstream/upstream.go
@@ -1,0 +1,42 @@
+//  Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package upstream is the root of a three-package chain (upstream <- middle <- downstream) that
+// exercises _transitive_ propagation of NilAway's inference facts: the nilability of S.Get's
+// return is established here, never mentioned in package middle, and consumed in package
+// downstream, which does NOT import this package directly (methods are callable on values
+// obtained through middle's API without naming this package).
+//
+// Under drivers that inherit all package facts across the action graph (analysistest,
+// singlechecker, golangci-lint), the chain works and the error is reported in downstream. Under
+// modular drivers that exchange facts via x/tools' internal/facts encoding (go vet/unitchecker,
+// bazel/nogo), imported package facts are no longer re-exported since x/tools v0.12.0
+// (golang/tools@d75c38746e "internal/facts: don't reexport imported facts unnecessarily"), so
+// this package's fact never reaches downstream and the error there is silently missed.
+package upstream
+
+// S is a struct whose Get method below is the carrier of the transitively-needed inference fact.
+type S struct{}
+
+// Get returns nil directly, so its return site is determined nilable in _this_ package's
+// exported InferredMap package fact. Nothing in this package or in middle dereferences it, so
+// the determination reaches a use site only if facts propagate transitively.
+func (s *S) Get() *int {
+	return nil
+}
+
+// NewS returns a non-nil S so that calling methods on the chain is otherwise safe.
+func NewS() *S {
+	return &S{}
+}


### PR DESCRIPTION
## Summary
Add a test-only unitchecker path so standard analysistest cases also guard against regressions specific to serialized package facts. Include a transitive fact fixture documenting the known multi-hop gap while temporarily excluding it from modular parity.

## Test Plan
- `make test`
- `make lint`

## Revert Plan
Revert this PR.

## API Changes
None.

## Monitoring and Alerts
None.

## Issues

