### PR TITLE
feat(struct-init-v2): resolve field initializers flow-sensitively

### DIFF
--- a/assertion/function/assertiontree/structinitv2.go
+++ b/assertion/function/assertiontree/structinitv2.go
@@ -378,6 +378,18 @@ func (r *RootAssertionNode) addFieldProducers(structType *types.Struct, fieldIni
 		fieldVal := asthelper.GetFieldVal(fieldInits, field.Name(), numFields, i)
 		nilable := !typeshelper.TypeBarsNilness(field.Type())
 
+		// Locals lack boundary annotations, so move the field subtree to the initializer and let
+		// backpropagation find its current value. Boundary-rooted values keep static snapshots.
+		if fieldVal != nil && r.isLocalRootedValue(fieldVal) {
+			if srcPath, _ := r.ParseExprAsProducer(fieldVal, false); srcPath != nil {
+				dstPath, _ := r.ParseExprAsProducer(fieldSel, false)
+				if lifted, ok := r.LiftFromPath(dstPath); ok && lifted != nil {
+					r.LandAtPath(srcPath, lifted)
+				}
+				continue
+			}
+		}
+
 		switch {
 		case fieldVal != nil:
 			if innerType, innerInits, ok := r.asStructAllocation(fieldVal); ok {
@@ -644,6 +656,18 @@ func (r *RootAssertionNode) bindAllocationFieldsToContext(structType *types.Stru
 		site := &annotation.StructFieldContextSite{
 			FuncObj: funcObj, Kind: kind, Index: index, Path: path,
 		}
+		// Park trackable initializers so backpropagation resolves their value at this return. Formal
+		// parameter flows stay out of shared return sites and resolve through call-scoped sources.
+		if fieldVal != nil {
+			if trackable, _ := r.ParseExprAsProducer(fieldVal, false); trackable != nil {
+				r.AddConsumption(&annotation.ConsumeTrigger{
+					Annotation: &annotation.StructFieldToContext{TriggerIfNonNil: &annotation.TriggerIfNonNil{Ann: site}},
+					Expr:       fieldVal,
+					Guards:     guard.NoGuards(),
+				})
+				continue
+			}
+		}
 		r.AddNewTriggers(annotation.FullTrigger{
 			Producer: &annotation.ProduceTrigger{Annotation: r.getFieldInitNilabilityProducer(structType, fieldInits, i), Expr: valExpr},
 			Consumer: &annotation.ConsumeTrigger{
@@ -692,6 +716,27 @@ func (r *RootAssertionNode) getParamIndex(v *types.Var) (int, bool) {
 	return 0, false
 }
 
+// dropSharedReturnFieldConsumers keeps formal parameters and receivers out of shared return-field
+// sites. Their supported return flows are supplied from each caller's arguments instead.
+func (r *RootAssertionNode) dropSharedReturnFieldConsumers(node AssertionNode) {
+	consumers := node.ConsumeTriggers()
+	kept := consumers[:0]
+	for _, consumer := range consumers {
+		toContext, ok := consumer.Annotation.(*annotation.StructFieldToContext)
+		if ok {
+			if site, ok := toContext.Ann.(*annotation.StructFieldContextSite); ok &&
+				site.FuncObj == r.FuncObj() && site.Kind == annotation.StructFieldReturnContext && !site.Location.IsValid() {
+				continue
+			}
+		}
+		kept = append(kept, consumer)
+	}
+	node.SetConsumeTriggers(kept)
+	for _, child := range node.Children() {
+		r.dropSharedReturnFieldConsumers(child)
+	}
+}
+
 // addParamFieldProducers attaches, at function entry, producers making each nilable field of
 // a struct-typed parameter/receiver nil iff the corresponding parameter context site is inferred
 // nilable.
@@ -708,12 +753,13 @@ func (r *RootAssertionNode) addParamFieldProducers(builtExpr ast.Expr) {
 	if !ok {
 		return
 	}
-	if typeshelper.AsDeeplyStruct(v.Type()) == nil {
-		return
-	}
 	path, _ := r.ParseExprAsProducer(builtExpr, false)
 	node, _ := r.lookupPath(path)
 	if node == nil {
+		return
+	}
+	r.dropSharedReturnFieldConsumers(node)
+	if typeshelper.AsDeeplyStruct(v.Type()) == nil {
 		return
 	}
 	var paths []accessedFieldPath

--- a/nilaway_test.go
+++ b/nilaway_test.go
@@ -132,6 +132,7 @@ func TestStructInitV2(t *testing.T) { //nolint:paralleltest
 	testdata := analysistest.TestData()
 	analysistest.Run(t, testdata, Analyzer,
 		"structinitv2/local",
+		"structinitv2/returnerr",
 		"structinitv2/defaultfield",
 		"structinitv2/deep",
 		"structinitv2/crosspkg/app",

--- a/testdata/src/structinitv2/limitations/flow_only_return.go
+++ b/testdata/src/structinitv2/limitations/flow_only_return.go
@@ -1,0 +1,45 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package limitations
+
+// Flow-only parameter sources remain unsupported. The collector does not follow values through
+// local snapshots, so both callers remain silent until flow-aware collection is added.
+
+type flowLeaf struct {
+	Ptr *int
+}
+
+type flowDiff struct {
+	Value *int
+}
+
+func newFlowDiff(l *flowLeaf) *flowDiff {
+	value := l.Ptr
+	l.Ptr = nil
+	return &flowDiff{Value: value}
+}
+
+func flowOnlySafeCaller() {
+	ptr := 1
+	leaf := &flowLeaf{Ptr: &ptr}
+	diff := newFlowDiff(leaf)
+	print(*diff.Value)
+}
+
+func flowOnlyBadCaller() {
+	leaf := &flowLeaf{}
+	diff := newFlowDiff(leaf)
+	print(*diff.Value)
+}


### PR DESCRIPTION
Resolve struct field initializers from their flow-sensitive local values instead of declaration-time snapshots.

Changes
- Re-home local-rooted field consumers onto the initializer value.
- Park trackable returned-allocation initializers until backpropagation reaches their source.
- Keep formal parameter flows out of shared return sites and activate return-error coverage.