### PR TITLE
feat(struct-init-v2): resolve parameter-dependent shallow results per call site

### DIFF
--- a/assertion/function/assertiontree/func_assertion_node.go
+++ b/assertion/function/assertiontree/func_assertion_node.go
@@ -29,6 +29,10 @@ type funcAssertionNode struct {
 	// declaring identifier for this function
 	decl *types.Func
 	args []ast.Expr
+	// call identifies the source call. With -experimental-struct-init-v2 enabled, shallowEqNodes
+	// uses its position to distinguish nodes only when the result has a unique whole-result
+	// parameter source.
+	call *ast.CallExpr
 }
 
 func (f *funcAssertionNode) MinimalString() string {
@@ -41,10 +45,14 @@ func (f *funcAssertionNode) DefaultTrigger() annotation.ProducingAnnotationTrigg
 		panic("only functions with singular result should be entered into the assertion tree")
 	}
 
-	// A result value supplied by a caller argument must not be read from the shared declaration
-	// return, which merges unrelated callers (see getFuncReturnProducers).
+	// Parameter-sourced results use call-scoped sites instead of the shared return.
 	if root := f.Root(); root != nil && root.functionContext.functionConfig.EnableStructInitV2 &&
 		root.resultValueHasParamSource(f.decl, 0) {
+		if f.call != nil {
+			if siteProducer, ok := root.shallowCallResultSiteProducer(f.call, f.decl, 0); ok {
+				return siteProducer
+			}
+		}
 		return &annotation.ProduceTriggerNever{}
 	}
 

--- a/assertion/function/assertiontree/parse_expr_producer.go
+++ b/assertion/function/assertiontree/parse_expr_producer.go
@@ -337,7 +337,7 @@ func (r *RootAssertionNode) ParseExprAsProducer(expr ast.Expr, doNotTrack bool) 
 			// non-builtin funcs
 			if !doNotTrack && litArgs() {
 				return TrackableExpr{&funcAssertionNode{
-					decl: r.ObjectOf(fun).(*types.Func), args: expr.Args}}, nil
+					decl: r.ObjectOf(fun).(*types.Func), args: expr.Args, call: expr}}, nil
 			}
 			// function call has non-literal args, so is not literal, use its return annotation
 			// alternatively, doNotTrack was set
@@ -364,11 +364,11 @@ func (r *RootAssertionNode) ParseExprAsProducer(expr ast.Expr, doNotTrack bool) 
 			if litArgs() {
 				if r.isPkgName(fun.X) {
 					return TrackableExpr{&funcAssertionNode{
-						decl: r.ObjectOf(fun.Sel).(*types.Func), args: expr.Args}}, nil
+						decl: r.ObjectOf(fun.Sel).(*types.Func), args: expr.Args, call: expr}}, nil
 				}
 				if recv, _ := r.ParseExprAsProducer(fun.X, false); recv != nil {
 					return append(recv, &funcAssertionNode{
-						decl: r.ObjectOf(fun.Sel).(*types.Func), args: expr.Args}), nil
+						decl: r.ObjectOf(fun.Sel).(*types.Func), args: expr.Args, call: expr}), nil
 				}
 				// receiver is not trackable, use its return annotation
 				return nil, r.getFuncReturnProducers(fun.Sel, expr)
@@ -402,7 +402,7 @@ func (r *RootAssertionNode) ParseExprAsProducer(expr ast.Expr, doNotTrack bool) 
 			// non-builtin funcs
 			if !doNotTrack && litArgs() {
 				return TrackableExpr{&funcAssertionNode{
-					decl: r.ObjectOf(funcIdent).(*types.Func), args: expr.Args}}, nil
+					decl: r.ObjectOf(funcIdent).(*types.Func), args: expr.Args, call: expr}}, nil
 			}
 			// function call has non-literal args, so is not literal, use its return annotation
 			// alternatively, doNotTrack was set
@@ -584,12 +584,13 @@ func (r *RootAssertionNode) getFuncReturnProducers(ident *ast.Ident, expr *ast.C
 			},
 			IsFromRichCheckEffectFunc: isErrReturning || isOkReturning,
 		}
-		// A result value supplied by a caller argument must not be read from the shared
-		// declaration return, which merges unrelated callers. This revision produces
-		// "no evidence of nil" instead (a documented under-report; the per-call resolution lands
-		// in the following revisions).
+		// Parameter-sourced results use call-scoped sites; unresolved sources remain silent.
 		if r.functionContext.functionConfig.EnableStructInitV2 && r.resultValueHasParamSource(funcObj, i) {
-			shallowAnnotation = &annotation.ProduceTriggerNever{}
+			if siteProducer, ok := r.shallowCallResultSiteProducer(expr, funcObj, i); ok {
+				shallowAnnotation = siteProducer
+			} else {
+				shallowAnnotation = &annotation.ProduceTriggerNever{}
+			}
 		}
 
 		producers[i] = producer.DeepParsedProducer{

--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -777,6 +777,8 @@ func (r *RootAssertionNode) AddComputation(expr ast.Expr) {
 
 		if r.functionContext.functionConfig.EnableStructInitV2 {
 			if target, ok := typeshelper.ResolveStaticCallTarget(r.Pass().TypesInfo, expr); ok {
+				// Bind shallow result sources before param-out so they observe post-call values.
+				r.bindShallowCallResultArgs(expr, target.Origin)
 				r.addCallParamOutFieldProducers(expr, target)
 				r.bindForwardedParamOut(expr, target)
 				r.bindArgAndReceiverFieldsToContext(expr, target)
@@ -1123,6 +1125,14 @@ func (r *RootAssertionNode) shallowEqNodes(left, right AssertionNode) bool {
 		}
 		if left.decl != right.decl {
 			return false
+		}
+		// Parameter-sourced results at different call locations cannot share assertion nodes.
+		if r.functionContext.functionConfig.EnableStructInitV2 &&
+			left.call != nil && right.call != nil && left.call.Pos() != right.call.Pos() {
+			sources := r.functionContext.boundaryFieldEffects.ReturnParamSources(left.decl)
+			if _, ok := sources.ParamPathFromResultPath(0, annotation.FieldPath{}); ok {
+				return false
+			}
 		}
 		if len(left.args) != len(right.args) {
 			return false

--- a/assertion/function/assertiontree/structinitv2.go
+++ b/assertion/function/assertiontree/structinitv2.go
@@ -215,6 +215,58 @@ func (r *RootAssertionNode) bindParamSourcedResultFieldAtCall(
 	return true
 }
 
+// bindShallowCallResultArgs supplies call-scoped sites for parameter-sourced result values.
+func (r *RootAssertionNode) bindShallowCallResultArgs(call *ast.CallExpr, funcObj *types.Func) {
+	sources := r.functionContext.boundaryFieldEffects.ReturnParamSources(funcObj)
+	sig := funcObj.Signature()
+	for resultIdx := range sig.Results().Len() {
+		result := structfieldeffects.IndexedFieldPath{Idx: resultIdx}
+		param, ok := sources.ParamPathFromResultPath(result.Idx, result.Path)
+		if !ok {
+			continue
+		}
+		sourceExpr, ok := r.paramPathExprAtCall(call, sig, param)
+		if !ok {
+			continue
+		}
+		site := &annotation.StructFieldContextSite{
+			FuncObj:  funcObj,
+			Kind:     annotation.StructFieldReturnContext,
+			Index:    result.Idx,
+			Path:     result.Path,
+			Location: r.LocationOf(call),
+		}
+		r.bindExprNilabilityToContext(sourceExpr, site)
+	}
+}
+
+// shallowCallResultSiteProducer returns a call-scoped producer for a parameter-sourced result.
+func (r *RootAssertionNode) shallowCallResultSiteProducer(
+	call *ast.CallExpr,
+	funcObj *types.Func,
+	resultIdx int,
+) (annotation.ProducingAnnotationTrigger, bool) {
+	sources := r.functionContext.boundaryFieldEffects.ReturnParamSources(funcObj)
+	result := structfieldeffects.IndexedFieldPath{Idx: resultIdx}
+	param, ok := sources.ParamPathFromResultPath(result.Idx, result.Path)
+	if !ok {
+		return nil, false
+	}
+	if _, ok := r.paramPathExprAtCall(call, funcObj.Signature(), param); !ok {
+		return nil, false
+	}
+	site := &annotation.StructFieldContextSite{
+		FuncObj:  funcObj,
+		Kind:     annotation.StructFieldReturnContext,
+		Index:    result.Idx,
+		Path:     result.Path,
+		Location: r.LocationOf(call),
+	}
+	return &annotation.StructFieldFromContext{
+		TriggerIfNilable: &annotation.TriggerIfNilable{Ann: site},
+	}, true
+}
+
 func (r *RootAssertionNode) paramPathExprAtCall(
 	call *ast.CallExpr,
 	sig *types.Signature,
@@ -254,8 +306,7 @@ func (r *RootAssertionNode) paramPathExprAtCall(
 	return r.buildFieldPathSelector(source, structType, param.Path)
 }
 
-// bindExprNilabilityToContext supplies site from expr, using static nilability when expr is not
-// trackable.
+// bindExprNilabilityToContext supplies site from expr, using static nilability as a fallback.
 func (r *RootAssertionNode) bindExprNilabilityToContext(expr ast.Expr, site annotation.Key) {
 	consumer := &annotation.ConsumeTrigger{
 		Annotation: &annotation.StructFieldToContext{TriggerIfNonNil: &annotation.TriggerIfNonNil{Ann: site}},

--- a/assertion/function/assertiontree/util.go
+++ b/assertion/function/assertiontree/util.go
@@ -418,7 +418,7 @@ func CopyNode(node AssertionNode) AssertionNode {
 	case *fldAssertionNode:
 		fresh = &fldAssertionNode{decl: node.decl, functionContext: node.functionContext}
 	case *funcAssertionNode:
-		fresh = &funcAssertionNode{decl: node.decl, args: node.args}
+		fresh = &funcAssertionNode{decl: node.decl, args: node.args, call: node.call}
 	case *indexAssertionNode:
 		fresh = &indexAssertionNode{
 			index:    node.index,

--- a/testdata/src/structinitv2/crosspkg/app/fieldvalueescape.go
+++ b/testdata/src/structinitv2/crosspkg/app/fieldvalueescape.go
@@ -22,10 +22,8 @@ import "structinitv2/crosspkg/shared"
 
 func unsafeFieldValueEscape() {
 	a := &shared.A{}
-	// Temporarily silent: shared.Get carries a whole-result param source (imported through the
-	// effects fact), so its result is severed from the shared return summary; flips back to a
-	// per-call report when call-site resolution lands.
-	usePtr(shared.Get(a).Ptr)
+	// The imported source resolves the result from this call's argument.
+	usePtr(shared.Get(a).Ptr) //want "result 0 of `Get`"
 }
 
 func safeFieldValueEscape() {

--- a/testdata/src/structinitv2/paramfield/fieldvalueescape.go
+++ b/testdata/src/structinitv2/paramfield/fieldvalueescape.go
@@ -35,11 +35,8 @@ func escapeDirect(b *escapeBox) *escapeLeaf {
 
 func useEscapeDirectUnsafe() {
 	b := &escapeBox{}
-	// Temporarily silent: `return b.inner` is a whole-result param source, so the result is
-	// severed from the shared return summary (which would merge this nil flow into
-	// useEscapeDirectSafe below). Flips back to a per-call report when call-site resolution
-	// lands.
-	print(escapeDirect(b).ptr)
+	// This result resolves from its argument without poisoning the safe call below.
+	print(escapeDirect(b).ptr) //want "result 0 of `escapeDirect`"
 }
 
 func useEscapeDirectSafe() {
@@ -63,16 +60,12 @@ func useEscapeSnapshotSafe() {
 	print(escapeSnapshot(b).ptr)
 }
 
-// The same value demand applies to a method receiver boundary. No safe negative control here:
-// before the param-source sever, the method's shared return site merged all callers, so a safe
-// caller of innerValue would have inherited this caller's nil flow.
+// innerValue projects its receiver field as the result.
 func (b *escapeBox) innerValue() *escapeLeaf {
 	return b.inner
 }
 
 func useReceiverEscapeUnsafe() {
 	b := &escapeBox{}
-	// Temporarily silent: receiver-projection param sources sever the result from the shared summary;
-	// flips back to a per-call report when call-site resolution lands.
-	print(b.innerValue().ptr)
+	print(b.innerValue().ptr) //want "result 0 of `innerValue`"
 }

--- a/testdata/src/structinitv2/returnshape/app/app.go
+++ b/testdata/src/structinitv2/returnshape/app/app.go
@@ -21,39 +21,39 @@ import (
 	"structinitv2/returnshape/mid"
 )
 
-// Param tie: b ties to t; t.Mid.Child is nil, so the deep deref flags.
+// A forwarded parameter keeps this call's argument shape.
 func useForwardParam() {
 	t := &lib.Outer{Mid: &lib.Node{}}
 	b := lib.ForwardParam(t)
-	print(b.Mid.Child.Ptr) //want "uninitialized field `Child`"
+	print(b.Mid.Child.Ptr) //want "field `Mid.Child` of result 0 of `ForwardParam`"
 }
 
-// The tie carries t's real (non-nil) shape; no flag.
+// A safe call does not inherit another call's nil argument.
 func useForwardParamSafe() {
 	t := &lib.Outer{Mid: &lib.Node{Child: &lib.Leaf{}}}
 	b := lib.ForwardParam(t)
 	print(b.Mid.Child.Ptr)
 }
 
-// ForwardParamNilField nils the field before forwarding; the deref must observe the post-call nil.
+// A forwarded parameter observes post-call field writes.
 func useForwardParamNilField() {
 	t := &lib.Node{Child: &lib.Leaf{}}
 	b := lib.ForwardParamNilField(t)
-	print(b.Child.Ptr) //want "field `Child` of param 0 of `ForwardParamNilField`"
+	print(b.Child.Ptr) //want "field `Child` of result 0 of `ForwardParamNilField`"
 }
 
-// Receiver forwarding: b ties to the receiver t; t.Child is nil.
+// Receiver forwarding uses the receiver as its source.
 func useRecv() {
 	t := &lib.Node{}
 	b := t.Self()
-	print(b.Child.Ptr) //want "uninitialized field `Child`"
+	print(b.Child.Ptr) //want "field `Child` of result 0 of `Self`"
 }
 
-// Field-projection param tie: b ties to t.In; t.In.Child is nil.
+// A projected result uses the argument field as its source.
 func useForwardParamProjection() {
 	t := &lib.Wrap{In: &lib.Inner{}}
 	b := lib.ForwardParamProjection(t)
-	print(b.Child.Ptr) //want "uninitialized field `Child`"
+	print(b.Child.Ptr) //want "field `Child` of result 0 of `ForwardParamProjection`"
 }
 
 // Transitive parameter sources are not resolved.
@@ -70,8 +70,7 @@ func useForwardParamTransitiveSafe() {
 	print(b.Mid.Child.Ptr)
 }
 
-// Ambiguous multi-return forwarder: the result could be either parameter, so the tie bails — a
-// documented under-report, NOT flagged.
+// Ambiguous parameter sources remain silent.
 func useForwardParamAmbiguous() {
 	t := &lib.Outer{Mid: &lib.Node{}}
 	w := &lib.Outer{Mid: &lib.Node{}}
@@ -86,24 +85,21 @@ func useForwardParamCrossPkg() {
 	print(b.Mid.Child.Ptr)
 }
 
-// Mixed sometimes constructs (Mid.Child nil) and sometimes forwards its param. The forwarding
-// summary is dropped, but the construct branch's own nil field is still a genuine true positive.
+// Mixed construct/forward results retain concrete effects but no parameter source.
 func useMixed() {
 	t := &lib.Outer{Mid: &lib.Node{Child: &lib.Leaf{}}}
 	b := lib.Mixed(t, true)
 	print(b.Mid.Child.Ptr) //want "field `Mid.Child` of result 0 of `Mixed`"
 }
 
-// MixedSafe's construct branch is safe but it also forwards its param, so the forwarding tie is
-// dropped: even though t.Mid.Child is nil, b must NOT be tied to t, so this is NOT flagged.
+// A dropped source must not tie the safe constructed result to its argument.
 func useMixedSafe() {
 	t := &lib.Outer{Mid: &lib.Node{}}
 	b := lib.MixedSafe(t, true)
 	print(b.Mid.Child.Ptr)
 }
 
-// Spreading a multi-result call (`TwoOut()`) into a forwarder gives the tie a non-lvalue argument,
-// so it must bail. The deref is a sound under-report; the point is that analysis completes.
+// Tuple-spread arguments cannot be resolved and remain silent.
 func useForwardFirstParamSpread() {
 	b := lib.ForwardFirstParam(lib.TwoOut())
 	print(b.Mid.Child.Ptr)
@@ -143,4 +139,37 @@ func usePairDeepPostCallBad() {
 	existing := &lib.Leaf{Ptr: &ptr}
 	bad := lib.NewPairAfterNil(existing, requested)
 	print(*bad.Existing.Ptr) //want "field `Ptr` of param 0 of `NewPairAfterNil`"
+}
+
+// A nil projected field makes this call's shallow result nil.
+func useForwardParamProjectionNil() {
+	t := &lib.Wrap{}
+	print(lib.ForwardParamProjection(t).Child.Ptr) //want "uninitialized field `In`"
+}
+
+// A safe projection call does not inherit another call's nil source.
+func useForwardParamProjectionShallowSafe() {
+	t := &lib.Wrap{In: &lib.Inner{Child: &lib.Leaf{}}}
+	print(lib.ForwardParamProjection(t).Child.Ptr)
+}
+
+// Receiver field projections use the same shallow result binding.
+func useReceiverProjectionNil() {
+	t := &lib.Wrap{}
+	print(t.ReceiverProjection().Child.Ptr) //want "uninitialized field `In`"
+}
+
+func useReceiverProjectionSafe() {
+	t := &lib.Wrap{In: &lib.Inner{Child: &lib.Leaf{}}}
+	print(t.ReceiverProjection().Child.Ptr)
+}
+
+// Calls at different locations use distinct sites even when otherwise identical.
+func useIdenticalCallsStayDistinct() {
+	t := &lib.Wrap{}
+	first := t.ReceiverProjection()
+	print(first.Child.Ptr) //want "uninitialized field `In`"
+	t.In = &lib.Inner{Child: &lib.Leaf{}}
+	second := t.ReceiverProjection()
+	print(second.Child.Ptr)
 }

--- a/testdata/src/structinitv2/returnshape/lib/lib.go
+++ b/testdata/src/structinitv2/returnshape/lib/lib.go
@@ -66,6 +66,11 @@ func ForwardParamProjection(x *Wrap) *Inner {
 	return x.In
 }
 
+// ReceiverProjection returns x.In.
+func (x *Wrap) ReceiverProjection() *Inner {
+	return x.In
+}
+
 // ForwardParamTransitive returns a call to ForwardParam passing its own parameter, so it too
 // forwards param 0 to result 0; a caller's deref observes its own argument shape.
 func ForwardParamTransitive(y *Outer) *Outer {


### PR DESCRIPTION
Resolve that root demand through the same call-site source and site so shallow nilability remains caller-specific.

Changes
- Bind root result demands before param-out productions so shallow results observe post-call argument values.
- Read tracked and untracked call values from the located return site instead of the shared declaration return.
- Keep identical calls at different locations distinct and resolve projected fields of inline allocation arguments.
- Cover direct function, method, projection, and escaped-field shallow-result scenarios.