### PR TITLE
Add transitive fact propagation test coverage

### DIFF
--- a/nilaway_test.go
+++ b/nilaway_test.go
@@ -66,6 +66,7 @@ func TestNilAway(t *testing.T) {
 		{name: "SimpleFlow", patterns: []string{"go.uber.org/simpleflow"}},
 		{name: "LoopFlow", patterns: []string{"go.uber.org/loopflow"}},
 		{name: "MethodImplementation", patterns: []string{"go.uber.org/methodimplementation/..."}},
+		{name: "TransitiveFacts", patterns: []string{"go.uber.org/transitivefacts/..."}},
 		{name: "NamedReturn", patterns: []string{"go.uber.org/namedreturn"}},
 		{name: "IgnoreGenerated", patterns: []string{"go.uber.org/ignoregenerated"}},
 		{name: "IgnorePackage", patterns: []string{"ignoredpkg1", "ignoredpkg2"}},

--- a/testdata/src/go.uber.org/transitivefacts/downstream/downstream.go
+++ b/testdata/src/go.uber.org/transitivefacts/downstream/downstream.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package downstream
+
+import "go.uber.org/transitivefacts/middle"
+
+func DerefThroughTransitiveFacts() {
+	print(*middle.Source()) // want "result 0 of `Source.*` dereferenced"
+}

--- a/testdata/src/go.uber.org/transitivefacts/downstream/downstream.go
+++ b/testdata/src/go.uber.org/transitivefacts/downstream/downstream.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Uber Technologies, Inc.
+//  Copyright (c) 2026 Uber Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,10 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package downstream is the final hop of the transitive-facts chain. It imports ONLY middle —
+// not upstream. Calling Get on the value returned by middle.Make() is legal without importing
+// upstream, but knowing that Get returns nilable requires upstream's inference fact, which must
+// survive transitive re-export through middle for the dereference below to be flagged.
 package downstream
 
 import "go.uber.org/transitivefacts/middle"
 
-func DerefThroughTransitiveFacts() {
-	print(*middle.Source()) // want "result 0 of `Source.*` dereferenced"
+func useTransitive() {
+	// Two-hop flow: Get's return was determined nilable in upstream, whose fact must travel
+	// upstream -> middle -> downstream. Drivers pruning imported package facts miss this error.
+	print(*middle.Make().Get()) //want "result 0 of `Get\\(\\)` dereferenced"
+}
+
+func useOneHop() {
+	// One-hop control: NilableFunc's nilability is in middle's own fact, which every driver
+	// reads directly. This error is reported even by fact-pruning drivers.
+	print(*middle.NilableFunc()) //want "result 0 of `NilableFunc\\(\\)` dereferenced"
 }

--- a/testdata/src/go.uber.org/transitivefacts/middle/middle.go
+++ b/testdata/src/go.uber.org/transitivefacts/middle/middle.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middle
+
+import "go.uber.org/transitivefacts/upstream"
+
+// Source forwards upstream.Source through an intermediate package. The downstream package imports
+// only middle, so detecting the nil flow requires facts to propagate transitively through middle.
+func Source() *int {
+	return upstream.Source()
+}

--- a/testdata/src/go.uber.org/transitivefacts/middle/middle.go
+++ b/testdata/src/go.uber.org/transitivefacts/middle/middle.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Uber Technologies, Inc.
+//  Copyright (c) 2026 Uber Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,12 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package middle is the intermediate hop of the transitive-facts chain. It re-exposes
+// upstream.S through its own API but crucially never calls, guards, or otherwise mentions
+// upstream's S.Get method. Because InferredMap.Export is incremental (it exports only
+// information not already present in upstream maps), this package's fact therefore carries
+// nothing about S.Get: its return nilability lives solely in upstream's fact, and downstream can
+// only learn it if the driver propagates facts transitively.
 package middle
 
 import "go.uber.org/transitivefacts/upstream"
 
-// Source forwards upstream.Source through an intermediate package. The downstream package imports
-// only middle, so detecting the nil flow requires facts to propagate transitively through middle.
-func Source() *int {
-	return upstream.Source()
+// Make wraps upstream.NewS, making upstream.S reachable from this package's API so that the
+// downstream package can call its Get method without importing upstream directly.
+func Make() *upstream.S {
+	return upstream.NewS()
+}
+
+// NilableFunc returns nil directly, so its return site is determined nilable in _this_ package's
+// own incremental map. It serves as the one-hop control for the experiment: even fact-pruning
+// drivers report its unchecked dereference in downstream, proving that direct-import facts still
+// flow while the two-hop fact about upstream's S.Get does not.
+func NilableFunc() *int {
+	return nil
 }

--- a/testdata/src/go.uber.org/transitivefacts/upstream/upstream.go
+++ b/testdata/src/go.uber.org/transitivefacts/upstream/upstream.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Uber Technologies, Inc.
+//  Copyright (c) 2026 Uber Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,9 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package upstream is the root of a three-package chain (upstream <- middle <- downstream) that
+// exercises _transitive_ propagation of NilAway's inference facts: the nilability of S.Get's
+// return is established here, never mentioned in package middle, and consumed in package
+// downstream, which does NOT import this package directly (methods are callable on values
+// obtained through middle's API without naming this package).
+//
+// Under drivers that inherit all package facts across the action graph (analysistest,
+// singlechecker, golangci-lint), the chain works and the error is reported in downstream. Under
+// modular drivers that exchange facts via x/tools' internal/facts encoding (go vet/unitchecker,
+// bazel/nogo), imported package facts are no longer re-exported since x/tools v0.12.0
+// (golang/tools@d75c38746e "internal/facts: don't reexport imported facts unnecessarily"), so
+// this package's fact never reaches downstream and the error there is silently missed.
 package upstream
 
-// nilable(result 0)
-func Source() *int {
+// S is a struct whose Get method below is the carrier of the transitively-needed inference fact.
+type S struct{}
+
+// Get returns nil directly, so its return site is determined nilable in _this_ package's
+// exported InferredMap package fact. Nothing in this package or in middle dereferences it, so
+// the determination reaches a use site only if facts propagate transitively.
+func (s *S) Get() *int {
 	return nil
+}
+
+// NewS returns a non-nil S so that calling methods on the chain is otherwise safe.
+func NewS() *S {
+	return &S{}
 }

--- a/testdata/src/go.uber.org/transitivefacts/upstream/upstream.go
+++ b/testdata/src/go.uber.org/transitivefacts/upstream/upstream.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upstream
+
+// nilable(result 0)
+func Source() *int {
+	return nil
+}

--- a/tools/cmd/integration-test/main.go
+++ b/tools/cmd/integration-test/main.go
@@ -224,11 +224,19 @@ func Run() (err error) {
 			}
 			// TODO: Remove these suppressions once incremental fact exporting is fixed in NilAway.
 			// go vet cannot report diagnostics positioned in an imported package that are
-			// discovered only while analyzing an importing package.
-			for pos := range expected {
+			// discovered only while analyzing an importing package, or diagnostics that require
+			// facts from a transitive dependency.
+			for pos, wants := range expected {
 				switch filepath.ToSlash(filepath.Dir(pos.Filename)) {
 				case "methodimplementation/multipackage/packageB", "nolint/upstream":
 					delete(expected, pos)
+				case "transitivefacts/downstream":
+					for _, want := range wants {
+						if want.String() == "result 0 of `Get\\(\\)` dereferenced" {
+							delete(expected, pos)
+							break
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Add a three-package testdata chain that requires NilAway facts to propagate transitively through an intermediate package. Include the fixture in the unit and integration test suites to verify consistent behavior across all drivers.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>