### PR TITLE
refactor(struct-init-v2): standardize return param-source queries

### DIFF
--- a/assertion/function/assertiontree/structinitv2.go
+++ b/assertion/function/assertiontree/structinitv2.go
@@ -22,7 +22,6 @@ import (
 	"sort"
 
 	"go.uber.org/nilaway/annotation"
-	"go.uber.org/nilaway/assertion/function/structfieldeffects"
 	"go.uber.org/nilaway/guard"
 	"go.uber.org/nilaway/util/asthelper"
 	"go.uber.org/nilaway/util/typeshelper"
@@ -91,9 +90,7 @@ func (r *RootAssertionNode) addAllocationFieldProducers(lhsVal, rhsVal ast.Expr)
 // caller argument.
 func (r *RootAssertionNode) resultPathHasParamSource(funcObj *types.Func, resultIdx int, resultPath annotation.FieldPath) bool {
 	sources := r.functionContext.boundaryFieldEffects.ReturnParamSources(funcObj)
-	return slices.ContainsFunc(sources, func(src structfieldeffects.ReturnParamSource) bool {
-		return src.SuppliesResultPath(resultIdx, resultPath)
-	})
+	return sources.HasSource(resultIdx, resultPath)
 }
 
 // resultValueHasParamSource reports whether funcObj's resultIdx-th result value itself (not a

--- a/assertion/function/structfieldeffects/return_contracts.go
+++ b/assertion/function/structfieldeffects/return_contracts.go
@@ -44,21 +44,12 @@ type ReturnParamSource struct {
 	Param  IndexedFieldPath
 }
 
-// SuppliesResultPath reports whether s supplies the value at (resultIdx, resultPath): a
-// whole-result source (root result path) supplies every path of that result, and a field-level
-// source supplies its exact path and everything beneath it. The prefix match is per segment —
-// source `Mid` supplies `Mid.Child` but not the sibling field `Middle`.
-func (s ReturnParamSource) SuppliesResultPath(resultIdx int, resultPath annotation.FieldPath) bool {
-	_, ok := s.ResolveResultPath(resultIdx, resultPath)
-	return ok
-}
+// ReturnParamSources is the set of return parameter sources for a function.
+type ReturnParamSources []ReturnParamSource
 
-// ResolveResultPath resolves the param endpoint supplying (resultIdx, resultPath) through s: the
-// remainder of resultPath below s's result path is re-rooted under s's param path — source
-// `Mid <- p.inner` resolves result path `Mid.Child` to param path `inner.Child`, and a
-// whole-result source re-roots the full path. ok reports whether s supplies the path at all
-// (see SuppliesResultPath).
-func (s ReturnParamSource) ResolveResultPath(resultIdx int, resultPath annotation.FieldPath) (param IndexedFieldPath, ok bool) {
+// paramPathFromResultPath maps a result path covered by s to the corresponding parameter path. For example,
+// `Mid <- p.inner` maps result path `Mid.Child` to parameter path `inner.Child`.
+func (s ReturnParamSource) paramPathFromResultPath(resultIdx int, resultPath annotation.FieldPath) (IndexedFieldPath, bool) {
 	if s.Result.Idx != resultIdx {
 		return IndexedFieldPath{}, false
 	}
@@ -101,11 +92,45 @@ func (s returnParamSourceSet) sortedSources(funcObj *types.Func) []ReturnParamSo
 }
 
 // ReturnParamSources returns funcObj's return param sources in the sortedSources order.
-func (e *BoundaryFieldEffects) ReturnParamSources(funcObj *types.Func) []ReturnParamSource {
+func (e *BoundaryFieldEffects) ReturnParamSources(funcObj *types.Func) ReturnParamSources {
 	if e == nil {
 		return nil
 	}
 	return e.returnParamSources.sortedSources(funcObj)
+}
+
+// HasSource reports whether any parameter source covers resultPath of resultIdx. A root source
+// covers the whole result, while a field source covers its field and descendants.
+func (s ReturnParamSources) HasSource(resultIdx int, resultPath annotation.FieldPath) bool {
+	for _, source := range s {
+		if source.Result.Idx != resultIdx {
+			continue
+		}
+		if _, ok := resultPath.TrimPrefix(source.Result.Path); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// ParamPathFromResultPath maps resultPath of resultIdx to its parameter endpoint. It returns false
+// when no source covers the result path or when the covering sources map it to different endpoints;
+// HasSource distinguishes those cases when a caller needs to keep a sourced path severed.
+func (s ReturnParamSources) ParamPathFromResultPath(resultIdx int, resultPath annotation.FieldPath) (IndexedFieldPath, bool) {
+	var param IndexedFieldPath
+	found := false
+	for _, source := range s {
+		candidate, ok := source.paramPathFromResultPath(resultIdx, resultPath)
+		if !ok {
+			continue
+		}
+		if found && candidate != param {
+			return IndexedFieldPath{}, false
+		}
+		param = candidate
+		found = true
+	}
+	return param, found
 }
 
 // collectWholeResultParamSource records the whole-result param source of one return operand: a

--- a/assertion/function/structfieldeffects/return_contracts_test.go
+++ b/assertion/function/structfieldeffects/return_contracts_test.go
@@ -21,77 +21,103 @@ import (
 	"go.uber.org/nilaway/annotation"
 )
 
-func TestResolveResultPath(t *testing.T) {
+func TestReturnParamSources(t *testing.T) {
 	t.Parallel()
+
+	field := func(idx int, path ...string) IndexedFieldPath {
+		return IndexedFieldPath{Idx: idx, Path: annotation.NewFieldPath(path...)}
+	}
+	source := func(result, param IndexedFieldPath) ReturnParamSource {
+		return ReturnParamSource{Result: result, Param: param}
+	}
 
 	tests := []struct {
 		name       string
-		source     ReturnParamSource
+		sources    ReturnParamSources
 		resultIdx  int
 		resultPath annotation.FieldPath
 		wantParam  IndexedFieldPath
-		wantOK     bool
+		wantSource bool
+		wantPath   bool
 	}{
 		{
-			name:       "field-level source at its exact path",
-			source:     ReturnParamSource{Result: IndexedFieldPath{Idx: 0, Path: annotation.NewFieldPath("Mid")}, Param: IndexedFieldPath{Idx: 1, Path: annotation.NewFieldPath("inner")}},
-			resultIdx:  0,
+			name:       "no source",
 			resultPath: annotation.NewFieldPath("Mid"),
-			wantParam:  IndexedFieldPath{Idx: 1, Path: annotation.NewFieldPath("inner")},
-			wantOK:     true,
 		},
 		{
-			name:       "field-level source re-roots a deeper path",
-			source:     ReturnParamSource{Result: IndexedFieldPath{Idx: 0, Path: annotation.NewFieldPath("Mid")}, Param: IndexedFieldPath{Idx: 1, Path: annotation.NewFieldPath("inner")}},
-			resultIdx:  0,
+			name:       "field source at exact path",
+			sources:    ReturnParamSources{source(field(0, "Mid"), field(1, "inner"))},
+			resultPath: annotation.NewFieldPath("Mid"),
+			wantParam:  field(1, "inner"),
+			wantSource: true,
+			wantPath:   true,
+		},
+		{
+			name:       "field source maps descendant",
+			sources:    ReturnParamSources{source(field(0, "Mid"), field(1, "inner"))},
 			resultPath: annotation.NewFieldPath("Mid", "Child"),
-			wantParam:  IndexedFieldPath{Idx: 1, Path: annotation.NewFieldPath("inner", "Child")},
-			wantOK:     true,
+			wantParam:  field(1, "inner", "Child"),
+			wantSource: true,
+			wantPath:   true,
 		},
 		{
-			name:       "bare-param source keeps the bare param at the exact path",
-			source:     ReturnParamSource{Result: IndexedFieldPath{Idx: 0, Path: annotation.NewFieldPath("Existing")}, Param: IndexedFieldPath{Idx: 0}},
-			resultIdx:  0,
-			resultPath: annotation.NewFieldPath("Existing"),
-			wantParam:  IndexedFieldPath{Idx: 0},
-			wantOK:     true,
-		},
-		{
-			name:       "whole-result source re-roots the full path",
-			source:     ReturnParamSource{Result: IndexedFieldPath{Idx: 0}, Param: IndexedFieldPath{Idx: 0, Path: annotation.NewFieldPath("inner")}},
-			resultIdx:  0,
+			name: "covering sources agree",
+			sources: ReturnParamSources{
+				source(field(0, "Mid"), field(1, "inner")),
+				source(field(0, "Mid", "Child"), field(1, "inner", "Child")),
+			},
 			resultPath: annotation.NewFieldPath("Mid", "Child"),
-			wantParam:  IndexedFieldPath{Idx: 0, Path: annotation.NewFieldPath("inner", "Mid", "Child")},
-			wantOK:     true,
+			wantParam:  field(1, "inner", "Child"),
+			wantSource: true,
+			wantPath:   true,
 		},
 		{
-			name:       "whole-result source at the result value itself",
-			source:     ReturnParamSource{Result: IndexedFieldPath{Idx: 0}, Param: IndexedFieldPath{Idx: 0, Path: annotation.NewFieldPath("inner")}},
-			resultIdx:  0,
-			resultPath: annotation.FieldPath{},
-			wantParam:  IndexedFieldPath{Idx: 0, Path: annotation.NewFieldPath("inner")},
-			wantOK:     true,
+			name: "covering sources disagree",
+			sources: ReturnParamSources{
+				source(field(0, "Mid"), field(1, "other")),
+				source(field(0, "Mid", "Child"), field(1, "inner", "Child")),
+			},
+			resultPath: annotation.NewFieldPath("Mid", "Child"),
+			wantSource: true,
 		},
 		{
-			name:       "sibling field sharing the source prefix is not supplied",
-			source:     ReturnParamSource{Result: IndexedFieldPath{Idx: 0, Path: annotation.NewFieldPath("Mid")}, Param: IndexedFieldPath{Idx: 1, Path: annotation.NewFieldPath("inner")}},
-			resultIdx:  0,
+			name:       "root source maps descendant",
+			sources:    ReturnParamSources{source(field(0), field(1, "whole"))},
+			resultPath: annotation.NewFieldPath("Mid", "Child"),
+			wantParam:  field(1, "whole", "Mid", "Child"),
+			wantSource: true,
+			wantPath:   true,
+		},
+		{
+			name:       "root source maps root",
+			sources:    ReturnParamSources{source(field(0), field(1, "whole"))},
+			wantParam:  field(1, "whole"),
+			wantSource: true,
+			wantPath:   true,
+		},
+		{
+			name:    "field source does not cover root",
+			sources: ReturnParamSources{source(field(0, "Mid"), field(1, "inner"))},
+		},
+		{
+			name:       "sibling field is not covered",
+			sources:    ReturnParamSources{source(field(0, "Mid"), field(1, "inner"))},
 			resultPath: annotation.NewFieldPath("Middle"),
-			wantOK:     false,
 		},
 		{
-			name:       "different result index is not supplied",
-			source:     ReturnParamSource{Result: IndexedFieldPath{Idx: 0, Path: annotation.NewFieldPath("Mid")}, Param: IndexedFieldPath{Idx: 1, Path: annotation.NewFieldPath("inner")}},
+			name:       "different result is not covered",
+			sources:    ReturnParamSources{source(field(0, "Mid"), field(1, "inner"))},
 			resultIdx:  1,
 			resultPath: annotation.NewFieldPath("Mid"),
-			wantOK:     false,
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			param, ok := tt.source.ResolveResultPath(tt.resultIdx, tt.resultPath)
-			require.Equal(t, tt.wantOK, ok)
+			require.Equal(t, tt.wantSource, tt.sources.HasSource(tt.resultIdx, tt.resultPath))
+			param, ok := tt.sources.ParamPathFromResultPath(tt.resultIdx, tt.resultPath)
+			require.Equal(t, tt.wantPath, ok)
 			require.Equal(t, tt.wantParam, param)
 		})
 	}


### PR DESCRIPTION
Return parameter-source consumers independently rebuilt coverage and result-to-parameter mappings, allowing severing and call-site resolution to disagree. Centralize those queries on `ReturnParamSources`. No behavior change.

Changes
- Add `HasSource` and `ParamPathFromResultPath` with consistent `(resultIdx, resultPath)` inputs.
- Use `HasSource` for shared-site severing so ambiguous sources remain caller-dependent.
- Cover root, descendant, sibling, and disagreeing mappings in one table-driven test.