### PR TITLE
feat(struct-init-v2): propagate param sources through forwarded returns

### DIFF
--- a/assertion/function/structfieldeffects/collector.go
+++ b/assertion/function/structfieldeffects/collector.go
@@ -250,7 +250,10 @@ func (fc *functionCollector) collectReturnSites() {
 	fc.stableVars = fc.collectStableStructVars()
 	fc.unstableParams = fc.collectUnstableParamVars()
 
-	for _, stmt := range returnStatements(fc.fd.Body) {
+	statements := returnStatements(fc.fd.Body)
+	allowParamForwarding := len(statements) == 1
+	directSourceSites := make([]int, fc.sig.Results().Len())
+	for _, stmt := range statements {
 		// A bare spreading return such as `return f()` is one expression that yields every
 		// result, so len(stmt.Results) is 1 while the signature may have many; we bail out
 		// rather than try to split it, so such multi-result call returns are unsupported.
@@ -261,9 +264,29 @@ func (fc *functionCollector) collectReturnSites() {
 			if typeshelper.AsDeeplyStruct(fc.sig.Results().At(resultIdx).Type()) == nil {
 				continue
 			}
-			fc.collectReturnSiteEffect(resultIdx, resultExpr)
-			fc.collectWholeResultParamSource(resultIdx, resultExpr)
+			fc.collectReturnSiteEffect(resultIdx, resultExpr, allowParamForwarding)
+			if fc.collectWholeResultParamSource(resultIdx, resultExpr) {
+				directSourceSites[resultIdx]++
+			}
 		}
+	}
+
+	// A forwarding edge is sound only when the result has a single return site. With several
+	// sites, keep direct sources only when every path has one; otherwise the recorded sources do
+	// not describe the result on every path and are dropped as a deliberate under-report.
+	if allowParamForwarding {
+		return
+	}
+	for resultIdx, sourceSites := range directSourceSites {
+		if typeshelper.AsDeeplyStruct(fc.sig.Results().At(resultIdx).Type()) == nil ||
+			sourceSites == len(statements) {
+			continue
+		}
+		if fc.collected.resultsWithConstructSite[fc.funcObj][resultIdx] {
+			// Constructed results are reconciled by dropMixedResultParamSources.
+			continue
+		}
+		fc.collected.dropWholeResultParamSources(fc.funcObj, resultIdx)
 	}
 }
 
@@ -505,8 +528,9 @@ func (fc *functionCollector) collectStableStructVars() map[*types.Var]bool {
 // collectReturnSiteEffect records what one struct-shaped return operand contributes to the
 // effects summary: a construction (direct or through a stable local) enumerates its nil fields
 // and marks the result index as constructed (see markResultWithConstructSite); a direct return of a
-// static call result — or of a stable local bound to one — adds a return forwarding edge.
-func (fc *functionCollector) collectReturnSiteEffect(resultIdx int, resultExpr ast.Expr) {
+// static call result — or of a stable local bound to one — adds a return forwarding edge. A direct
+// call can retain parameter forwarding only when this result has a single return site.
+func (fc *functionCollector) collectReturnSiteEffect(resultIdx int, resultExpr ast.Expr, allowParamForwarding bool) {
 	if source, ok := staticStructAllocation(fc.pass, resultExpr); ok {
 		fc.collected.markResultWithConstructSite(fc.funcObj, resultIdx)
 		fc.enumerateConcreteReturnEffects(resultIdx, source.structType, source.fieldInits, annotation.FieldPath{})
@@ -515,7 +539,11 @@ func (fc *functionCollector) collectReturnSiteEffect(resultIdx int, resultExpr a
 	if call, ok := ast.Unparen(resultExpr).(*ast.CallExpr); ok {
 		target, ok := typeshelper.ResolveStaticCallTarget(fc.pass.TypesInfo, call)
 		if ok && target.Signature.Results().Len() == 1 {
-			fc.addReturnEdge(resultIdx, target, 0)
+			var paramForwardingEdges []paramFieldForwardEdge
+			if allowParamForwarding {
+				paramForwardingEdges = fc.returnCallParamForwardingEdges(call, target)
+			}
+			fc.addReturnEdge(resultIdx, target, 0, paramForwardingEdges)
 		}
 		return
 	}
@@ -533,13 +561,18 @@ func (fc *functionCollector) collectReturnSiteEffect(resultIdx int, resultExpr a
 		return
 	}
 	if source, ok := fc.resultVars[v]; ok {
-		fc.addReturnEdge(resultIdx, source.callee, source.idx)
+		fc.addReturnEdge(resultIdx, source.callee, source.idx, nil)
 	}
 }
 
 // addReturnEdge records a return forwarding edge when the callee resolves to an origin and its
 // forwarded result is struct-shaped.
-func (fc *functionCollector) addReturnEdge(callerResultIdx int, target typeshelper.StaticCallTarget, calleeResultIdx int) {
+func (fc *functionCollector) addReturnEdge(
+	callerResultIdx int,
+	target typeshelper.StaticCallTarget,
+	calleeResultIdx int,
+	paramForwardingEdges []paramFieldForwardEdge,
+) {
 	if target.Origin == nil {
 		return
 	}
@@ -548,9 +581,10 @@ func (fc *functionCollector) addReturnEdge(callerResultIdx int, target typeshelp
 		return
 	}
 	fc.collected.addReturnForwardEdge(fc.funcObj, returnForwardEdge{
-		callerResultIdx: callerResultIdx,
-		callee:          target.Origin,
-		calleeResultIdx: calleeResultIdx,
+		callerResultIdx:      callerResultIdx,
+		callee:               target.Origin,
+		calleeResultIdx:      calleeResultIdx,
+		paramForwardingEdges: paramForwardingEdges,
 	})
 }
 

--- a/assertion/function/structfieldeffects/effects.go
+++ b/assertion/function/structfieldeffects/effects.go
@@ -100,6 +100,7 @@ func (c *collectedFieldEffects) close() *BoundaryFieldEffects {
 	closeParamFieldSets(c.summary.paramReads, c.paramForwardingEdges)
 	closeReturnEffects(c.summary.returnEffects, c.returnForwardingEdges)
 	c.dropMixedResultParamSources()
+	closeReturnParamSources(c.summary.returnParamSources, c.returnForwardingEdges)
 	return c.summary
 }
 
@@ -174,11 +175,14 @@ type paramFieldForwardEdge struct {
 	calleeParamIdx int
 }
 
-// returnForwardEdge records that one result directly returns a callee result.
+// returnForwardEdge records that one result directly returns a callee result. A direct returned
+// call also retains its parameter-forwarding edges when every call input is a stable parameter of
+// the caller; call-backed locals leave paramForwardingEdges empty.
 type returnForwardEdge struct {
-	callerResultIdx int
-	callee          *types.Func
-	calleeResultIdx int
+	callerResultIdx      int
+	callee               *types.Func
+	calleeResultIdx      int
+	paramForwardingEdges []paramFieldForwardEdge
 }
 
 // closeParamFieldSets extends a field-effect set to a fixpoint over the forwarding edges:

--- a/assertion/function/structfieldeffects/return_contracts.go
+++ b/assertion/function/structfieldeffects/return_contracts.go
@@ -29,6 +29,7 @@ import (
 
 	"go.uber.org/nilaway/annotation"
 	"go.uber.org/nilaway/util/asthelper"
+	"go.uber.org/nilaway/util/typeshelper"
 )
 
 // ReturnParamSource records a result (or result field) whose value is the caller's own argument:
@@ -63,12 +64,17 @@ func (s ReturnParamSource) paramPathFromResultPath(resultIdx int, resultPath ann
 // returnParamSourceSet maps each function to its set of return param sources.
 type returnParamSourceSet map[*types.Func]map[ReturnParamSource]bool
 
-// add records source for funcObj, allocating the inner set on first use.
-func (s returnParamSourceSet) add(funcObj *types.Func, source ReturnParamSource) {
+// add records source for funcObj, allocating the inner set on first use. It reports whether
+// the source was newly added.
+func (s returnParamSourceSet) add(funcObj *types.Func, source ReturnParamSource) bool {
 	if s[funcObj] == nil {
 		s[funcObj] = make(map[ReturnParamSource]bool)
 	}
+	if s[funcObj][source] {
+		return false
+	}
 	s[funcObj][source] = true
+	return true
 }
 
 // sortedSources returns funcObj's return param sources in a deterministic order. The sources come
@@ -133,22 +139,124 @@ func (s ReturnParamSources) ParamPathFromResultPath(resultIdx int, resultPath an
 	return param, found
 }
 
-// collectWholeResultParamSource records the whole-result param source of one return operand: a
-// returned parameter or parameter field chain (`return p`, `return p.x`, receiver variants).
-// Disagreeing sources for the same result (a different parameter per return site) are all kept —
-// consumers refuse to answer when sources disagree, which keeps the collected set deterministic. A
-// result index that both constructs in-package and carries a whole-result source is ambiguous and
-// dropped in close(); field-level sources of constructed results are recorded by
-// recordFieldParamSource instead.
-func (fc *functionCollector) collectWholeResultParamSource(resultIdx int, expr ast.Expr) {
-	source, ok := fc.resolveReturnParamSource(expr)
-	if !ok {
-		return
+// collectWholeResultParamSource records a direct parameter source. Forwarded call sources compose
+// through the parameter edges retained on their return forwarding edge.
+func (fc *functionCollector) collectWholeResultParamSource(resultIdx int, expr ast.Expr) bool {
+	if source, ok := fc.resolveReturnParamSource(expr); ok {
+		fc.collected.addReturnParamSource(fc.funcObj, ReturnParamSource{
+			Result: IndexedFieldPath{Idx: resultIdx},
+			Param:  source,
+		})
+		return true
 	}
-	fc.collected.addReturnParamSource(fc.funcObj, ReturnParamSource{
-		Result: IndexedFieldPath{Idx: resultIdx},
-		Param:  source,
-	})
+	return false
+}
+
+// returnCallParamForwardingEdges maps every supported call input to a stable parameter of the
+// caller. Unsupported call shapes return no edges rather than risk relating the result to the
+// wrong caller value.
+func (fc *functionCollector) returnCallParamForwardingEdges(
+	call *ast.CallExpr,
+	target typeshelper.StaticCallTarget,
+) []paramFieldForwardEdge {
+	if target.Origin == nil || target.Signature.Variadic() {
+		return nil
+	}
+	var receiver ast.Expr
+	if sel, ok := ast.Unparen(call.Fun).(*ast.SelectorExpr); ok {
+		if selection := fc.pass.TypesInfo.Selections[sel]; selection != nil {
+			if selection.Kind() != types.MethodVal || len(selection.Index()) != 1 {
+				return nil
+			}
+			receiver = sel.X
+		}
+	}
+	var edges []paramFieldForwardEdge
+	add := func(idx int, expr ast.Expr) bool {
+		source, ok := fc.resolveReturnParamSource(expr)
+		if !ok {
+			return false
+		}
+		edges = append(edges, paramFieldForwardEdge{
+			callerParamIdx: source.Idx,
+			callerPrefix:   source.Path,
+			callee:         target.Origin,
+			calleeParamIdx: idx,
+		})
+		return true
+	}
+	if recv := target.Origin.Signature().Recv(); recv != nil {
+		if receiver == nil {
+			return nil
+		}
+		if _, isInterface := recv.Type().Underlying().(*types.Interface); isInterface {
+			return nil
+		}
+		if !add(annotation.ReceiverParamIndex, receiver) {
+			return nil
+		}
+	}
+	for i, arg := range call.Args {
+		if i >= target.Signature.Params().Len() {
+			break
+		}
+		if _, isInterface := target.Signature.Params().At(i).Type().Underlying().(*types.Interface); isInterface {
+			return nil
+		}
+		if !add(i, arg) {
+			return nil
+		}
+	}
+	return edges
+}
+
+// closeReturnParamSources composes callee sources through return forwarding edges until a fixpoint.
+// Edges form chains (`return f()` inside `return g()`), so newly composed wrapper sources must feed
+// back in for callers of the wrapper to resolve. Conflicting sources remain in the set so lookups
+// reject them as ambiguous.
+func closeReturnParamSources(sources returnParamSourceSet, edges map[*types.Func][]returnForwardEdge) {
+	changed := true
+	for changed {
+		changed = false
+		for fn, es := range edges {
+			for _, edge := range es {
+				if composeReturnParamSources(sources, fn, edge) {
+					changed = true
+				}
+			}
+		}
+	}
+}
+
+// composeReturnParamSources re-roots every composable source of edge's callee onto fn through
+// the matching parameter forwarding edge, reporting whether any source was newly added.
+func composeReturnParamSources(sources returnParamSourceSet, fn *types.Func, edge returnForwardEdge) bool {
+	if len(edge.paramForwardingEdges) == 0 {
+		return false
+	}
+	changed := false
+	for source := range sources[edge.callee] {
+		if source.Result.Idx != edge.calleeResultIdx {
+			continue
+		}
+		for _, paramEdge := range edge.paramForwardingEdges {
+			if paramEdge.calleeParamIdx != source.Param.Idx {
+				continue
+			}
+			paramPath := paramEdge.callerPrefix.Join(source.Param.Path)
+			if !paramPath.IsRoot() && !paramFieldPathIsAcyclic(fn, paramEdge.callerParamIdx, paramPath) {
+				break
+			}
+			if sources.add(fn, ReturnParamSource{
+				Result: IndexedFieldPath{Idx: edge.callerResultIdx, Path: source.Result.Path},
+				Param:  IndexedFieldPath{Idx: paramEdge.callerParamIdx, Path: paramPath},
+			}) {
+				changed = true
+			}
+			break
+		}
+	}
+	return changed
 }
 
 // recordFieldParamSource records the param source of one construction field: a field at path
@@ -171,10 +279,8 @@ func (fc *functionCollector) recordFieldParamSource(resultIdx int, path annotati
 	})
 }
 
-// dropMixedResultParamSources removes every param source of a result index that has an in-package
-// construction return site alongside a whole-result source. Such a result sometimes carries the
-// parameter and sometimes a fresh object, so no context-insensitive source is sound for it;
-// dropping is a deliberate under-report.
+// dropMixedResultParamSources drops sources for results that are both constructed and forwarded.
+// It runs before closure so the ambiguity cannot propagate into wrappers.
 func (c *collectedFieldEffects) dropMixedResultParamSources() {
 	for fn, results := range c.resultsWithConstructSite {
 		for idx := range results {
@@ -185,8 +291,23 @@ func (c *collectedFieldEffects) dropMixedResultParamSources() {
 					break
 				}
 			}
+			if !mixed {
+				for _, edge := range c.returnForwardingEdges[fn] {
+					if edge.callerResultIdx == idx && len(edge.paramForwardingEdges) > 0 {
+						mixed = true
+						break
+					}
+				}
+			}
 			if mixed {
 				c.dropReturnParamSources(fn, idx)
+				edges := c.returnForwardingEdges[fn]
+				for i := range edges {
+					if edges[i].callerResultIdx == idx {
+						edges[i].paramForwardingEdges = nil
+					}
+				}
+				c.returnForwardingEdges[fn] = edges
 			}
 		}
 	}
@@ -195,6 +316,14 @@ func (c *collectedFieldEffects) dropMixedResultParamSources() {
 func (c *collectedFieldEffects) dropReturnParamSources(fn *types.Func, result int) {
 	for key := range c.summary.returnParamSources[fn] {
 		if key.Result.Idx == result {
+			delete(c.summary.returnParamSources[fn], key)
+		}
+	}
+}
+
+func (c *collectedFieldEffects) dropWholeResultParamSources(fn *types.Func, result int) {
+	for key := range c.summary.returnParamSources[fn] {
+		if key.Result.Idx == result && key.Result.Path.IsRoot() {
 			delete(c.summary.returnParamSources[fn], key)
 		}
 	}

--- a/assertion/function/structfieldeffects/testdata/src/go.uber.org/returneffects/paramdependent.go
+++ b/assertion/function/structfieldeffects/testdata/src/go.uber.org/returneffects/paramdependent.go
@@ -115,3 +115,86 @@ func closureReassignedParam(y *Outer, z *Outer) *Outer { // expect_effects:
 func spreadReturn(y *Outer) (*Outer, error) { // expect_effects:
 	return forwardWithErr(y)
 }
+
+// A forwarded return call composes the callee's param sources onto the wrapper.
+func forwardViaCall(y *Outer) *Outer { // expect_effects: return_param_source:0::0:
+	return forwardParam(y)
+}
+
+// Composition re-roots the callee's parameter path under the forwarded parameter's field prefix.
+func forwardProjectionViaCall(y *Outer) *Node { // expect_effects: return_param_source:0::0:Mid param_reads:0:Mid
+	return forwardParamProjection(y)
+}
+
+// Field-level sources compose unchanged on the result side.
+func newPairViaCall(existing, requested *Leaf) *Pair { // expect_effects: return_param_source:0:Existing:0: return_param_source:0:Requested:1:
+	return newPair(existing, requested)
+}
+
+// Multi-return wrappers do not compose forwarding edges.
+func walkRec(r *Rec) *Rec { // expect_effects: param_reads:0:Self param_reads:0:Ptr
+	if r.Ptr == nil {
+		return r
+	}
+	return walkRec(r.Self)
+}
+
+// A forwarded call with a non-parameter argument composes nothing: the wrapper's result is not
+// supplied by the wrapper's own caller.
+func forwardWithLocalArg(y *Outer) *Pair { // expect_effects:
+	return newPair(nil, &Leaf{})
+}
+
+func newOuter() *Outer { // expect_effects: return_effects:0:Mid return_effects:0:Value.Child
+	return &Outer{}
+}
+
+// A non-source branch makes a multi-return wrapper unsupported.
+func forwardOrNew(y *Outer, pick bool) *Outer { // expect_effects: return_effects:0:Mid return_effects:0:Value.Child
+	if pick {
+		return forwardParam(y)
+	}
+	return newOuter()
+}
+
+func (o *Outer) selfParam() *Outer { // expect_effects: return_param_source:0::-1:
+	return o
+}
+
+func forwardMethodValue(y *Outer) *Outer { // expect_effects: return_param_source:0::0:
+	return y.selfParam()
+}
+
+// Method expressions do not compose because the receiver is an explicit argument.
+func forwardMethodExpr(y *Outer) *Outer { // expect_effects:
+	return (*Outer).selfParam(y)
+}
+
+type outerHolder struct{ *Outer }
+
+// Promoted methods do not compose because the receiver includes an implicit field path.
+func forwardPromotedMethod(h *outerHolder) *Outer { // expect_effects:
+	return h.selfParam()
+}
+
+type outerSlice struct{ Values []*Outer }
+
+func packOuter(values ...*Outer) *outerSlice { // expect_effects: return_param_source:0:Values:0:
+	return &outerSlice{Values: values}
+}
+
+// Variadic calls do not provide one expression for the variadic parameter.
+func forwardVariadic(y, z *Outer) *outerSlice { // expect_effects:
+	return packOuter(y, z)
+}
+
+type anyBox struct{ Value any }
+
+func packAny(value any) *anyBox { // expect_effects: return_param_source:0:Value:0:
+	return &anyBox{Value: value}
+}
+
+// Interface boxing can change shallow nilability, so it does not compose.
+func forwardInterface(y *Outer) *anyBox { // expect_effects:
+	return packAny(y)
+}

--- a/testdata/src/structinitv2/returnshape/app/app.go
+++ b/testdata/src/structinitv2/returnshape/app/app.go
@@ -56,14 +56,14 @@ func useForwardParamProjection() {
 	print(b.Child.Ptr) //want "field `Child` of result 0 of `ForwardParamProjection`"
 }
 
-// Transitive parameter sources are not resolved.
+// Transitive forwarding resolves against this caller's argument.
 func useForwardParamTransitive() {
 	t := &lib.Outer{Mid: &lib.Node{}}
 	b := lib.ForwardParamTransitive(t)
-	print(b.Mid.Child.Ptr)
+	print(b.Mid.Child.Ptr) //want "field `Mid.Child` of result 0 of `ForwardParamTransitive`"
 }
 
-// The transitive tie carries t's real (non-nil) shape; no flag.
+// A safe caller does not inherit another call's nil argument.
 func useForwardParamTransitiveSafe() {
 	t := &lib.Outer{Mid: &lib.Node{Child: &lib.Leaf{}}}
 	b := lib.ForwardParamTransitive(t)
@@ -78,11 +78,11 @@ func useForwardParamAmbiguous() {
 	print(b.Mid.Child.Ptr)
 }
 
-// Cross-package transitive parameter sources are not resolved.
+// Cross-package forwarding resolves against this caller's argument.
 func useForwardParamCrossPkg() {
 	t := &lib.Outer{Mid: &lib.Node{}}
 	b := mid.ForwardParamCrossPkg(t)
-	print(b.Mid.Child.Ptr)
+	print(b.Mid.Child.Ptr) //want "field `Mid.Child` of result 0 of `ForwardParamCrossPkg`"
 }
 
 // Mixed construct/forward results retain concrete effects but no parameter source.
@@ -172,4 +172,63 @@ func useIdenticalCallsStayDistinct() {
 	t.In = &lib.Inner{Child: &lib.Leaf{}}
 	second := t.ReceiverProjection()
 	print(second.Child.Ptr)
+}
+
+// A whole-value projection remains caller-sensitive through a forwarding call.
+func useForwardProjectionTransitiveNil() {
+	t := &lib.Wrap{}
+	print(lib.ForwardProjectionTransitive(t).Child.Ptr) //want "uninitialized field `In`"
+}
+
+func useForwardProjectionTransitiveSafe() {
+	t := &lib.Wrap{In: &lib.Inner{Child: &lib.Leaf{}}}
+	print(lib.ForwardProjectionTransitive(t).Child.Ptr)
+}
+
+// The shallow projection source also survives a cross-package forwarding hop.
+func useForwardProjectionCrossPkgNil() {
+	t := &lib.Wrap{}
+	print(mid.ForwardProjectionCrossPkg(t).Child.Ptr) //want "uninitialized field `In`"
+}
+
+func useForwardProjectionCrossPkgSafe() {
+	t := &lib.Wrap{In: &lib.Inner{Child: &lib.Leaf{}}}
+	print(mid.ForwardProjectionCrossPkg(t).Child.Ptr)
+}
+
+// The no-poison guarantee survives transitive composition through `return g(args)`.
+func usePairViaCallNoPoison() {
+	ptr := 1
+	requested := &lib.Leaf{Ptr: &ptr}
+	create := lib.NewPairViaCall(nil, requested)
+	print(*create.Requested.Ptr)
+	existing := &lib.Leaf{Ptr: &ptr}
+	update := lib.NewPairViaCall(existing, requested)
+	print(*update.Existing.Ptr)
+}
+
+// The composed field-level source keeps the true positive at its own call site.
+func usePairViaCallBad() {
+	ptr := 1
+	requested := &lib.Leaf{Ptr: &ptr}
+	bad := lib.NewPairViaCall(nil, requested)
+	print(*bad.Existing.Ptr) //want "field `Existing` of result 0"
+}
+
+// The no-poison guarantee also survives a cross-package forwarding hop.
+func useForwardPairNoPoison() {
+	ptr := 1
+	requested := &lib.Leaf{Ptr: &ptr}
+	create := mid.ForwardPair(nil, requested)
+	print(*create.Requested.Ptr)
+	existing := &lib.Leaf{Ptr: &ptr}
+	update := mid.ForwardPair(existing, requested)
+	print(*update.Existing.Ptr)
+}
+
+// Cross-package field sources keep the bad call visible.
+func useForwardPairBad() {
+	requested := &lib.Leaf{}
+	bad := mid.ForwardPair(nil, requested)
+	print(*bad.Existing.Ptr) //want "field `Existing` of result 0"
 }

--- a/testdata/src/structinitv2/returnshape/lib/lib.go
+++ b/testdata/src/structinitv2/returnshape/lib/lib.go
@@ -77,6 +77,11 @@ func ForwardParamTransitive(y *Outer) *Outer {
 	return ForwardParam(y)
 }
 
+// ForwardProjectionTransitive forwards a projected parameter field through another call.
+func ForwardProjectionTransitive(y *Wrap) *Inner {
+	return ForwardParamProjection(y)
+}
+
 // ForwardParamAmbiguous forwards a different parameter on each return site. Because the result could
 // be either parameter, the caller-side tie bails — a documented under-report.
 func ForwardParamAmbiguous(y *Outer, z *Outer, pick bool) *Outer {
@@ -133,4 +138,10 @@ func NewPair(existing, requested *Leaf) *Pair {
 func NewPairAfterNil(existing, requested *Leaf) *Pair {
 	existing.Ptr = nil
 	return &Pair{Existing: existing, Requested: requested}
+}
+
+// NewPairViaCall pins transitive composition of field-level param forwarding through
+// `return g(args)`.
+func NewPairViaCall(existing, requested *Leaf) *Pair {
+	return NewPair(existing, requested)
 }

--- a/testdata/src/structinitv2/returnshape/mid/mid.go
+++ b/testdata/src/structinitv2/returnshape/mid/mid.go
@@ -25,3 +25,13 @@ import "structinitv2/returnshape/lib"
 func ForwardParamCrossPkg(y *lib.Outer) *lib.Outer {
 	return lib.ForwardParam(y)
 }
+
+// ForwardProjectionCrossPkg forwards a shallow parameter projection across a package boundary.
+func ForwardProjectionCrossPkg(y *lib.Wrap) *lib.Inner {
+	return lib.ForwardParamProjection(y)
+}
+
+// ForwardPair forwards caller-dependent fields across a package boundary.
+func ForwardPair(existing, requested *lib.Leaf) *lib.Pair {
+	return lib.NewPair(existing, requested)
+}


### PR DESCRIPTION
Preserve parameter-source relationships when a function directly forwards another call, so callers of wrappers remain isolated instead of sharing result nilability.

Changes
- Close supported result-to-parameter relationships through single-return forwarding functions.
- Reject ambiguous multi-return, constructed, variadic, dynamic, and non-parameter forwarding paths.
- Restore transitive and cross-package forwarding coverage.