### PR TITLE
feat(struct-init-v2): correlate result fields with successful returns

### DIFF
--- a/assertion/function/assertiontree/backprop.go
+++ b/assertion/function/assertiontree/backprop.go
@@ -853,13 +853,19 @@ func backpropAcrossManyToOneAssignment(rootNode *RootAssertionNode, lhs, rhs []a
 			continue
 		}
 
+		// Match guards before field production detaches the tracked consumers.
+		rootNode.AddGuardMatch(lhsVal, ContinueTracking)
+
 		// Bind return fields before LHS production detaches its subtree.
 		if rootNode.functionContext.functionConfig.EnableStructInitV2 {
 			if funcObj := typeutil.StaticCallee(rootNode.Pass().TypesInfo, rhsVal); funcObj != nil {
 				sig := funcObj.Type().(*types.Signature)
 				if i < sig.Results().Len() {
 					if typeshelper.AsDeeplyStruct(sig.Results().At(i).Type()) != nil {
-						rootNode.addCallResultFieldProducers(lhsVal, rhsVal, funcObj, i)
+						// Non-error results require the caller to check the companion error or ok value.
+						needsGuard := (typeshelper.FuncIsErrReturning(sig) || typeshelper.FuncIsOkReturning(sig)) &&
+							i != sig.Results().Len()-1
+						rootNode.addCallResultFieldProducers(lhsVal, rhsVal, funcObj, i, needsGuard)
 					}
 				}
 			}
@@ -874,7 +880,6 @@ func backpropAcrossManyToOneAssignment(rootNode *RootAssertionNode, lhs, rhs []a
 		// beforeTriggersLastIndex is used to find the newly added triggers on the next line
 		beforeTriggersLastIndex := len(rootNode.triggers)
 
-		rootNode.AddGuardMatch(lhsVal, ContinueTracking)
 		rootNode.AddProduction(&annotation.ProduceTrigger{
 			Annotation: producers[i].GetShallow().Annotation,
 			Expr:       lhsVal,

--- a/assertion/function/assertiontree/rich_check_effect.go
+++ b/assertion/function/assertiontree/rich_check_effect.go
@@ -565,6 +565,10 @@ func guardExpr(rootNode *RootAssertionNode, expr TrackableExpr, nonce guard.Nonc
 		lookedUpNode.SetConsumeTriggers(
 			annotation.ConsumeTriggerSliceAsGuarded(
 				lookedUpNode.ConsumeTriggers(), nonce))
+		// Error and ok checks guard tracked result fields as well as the result itself.
+		if rootNode.functionContext.functionConfig.EnableStructInitV2 {
+			guardFieldSubtree(lookedUpNode, nonce)
+		}
 	}
 }
 

--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -516,6 +516,10 @@ func (r *RootAssertionNode) AddGuardMatch(expr ast.Expr, behavior GuardMatchBeha
 				consumers[i].GuardMatched = true
 			}
 		}
+		// Match field guards before result production detaches the consumers.
+		if r.functionContext.functionConfig.EnableStructInitV2 {
+			matchGuardFieldSubtree(currNode, guard)
+		}
 	case ProduceAsNonnil:
 		var newConsumers []*annotation.ConsumeTrigger
 		for _, consumer := range consumers {

--- a/assertion/function/assertiontree/structinitv2.go
+++ b/assertion/function/assertiontree/structinitv2.go
@@ -81,7 +81,7 @@ func (r *RootAssertionNode) addAllocationFieldProducers(lhsVal, rhsVal ast.Expr)
 	if call, ok := ast.Unparen(rhsVal).(*ast.CallExpr); ok {
 		if target, ok := typeshelper.ResolveStaticCallTarget(r.Pass().TypesInfo, call); ok && target.Signature.Results().Len() == 1 {
 			if typeshelper.AsDeeplyStruct(target.Signature.Results().At(0).Type()) != nil {
-				r.addCallResultFieldProducers(lhsVal, call, target.Origin, 0)
+				r.addCallResultFieldProducers(lhsVal, call, target.Origin, 0, false)
 			}
 		}
 	}
@@ -101,13 +101,15 @@ func (r *RootAssertionNode) resultValueHasParamSource(funcObj *types.Func, resul
 	return r.resultPathHasParamSource(funcObj, resultIdx, annotation.FieldPath{})
 }
 
-// addCallResultFieldProducers adds producers for the accessed fields of a call result. Parameter
-// sources use call-scoped sites; unresolved sources are skipped to avoid merging callers.
+// addCallResultFieldProducers adds producers for accessed call-result fields. Parameter sources
+// use call-scoped sites; unresolved sources remain severed. needsGuard requires the caller to
+// check a companion error or ok result before using the fields.
 func (r *RootAssertionNode) addCallResultFieldProducers(
 	base ast.Expr,
 	call *ast.CallExpr,
 	funcObj *types.Func,
 	resultIdx int,
+	needsGuard bool,
 ) {
 	path, _ := r.ParseExprAsProducer(base, false)
 	node, _ := r.lookupPath(path)
@@ -129,14 +131,14 @@ func (r *RootAssertionNode) addCallResultFieldProducers(
 	sources := r.functionContext.boundaryFieldEffects.ReturnParamSources(funcObj)
 	for _, p := range paths {
 		result := structfieldeffects.IndexedFieldPath{Idx: resultIdx, Path: p.path}
-		if r.bindParamSourcedResultFieldAtCall(call, funcObj, sources, result, p.sel) {
+		if r.bindParamSourcedResultFieldAtCall(call, funcObj, sources, result, p.sel, needsGuard) {
 			continue
 		}
 		// Unresolved param sources cannot safely use shared sites.
 		if sources.HasSource(result.Idx, result.Path) {
 			continue
 		}
-		r.addSharedCallResultFieldProducer(p.sel, funcObj, resultIdx, p.path, returnEffects[p.path])
+		r.addSharedCallResultFieldProducer(p.sel, funcObj, resultIdx, p.path, returnEffects[p.path], needsGuard)
 	}
 }
 
@@ -146,6 +148,7 @@ func (r *RootAssertionNode) addSharedCallResultFieldProducer(
 	resultIdx int,
 	resultPath annotation.FieldPath,
 	definiteNil bool,
+	needsGuard bool,
 ) {
 	site := &annotation.StructFieldContextSite{
 		FuncObj: funcObj,
@@ -155,7 +158,7 @@ func (r *RootAssertionNode) addSharedCallResultFieldProducer(
 	}
 	r.AddProduction(&annotation.ProduceTrigger{
 		Annotation: &annotation.StructFieldFromContext{
-			TriggerIfNilable: &annotation.TriggerIfNilable{Ann: site},
+			TriggerIfNilable: &annotation.TriggerIfNilable{Ann: site, NeedsGuard: needsGuard},
 		},
 		Expr: dst,
 	})
@@ -189,6 +192,7 @@ func (r *RootAssertionNode) bindParamSourcedResultFieldAtCall(
 	sources structfieldeffects.ReturnParamSources,
 	result structfieldeffects.IndexedFieldPath,
 	dst ast.Expr,
+	needsGuard bool,
 ) bool {
 	param, ok := sources.ParamPathFromResultPath(result.Idx, result.Path)
 	if !ok {
@@ -207,7 +211,7 @@ func (r *RootAssertionNode) bindParamSourcedResultFieldAtCall(
 	}
 	r.AddProduction(&annotation.ProduceTrigger{
 		Annotation: &annotation.StructFieldFromContext{
-			TriggerIfNilable: &annotation.TriggerIfNilable{Ann: site},
+			TriggerIfNilable: &annotation.TriggerIfNilable{Ann: site, NeedsGuard: needsGuard},
 		},
 		Expr: dst,
 	})
@@ -215,7 +219,8 @@ func (r *RootAssertionNode) bindParamSourcedResultFieldAtCall(
 	return true
 }
 
-// bindShallowCallResultArgs supplies call-scoped sites for parameter-sourced result values.
+// bindShallowCallResultArgs supplies call-scoped result sites from the call's arguments. It runs
+// before param-out so backpropagation observes post-call values.
 func (r *RootAssertionNode) bindShallowCallResultArgs(call *ast.CallExpr, funcObj *types.Func) {
 	sources := r.functionContext.boundaryFieldEffects.ReturnParamSources(funcObj)
 	sig := funcObj.Signature()
@@ -262,8 +267,11 @@ func (r *RootAssertionNode) shallowCallResultSiteProducer(
 		Path:     result.Path,
 		Location: r.LocationOf(call),
 	}
+	sig := funcObj.Signature()
+	needsGuard := (typeshelper.FuncIsErrReturning(sig) || typeshelper.FuncIsOkReturning(sig)) &&
+		resultIdx != sig.Results().Len()-1
 	return &annotation.StructFieldFromContext{
-		TriggerIfNilable: &annotation.TriggerIfNilable{Ann: site},
+		TriggerIfNilable: &annotation.TriggerIfNilable{Ann: site, NeedsGuard: needsGuard},
 	}, true
 }
 
@@ -439,9 +447,35 @@ func (r *RootAssertionNode) collectAccessedFieldPaths(node AssertionNode, base a
 	}
 }
 
-// bindReturnFieldsToContext binds, at a return statement, the fields of each struct-typed return
-// value to that result's return context site, so the returned value's per-field nilability
-// becomes the function's return summary.
+// guardFieldSubtree guards field consumers below node. The caller handles node itself.
+func guardFieldSubtree(node AssertionNode, nonce guard.Nonce) {
+	for _, child := range node.Children() {
+		if _, ok := child.(*fldAssertionNode); !ok {
+			continue
+		}
+		child.SetConsumeTriggers(annotation.ConsumeTriggerSliceAsGuarded(child.ConsumeTriggers(), nonce))
+		guardFieldSubtree(child, nonce)
+	}
+}
+
+// matchGuardFieldSubtree matches guarded field consumers below node.
+func matchGuardFieldSubtree(node AssertionNode, nonce guard.Nonce) {
+	for _, child := range node.Children() {
+		if _, ok := child.(*fldAssertionNode); !ok {
+			continue
+		}
+		consumers := child.ConsumeTriggers()
+		for i, consumer := range consumers {
+			if consumer.Guards.Contains(nonce) && !consumer.GuardMatched {
+				consumers[i].GuardMatched = true
+			}
+		}
+		matchGuardFieldSubtree(child, nonce)
+	}
+}
+
+// bindReturnFieldsToContext binds returned struct fields to their summary. Error-returning
+// functions contribute fields only when the error is definitely nil; unknown errors stay silent.
 func (r *RootAssertionNode) bindReturnFieldsToContext(node *ast.ReturnStmt) {
 	sig := r.FuncObj().Type().(*types.Signature)
 	if len(node.Results) != sig.Results().Len() {
@@ -449,8 +483,7 @@ func (r *RootAssertionNode) bindReturnFieldsToContext(node *ast.ReturnStmt) {
 	}
 	if typeshelper.FuncIsErrReturning(sig) {
 		errExpr := node.Results[sig.Results().Len()-1]
-		// We are not attaching a consumer when we are sure that the the err is definitely non-nil
-		if _, definitelyNonNil := r.getShallowExprNilabilityProducer(errExpr).(*annotation.ProduceTriggerNever); definitelyNonNil {
+		if !isErrorReturnNil(r, errExpr) {
 			return
 		}
 	}

--- a/assertion/function/structfieldeffects/collector.go
+++ b/assertion/function/structfieldeffects/collector.go
@@ -253,11 +253,17 @@ func (fc *functionCollector) collectReturnSites() {
 	statements := returnStatements(fc.fd.Body)
 	allowParamForwarding := len(statements) == 1
 	directSourceSites := make([]int, fc.sig.Results().Len())
+	sourceSiteCount := len(statements)
 	for _, stmt := range statements {
 		// A bare spreading return such as `return f()` is one expression that yields every
 		// result, so len(stmt.Results) is 1 while the signature may have many; we bail out
 		// rather than try to split it, so such multi-result call returns are unsupported.
 		if len(stmt.Results) != fc.sig.Results().Len() {
+			continue
+		}
+		// Error paths do not describe the value observed by a checked caller.
+		if typeshelper.FuncIsErrReturning(fc.sig) && !fc.pass.IsNil(stmt.Results[len(stmt.Results)-1]) {
+			sourceSiteCount--
 			continue
 		}
 		for resultIdx, resultExpr := range stmt.Results {
@@ -279,7 +285,7 @@ func (fc *functionCollector) collectReturnSites() {
 	}
 	for resultIdx, sourceSites := range directSourceSites {
 		if typeshelper.AsDeeplyStruct(fc.sig.Results().At(resultIdx).Type()) == nil ||
-			sourceSites == len(statements) {
+			sourceSites == sourceSiteCount {
 			continue
 		}
 		if fc.collected.resultsWithConstructSite[fc.funcObj][resultIdx] {

--- a/testdata/src/structinitv2/deep/deep.go
+++ b/testdata/src/structinitv2/deep/deep.go
@@ -98,11 +98,14 @@ func useReturnVarDeclNil() {
 	print(b.aptr.aptr.ptr) //want "uninitialized field `aptr`"
 }
 
-// Multi-return assignments bind the struct result by result index.
+// Multi-return assignments bind fields by result index after an ok check.
 func giveNilWithFlag() (*A, bool) { return &A{aptr: &A2{}}, false }
 
 func useMultiReturnNil() {
-	b, _ := giveNilWithFlag()
+	b, ok := giveNilWithFlag()
+	if !ok {
+		return
+	}
 	print(b.aptr.aptr.ptr) //want "uninitialized field `aptr`"
 }
 

--- a/testdata/src/structinitv2/returnerr/funcreturnwitherrors.go
+++ b/testdata/src/structinitv2/returnerr/funcreturnwitherrors.go
@@ -233,3 +233,49 @@ func m13errVarUnchecked() *int {
 	t, _ := giveACompositeOrErrVar()
 	return t.aptr.ptr //want "accessed field `ptr`"
 }
+
+// Parameter sources on an error path must not affect the checked success result.
+func paramFieldOnlyOnError(p *leaf) (*A11, error) {
+	if dummy() {
+		return &A11{aptr: p}, errors.New("boom")
+	}
+	return &A11{aptr: new(leaf)}, nil
+}
+
+func checkedParamFieldErrorPath() *int {
+	t, err := paramFieldOnlyOnError(nil)
+	if err != nil {
+		return new(int)
+	}
+	return t.aptr.ptr
+}
+
+func returnParamWithErr(p *A11) (*A11, error) { return p, nil }
+
+func uncheckedParamResult() {
+	t, _ := returnParamWithErr(&A11{})
+	_ = *t //want "lacking guarding"
+}
+
+func checkedParamResult() {
+	t, err := returnParamWithErr(&A11{})
+	if err != nil {
+		return
+	}
+	_ = *t
+}
+
+func returnParamOnSuccess(p *A11) (*A11, error) {
+	if dummy() {
+		return &A11{}, errors.New("boom")
+	}
+	return p, nil
+}
+
+func checkedNilParamResult() {
+	t, err := returnParamOnSuccess(nil)
+	if err != nil {
+		return
+	}
+	_ = *t //want "nilable value reaches result 0"
+}


### PR DESCRIPTION
Correlate struct-result fields with successful `(value, error)` and `(value, ok)` paths, so checked callers avoid error-path false positives while unchecked callers still report.

Changes
- Collect and bind result fields only from definitely successful return sites.
- Require companion error or ok guards on shallow and field result producers.
- Propagate guard matches through tracked result fields.