### PR TITLE
feat(struct-init-v2): resolve parameter-dependent result fields per call site

### DIFF
--- a/assertion/function/assertiontree/backprop.go
+++ b/assertion/function/assertiontree/backprop.go
@@ -859,7 +859,7 @@ func backpropAcrossManyToOneAssignment(rootNode *RootAssertionNode, lhs, rhs []a
 				sig := funcObj.Type().(*types.Signature)
 				if i < sig.Results().Len() {
 					if typeshelper.AsDeeplyStruct(sig.Results().At(i).Type()) != nil {
-						rootNode.addCallResultFieldProducers(lhsVal, funcObj, i)
+						rootNode.addCallResultFieldProducers(lhsVal, rhsVal, funcObj, i)
 					}
 				}
 			}

--- a/assertion/function/assertiontree/structinitv2.go
+++ b/assertion/function/assertiontree/structinitv2.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 
 	"go.uber.org/nilaway/annotation"
+	"go.uber.org/nilaway/assertion/function/structfieldeffects"
 	"go.uber.org/nilaway/guard"
 	"go.uber.org/nilaway/util/asthelper"
 	"go.uber.org/nilaway/util/typeshelper"
@@ -80,7 +81,7 @@ func (r *RootAssertionNode) addAllocationFieldProducers(lhsVal, rhsVal ast.Expr)
 	if call, ok := ast.Unparen(rhsVal).(*ast.CallExpr); ok {
 		if target, ok := typeshelper.ResolveStaticCallTarget(r.Pass().TypesInfo, call); ok && target.Signature.Results().Len() == 1 {
 			if typeshelper.AsDeeplyStruct(target.Signature.Results().At(0).Type()) != nil {
-				r.addCallResultFieldProducers(lhsVal, target.Origin, 0)
+				r.addCallResultFieldProducers(lhsVal, call, target.Origin, 0)
 			}
 		}
 	}
@@ -100,10 +101,14 @@ func (r *RootAssertionNode) resultValueHasParamSource(funcObj *types.Func, resul
 	return r.resultPathHasParamSource(funcObj, resultIdx, annotation.FieldPath{})
 }
 
-// addCallResultFieldProducers attaches producers for the accessed fields of a call result bound
-// to base: each path reads the shared return context site of funcObj's resultIdx-th result,
-// seeded with the callee's concrete return effects.
-func (r *RootAssertionNode) addCallResultFieldProducers(base ast.Expr, funcObj *types.Func, resultIdx int) {
+// addCallResultFieldProducers adds producers for the accessed fields of a call result. Parameter
+// sources use call-scoped sites; unresolved sources are skipped to avoid merging callers.
+func (r *RootAssertionNode) addCallResultFieldProducers(
+	base ast.Expr,
+	call *ast.CallExpr,
+	funcObj *types.Func,
+	resultIdx int,
+) {
 	path, _ := r.ParseExprAsProducer(base, false)
 	node, _ := r.lookupPath(path)
 	if node == nil {
@@ -121,41 +126,150 @@ func (r *RootAssertionNode) addCallResultFieldProducers(base ast.Expr, funcObj *
 		}
 	}
 
+	sources := r.functionContext.boundaryFieldEffects.ReturnParamSources(funcObj)
 	for _, p := range paths {
-		// A param-sourced return path is caller-dependent and is never solved on the shared
-		// return sites
-		if r.resultPathHasParamSource(funcObj, resultIdx, p.path) {
+		result := structfieldeffects.IndexedFieldPath{Idx: resultIdx, Path: p.path}
+		if r.bindParamSourcedResultFieldAtCall(call, funcObj, sources, result, p.sel) {
 			continue
 		}
-		site := &annotation.StructFieldContextSite{
-			FuncObj: funcObj, Kind: annotation.StructFieldReturnContext, Index: resultIdx, Path: p.path,
+		// Unresolved param sources cannot safely use shared sites.
+		if sources.HasSource(result.Idx, result.Path) {
+			continue
 		}
-		r.AddProduction(&annotation.ProduceTrigger{
-			Annotation: &annotation.StructFieldFromContext{
-				TriggerIfNilable: &annotation.TriggerIfNilable{Ann: site},
-			},
-			Expr: p.sel,
-		})
-		// If the callee's known return effects prove this path nil (e.g. `return &T{}`),
-		// additionally seed the context site with a definite nil here at the caller.
-		if returnEffects[p.path] {
-			segments := p.path.Segments()
-			r.AddNewTriggers(annotation.FullTrigger{
-				Producer: &annotation.ProduceTrigger{
-					Annotation: &annotation.StructFieldNil{
-						ProduceTriggerTautology: &annotation.ProduceTriggerTautology{},
-						FieldName:               segments[len(segments)-1],
-					},
-					Expr: p.sel,
-				},
-				Consumer: &annotation.ConsumeTrigger{
-					Annotation: &annotation.StructFieldToContext{TriggerIfNonNil: &annotation.TriggerIfNonNil{Ann: site}},
-					Expr:       p.sel,
-					Guards:     guard.NoGuards(),
-				},
-			})
-		}
+		r.addSharedCallResultFieldProducer(p.sel, funcObj, resultIdx, p.path, returnEffects[p.path])
 	}
+}
+
+func (r *RootAssertionNode) addSharedCallResultFieldProducer(
+	dst ast.Expr,
+	funcObj *types.Func,
+	resultIdx int,
+	resultPath annotation.FieldPath,
+	definiteNil bool,
+) {
+	site := &annotation.StructFieldContextSite{
+		FuncObj: funcObj,
+		Kind:    annotation.StructFieldReturnContext,
+		Index:   resultIdx,
+		Path:    resultPath,
+	}
+	r.AddProduction(&annotation.ProduceTrigger{
+		Annotation: &annotation.StructFieldFromContext{
+			TriggerIfNilable: &annotation.TriggerIfNilable{Ann: site},
+		},
+		Expr: dst,
+	})
+	if !definiteNil {
+		return
+	}
+	segments := resultPath.Segments()
+	r.AddNewTriggers(annotation.FullTrigger{
+		Producer: &annotation.ProduceTrigger{
+			Annotation: &annotation.StructFieldNil{
+				ProduceTriggerTautology: &annotation.ProduceTriggerTautology{},
+				FieldName:               segments[len(segments)-1],
+			},
+			Expr: dst,
+		},
+		Consumer: &annotation.ConsumeTrigger{
+			Annotation: &annotation.StructFieldToContext{
+				TriggerIfNonNil: &annotation.TriggerIfNonNil{Ann: site},
+			},
+			Expr:   dst,
+			Guards: guard.NoGuards(),
+		},
+	})
+}
+
+// bindParamSourcedResultFieldAtCall connects a result field to its argument source through a
+// call-scoped return site. It runs before param-out producers so the source reflects post-call state.
+func (r *RootAssertionNode) bindParamSourcedResultFieldAtCall(
+	call *ast.CallExpr,
+	funcObj *types.Func,
+	sources structfieldeffects.ReturnParamSources,
+	result structfieldeffects.IndexedFieldPath,
+	dst ast.Expr,
+) bool {
+	param, ok := sources.ParamPathFromResultPath(result.Idx, result.Path)
+	if !ok {
+		return false
+	}
+	sourceExpr, ok := r.paramPathExprAtCall(call, funcObj.Signature(), param)
+	if !ok {
+		return false
+	}
+	site := &annotation.StructFieldContextSite{
+		FuncObj:  funcObj,
+		Kind:     annotation.StructFieldReturnContext,
+		Index:    result.Idx,
+		Path:     result.Path,
+		Location: r.LocationOf(call),
+	}
+	r.AddProduction(&annotation.ProduceTrigger{
+		Annotation: &annotation.StructFieldFromContext{
+			TriggerIfNilable: &annotation.TriggerIfNilable{Ann: site},
+		},
+		Expr: dst,
+	})
+	r.bindExprNilabilityToContext(sourceExpr, site)
+	return true
+}
+
+func (r *RootAssertionNode) paramPathExprAtCall(
+	call *ast.CallExpr,
+	sig *types.Signature,
+	param structfieldeffects.IndexedFieldPath,
+) (ast.Expr, bool) {
+	var source ast.Expr
+	var sourceType types.Type
+	switch param.Idx {
+	case annotation.ReceiverParamIndex:
+		recv := sig.Recv()
+		sel, ok := ast.Unparen(call.Fun).(*ast.SelectorExpr)
+		if recv == nil || !ok {
+			return nil, false
+		}
+		source, sourceType = sel.X, recv.Type()
+	default:
+		if param.Idx < 0 || param.Idx >= sig.Params().Len() || param.Idx >= len(call.Args) {
+			return nil, false
+		}
+		source, sourceType = call.Args[param.Idx], sig.Params().At(param.Idx).Type()
+	}
+	if _, ok := r.Pass().TypesInfo.TypeOf(source).(*types.Tuple); ok {
+		// A spread multi-result call does not identify an expression for this parameter.
+		return nil, false
+	}
+	if param.Path.IsRoot() {
+		return source, true
+	}
+	// Selecting a field from nil would panic before the call returns.
+	if ident, ok := ast.Unparen(source).(*ast.Ident); ok && r.isNil(ident) {
+		return nil, false
+	}
+	structType := typeshelper.AsDeeplyStruct(sourceType)
+	if structType == nil {
+		return nil, false
+	}
+	return r.buildFieldPathSelector(source, structType, param.Path)
+}
+
+// bindExprNilabilityToContext supplies site from expr, using static nilability when expr is not
+// trackable.
+func (r *RootAssertionNode) bindExprNilabilityToContext(expr ast.Expr, site annotation.Key) {
+	consumer := &annotation.ConsumeTrigger{
+		Annotation: &annotation.StructFieldToContext{TriggerIfNonNil: &annotation.TriggerIfNonNil{Ann: site}},
+		Expr:       expr,
+		Guards:     guard.NoGuards(),
+	}
+	if trackable, _ := r.ParseExprAsProducer(expr, false); trackable != nil {
+		r.AddConsumption(consumer)
+		return
+	}
+	r.AddNewTriggers(annotation.FullTrigger{
+		Producer: &annotation.ProduceTrigger{Annotation: r.getShallowExprNilabilityProducer(expr), Expr: expr},
+		Consumer: consumer,
+	})
 }
 
 // getShallowExprNilabilityProducer returns the producer encoding the nilability of the value of expr: an

--- a/nilaway_test.go
+++ b/nilaway_test.go
@@ -140,8 +140,7 @@ func TestStructInitV2(t *testing.T) { //nolint:paralleltest
 		"structinitv2/paramsideeffect",
 		"structinitv2/returnlocal",
 		"structinitv2/returnzerovalue/app",
-		// structinitv2/returnshape/app asserts the per-call resolution of param-sourced results;
-		// enable it when call-site sensitivity of param-sourced results lands.
+		"structinitv2/returnshape/app",
 	)
 }
 

--- a/testdata/src/structinitv2/returnshape/app/app.go
+++ b/testdata/src/structinitv2/returnshape/app/app.go
@@ -56,11 +56,11 @@ func useForwardParamProjection() {
 	print(b.Child.Ptr) //want "uninitialized field `Child`"
 }
 
-// Transitive param tie: the tie reaches back to the caller's argument t, whose Mid.Child is nil.
+// Transitive parameter sources are not resolved.
 func useForwardParamTransitive() {
 	t := &lib.Outer{Mid: &lib.Node{}}
 	b := lib.ForwardParamTransitive(t)
-	print(b.Mid.Child.Ptr) //want "uninitialized field `Child`"
+	print(b.Mid.Child.Ptr)
 }
 
 // The transitive tie carries t's real (non-nil) shape; no flag.
@@ -79,11 +79,11 @@ func useForwardParamAmbiguous() {
 	print(b.Mid.Child.Ptr)
 }
 
-// Cross-package transitive tie: the tie reaches the caller's argument t two package hops away.
+// Cross-package transitive parameter sources are not resolved.
 func useForwardParamCrossPkg() {
 	t := &lib.Outer{Mid: &lib.Node{}}
 	b := mid.ForwardParamCrossPkg(t)
-	print(b.Mid.Child.Ptr) //want "uninitialized field `Child`"
+	print(b.Mid.Child.Ptr)
 }
 
 // Mixed sometimes constructs (Mid.Child nil) and sometimes forwards its param. The forwarding
@@ -107,4 +107,40 @@ func useMixedSafe() {
 func useForwardFirstParamSpread() {
 	b := lib.ForwardFirstParam(lib.TwoOut())
 	print(b.Mid.Child.Ptr)
+}
+
+// A nil argument at one call must not affect another call's result.
+func usePairNoPoison() {
+	ptr := 1
+	requested := &lib.Leaf{Ptr: &ptr}
+	create := lib.NewPair(nil, requested)
+	print(*create.Requested.Ptr)
+	existing := &lib.Leaf{Ptr: &ptr}
+	update := lib.NewPair(existing, requested)
+	print(*update.Existing.Ptr)
+}
+
+// A nil argument affects its own call result.
+func usePairBad() {
+	ptr := 1
+	requested := &lib.Leaf{Ptr: &ptr}
+	bad := lib.NewPair(nil, requested)
+	print(*bad.Existing.Ptr) //want "field `Existing` of result 0"
+}
+
+// A copied field's descendants map to the argument's descendants.
+func usePairDeepBad() {
+	requested := &lib.Leaf{}
+	existing := &lib.Leaf{}
+	bad := lib.NewPair(existing, requested)
+	print(*bad.Existing.Ptr) //want "uninitialized field `Ptr`"
+}
+
+// A copied field observes the argument's post-call value.
+func usePairDeepPostCallBad() {
+	ptr := 1
+	requested := &lib.Leaf{Ptr: &ptr}
+	existing := &lib.Leaf{Ptr: &ptr}
+	bad := lib.NewPairAfterNil(existing, requested)
+	print(*bad.Existing.Ptr) //want "field `Ptr` of param 0 of `NewPairAfterNil`"
 }

--- a/testdata/src/structinitv2/returnshape/lib/lib.go
+++ b/testdata/src/structinitv2/returnshape/lib/lib.go
@@ -112,3 +112,20 @@ func TwoOut() (*Outer, bool) {
 func ForwardFirstParam(x *Outer, ok bool) *Outer {
 	return x
 }
+
+// Pair contains values copied from NewPair's arguments.
+type Pair struct {
+	Existing  *Leaf
+	Requested *Leaf
+}
+
+// NewPair returns a Pair containing its arguments.
+func NewPair(existing, requested *Leaf) *Pair {
+	return &Pair{Existing: existing, Requested: requested}
+}
+
+// NewPairAfterNil clears existing.Ptr before copying existing into the result.
+func NewPairAfterNil(existing, requested *Leaf) *Pair {
+	existing.Ptr = nil
+	return &Pair{Existing: existing, Requested: requested}
+}


### PR DESCRIPTION
Resolve each uniquely mapped demanded field path through a call-site-scoped context site, preserving caller isolation while restoring those reports.

Changes
- Re-root demanded suffixes uniformly for constructed-field and whole-result parameter sources.
- Bind each mapped argument during assignment processing so param-out productions supply its post-call value.
- Activate direct return-shape coverage, including deep copied fields and post-write values; transitive forwarding remains silent until its closure lands.