### PR TITLE
fix(map-read): guard only maps with nilable values

### DIFF
--- a/annotation/util.go
+++ b/annotation/util.go
@@ -44,7 +44,7 @@ func DeepNilabilityAsNamedType(typ types.Type) ProducingAnnotationTrigger {
 		return &ArrayRead{TriggerIfDeepNilable: nameAsDeepTrigger(t.Obj())}
 	case *types.Map:
 		trigger := nameAsDeepTrigger(t.Obj())
-		trigger.NeedsGuard = true
+		trigger.NeedsGuard = typeshelper.IsDeeplyTypeWithNilableElement[*types.Map](t)
 		return &MapRead{
 			TriggerIfDeepNilable: trigger,
 		}
@@ -65,7 +65,7 @@ func DeepNilabilityOfFuncRet(fn *types.Func, retNum int) ProducingAnnotationTrig
 		return &FuncReturnDeep{
 			TriggerIfDeepNilable: &TriggerIfDeepNilable{
 				Ann:        RetKeyFromRetNum(fn, retNum),
-				NeedsGuard: typeshelper.IsDeeplyType[*types.Map](retType)},
+				NeedsGuard: typeshelper.IsDeeplyTypeWithNilableElement[*types.Map](retType)},
 		}
 	}
 	return DeepNilabilityAsNamedType(retType)
@@ -79,7 +79,7 @@ func DeepNilabilityOfFld(fld *types.Var) ProducingAnnotationTrigger {
 			TriggerIfDeepNilable: &TriggerIfDeepNilable{
 				Ann: &FieldAnnotationKey{
 					FieldDecl: fld},
-				NeedsGuard: typeshelper.IsDeeplyType[*types.Map](fld.Type())},
+				NeedsGuard: typeshelper.IsDeeplyTypeWithNilableElement[*types.Map](fld.Type())},
 		}
 	}
 	return DeepNilabilityAsNamedType(fld.Type())
@@ -96,7 +96,7 @@ func DeepNilabilityOfVar(fdecl *types.Func, v *types.Var) ProducingAnnotationTri
 					Ann: &GlobalVarAnnotationKey{
 						VarDecl: v,
 					},
-					NeedsGuard: typeshelper.IsDeeplyType[*types.Map](v.Type())},
+					NeedsGuard: typeshelper.IsDeeplyTypeWithNilableElement[*types.Map](v.Type())},
 			}
 		}
 		if VarIsParam(fdecl, v) {
@@ -115,7 +115,7 @@ func DeepNilabilityOfVar(fdecl *types.Func, v *types.Var) ProducingAnnotationTri
 				Ann: &LocalVarAnnotationKey{
 					VarDecl: v,
 				},
-				NeedsGuard: typeshelper.IsDeeplyType[*types.Map](v.Type()),
+				NeedsGuard: typeshelper.IsDeeplyTypeWithNilableElement[*types.Map](v.Type()),
 			},
 		}
 	}
@@ -195,12 +195,12 @@ func paramAsDeepProducer(fdecl *types.Func, param *types.Var) ProducingAnnotatio
 		return &VariadicFuncParamDeep{
 			TriggerIfNilable: &TriggerIfNilable{
 				Ann:        paramKey,
-				NeedsGuard: typeshelper.IsDeeplyType[*types.Map](param.Type())}}
+				NeedsGuard: typeshelper.IsDeeplyTypeWithNilableElement[*types.Map](param.Type())}}
 	}
 	return &FuncParamDeep{
 		TriggerIfDeepNilable: &TriggerIfDeepNilable{
 			Ann:        paramKey,
-			NeedsGuard: typeshelper.IsDeeplyType[*types.Map](param.Type())},
+			NeedsGuard: typeshelper.IsDeeplyTypeWithNilableElement[*types.Map](param.Type())},
 	}
 }
 

--- a/assertion/function/assertiontree/backprop.go
+++ b/assertion/function/assertiontree/backprop.go
@@ -853,13 +853,19 @@ func backpropAcrossManyToOneAssignment(rootNode *RootAssertionNode, lhs, rhs []a
 			continue
 		}
 
+		// Match guards before field production detaches the tracked consumers.
+		rootNode.AddGuardMatch(lhsVal, ContinueTracking)
+
 		// Bind return fields before LHS production detaches its subtree.
 		if rootNode.functionContext.functionConfig.EnableStructInitV2 {
 			if funcObj := typeutil.StaticCallee(rootNode.Pass().TypesInfo, rhsVal); funcObj != nil {
 				sig := funcObj.Type().(*types.Signature)
 				if i < sig.Results().Len() {
 					if typeshelper.AsDeeplyStruct(sig.Results().At(i).Type()) != nil {
-						rootNode.addCallResultFieldProducers(lhsVal, rhsVal, funcObj, i)
+						// Non-error results require the caller to check the companion error or ok value.
+						needsGuard := (typeshelper.FuncIsErrReturning(sig) || typeshelper.FuncIsOkReturning(sig)) &&
+							i != sig.Results().Len()-1
+						rootNode.addCallResultFieldProducers(lhsVal, rhsVal, funcObj, i, needsGuard)
 					}
 				}
 			}
@@ -874,7 +880,6 @@ func backpropAcrossManyToOneAssignment(rootNode *RootAssertionNode, lhs, rhs []a
 		// beforeTriggersLastIndex is used to find the newly added triggers on the next line
 		beforeTriggersLastIndex := len(rootNode.triggers)
 
-		rootNode.AddGuardMatch(lhsVal, ContinueTracking)
 		rootNode.AddProduction(&annotation.ProduceTrigger{
 			Annotation: producers[i].GetShallow().Annotation,
 			Expr:       lhsVal,

--- a/assertion/function/assertiontree/rich_check_effect.go
+++ b/assertion/function/assertiontree/rich_check_effect.go
@@ -565,6 +565,10 @@ func guardExpr(rootNode *RootAssertionNode, expr TrackableExpr, nonce guard.Nonc
 		lookedUpNode.SetConsumeTriggers(
 			annotation.ConsumeTriggerSliceAsGuarded(
 				lookedUpNode.ConsumeTriggers(), nonce))
+		// Error and ok checks guard tracked result fields as well as the result itself.
+		if rootNode.functionContext.functionConfig.EnableStructInitV2 {
+			guardFieldSubtree(lookedUpNode, nonce)
+		}
 	}
 }
 

--- a/assertion/function/assertiontree/root_assertion_node.go
+++ b/assertion/function/assertiontree/root_assertion_node.go
@@ -516,6 +516,10 @@ func (r *RootAssertionNode) AddGuardMatch(expr ast.Expr, behavior GuardMatchBeha
 				consumers[i].GuardMatched = true
 			}
 		}
+		// Match field guards before result production detaches the consumers.
+		if r.functionContext.functionConfig.EnableStructInitV2 {
+			matchGuardFieldSubtree(currNode, guard)
+		}
 	case ProduceAsNonnil:
 		var newConsumers []*annotation.ConsumeTrigger
 		for _, consumer := range consumers {

--- a/assertion/function/assertiontree/structinitv2.go
+++ b/assertion/function/assertiontree/structinitv2.go
@@ -81,7 +81,7 @@ func (r *RootAssertionNode) addAllocationFieldProducers(lhsVal, rhsVal ast.Expr)
 	if call, ok := ast.Unparen(rhsVal).(*ast.CallExpr); ok {
 		if target, ok := typeshelper.ResolveStaticCallTarget(r.Pass().TypesInfo, call); ok && target.Signature.Results().Len() == 1 {
 			if typeshelper.AsDeeplyStruct(target.Signature.Results().At(0).Type()) != nil {
-				r.addCallResultFieldProducers(lhsVal, call, target.Origin, 0)
+				r.addCallResultFieldProducers(lhsVal, call, target.Origin, 0, false)
 			}
 		}
 	}
@@ -101,13 +101,15 @@ func (r *RootAssertionNode) resultValueHasParamSource(funcObj *types.Func, resul
 	return r.resultPathHasParamSource(funcObj, resultIdx, annotation.FieldPath{})
 }
 
-// addCallResultFieldProducers adds producers for the accessed fields of a call result. Parameter
-// sources use call-scoped sites; unresolved sources are skipped to avoid merging callers.
+// addCallResultFieldProducers adds producers for accessed call-result fields. Parameter sources
+// use call-scoped sites; unresolved sources remain severed. needsGuard requires the caller to
+// check a companion error or ok result before using the fields.
 func (r *RootAssertionNode) addCallResultFieldProducers(
 	base ast.Expr,
 	call *ast.CallExpr,
 	funcObj *types.Func,
 	resultIdx int,
+	needsGuard bool,
 ) {
 	path, _ := r.ParseExprAsProducer(base, false)
 	node, _ := r.lookupPath(path)
@@ -129,14 +131,14 @@ func (r *RootAssertionNode) addCallResultFieldProducers(
 	sources := r.functionContext.boundaryFieldEffects.ReturnParamSources(funcObj)
 	for _, p := range paths {
 		result := structfieldeffects.IndexedFieldPath{Idx: resultIdx, Path: p.path}
-		if r.bindParamSourcedResultFieldAtCall(call, funcObj, sources, result, p.sel) {
+		if r.bindParamSourcedResultFieldAtCall(call, funcObj, sources, result, p.sel, needsGuard) {
 			continue
 		}
 		// Unresolved param sources cannot safely use shared sites.
 		if sources.HasSource(result.Idx, result.Path) {
 			continue
 		}
-		r.addSharedCallResultFieldProducer(p.sel, funcObj, resultIdx, p.path, returnEffects[p.path])
+		r.addSharedCallResultFieldProducer(p.sel, funcObj, resultIdx, p.path, returnEffects[p.path], needsGuard)
 	}
 }
 
@@ -146,6 +148,7 @@ func (r *RootAssertionNode) addSharedCallResultFieldProducer(
 	resultIdx int,
 	resultPath annotation.FieldPath,
 	definiteNil bool,
+	needsGuard bool,
 ) {
 	site := &annotation.StructFieldContextSite{
 		FuncObj: funcObj,
@@ -155,7 +158,7 @@ func (r *RootAssertionNode) addSharedCallResultFieldProducer(
 	}
 	r.AddProduction(&annotation.ProduceTrigger{
 		Annotation: &annotation.StructFieldFromContext{
-			TriggerIfNilable: &annotation.TriggerIfNilable{Ann: site},
+			TriggerIfNilable: &annotation.TriggerIfNilable{Ann: site, NeedsGuard: needsGuard},
 		},
 		Expr: dst,
 	})
@@ -189,6 +192,7 @@ func (r *RootAssertionNode) bindParamSourcedResultFieldAtCall(
 	sources structfieldeffects.ReturnParamSources,
 	result structfieldeffects.IndexedFieldPath,
 	dst ast.Expr,
+	needsGuard bool,
 ) bool {
 	param, ok := sources.ParamPathFromResultPath(result.Idx, result.Path)
 	if !ok {
@@ -207,7 +211,7 @@ func (r *RootAssertionNode) bindParamSourcedResultFieldAtCall(
 	}
 	r.AddProduction(&annotation.ProduceTrigger{
 		Annotation: &annotation.StructFieldFromContext{
-			TriggerIfNilable: &annotation.TriggerIfNilable{Ann: site},
+			TriggerIfNilable: &annotation.TriggerIfNilable{Ann: site, NeedsGuard: needsGuard},
 		},
 		Expr: dst,
 	})
@@ -215,7 +219,8 @@ func (r *RootAssertionNode) bindParamSourcedResultFieldAtCall(
 	return true
 }
 
-// bindShallowCallResultArgs supplies call-scoped sites for parameter-sourced result values.
+// bindShallowCallResultArgs supplies call-scoped result sites from the call's arguments. It runs
+// before param-out so backpropagation observes post-call values.
 func (r *RootAssertionNode) bindShallowCallResultArgs(call *ast.CallExpr, funcObj *types.Func) {
 	sources := r.functionContext.boundaryFieldEffects.ReturnParamSources(funcObj)
 	sig := funcObj.Signature()
@@ -262,8 +267,11 @@ func (r *RootAssertionNode) shallowCallResultSiteProducer(
 		Path:     result.Path,
 		Location: r.LocationOf(call),
 	}
+	sig := funcObj.Signature()
+	needsGuard := (typeshelper.FuncIsErrReturning(sig) || typeshelper.FuncIsOkReturning(sig)) &&
+		resultIdx != sig.Results().Len()-1
 	return &annotation.StructFieldFromContext{
-		TriggerIfNilable: &annotation.TriggerIfNilable{Ann: site},
+		TriggerIfNilable: &annotation.TriggerIfNilable{Ann: site, NeedsGuard: needsGuard},
 	}, true
 }
 
@@ -439,9 +447,35 @@ func (r *RootAssertionNode) collectAccessedFieldPaths(node AssertionNode, base a
 	}
 }
 
-// bindReturnFieldsToContext binds, at a return statement, the fields of each struct-typed return
-// value to that result's return context site, so the returned value's per-field nilability
-// becomes the function's return summary.
+// guardFieldSubtree guards field consumers below node. The caller handles node itself.
+func guardFieldSubtree(node AssertionNode, nonce guard.Nonce) {
+	for _, child := range node.Children() {
+		if _, ok := child.(*fldAssertionNode); !ok {
+			continue
+		}
+		child.SetConsumeTriggers(annotation.ConsumeTriggerSliceAsGuarded(child.ConsumeTriggers(), nonce))
+		guardFieldSubtree(child, nonce)
+	}
+}
+
+// matchGuardFieldSubtree matches guarded field consumers below node.
+func matchGuardFieldSubtree(node AssertionNode, nonce guard.Nonce) {
+	for _, child := range node.Children() {
+		if _, ok := child.(*fldAssertionNode); !ok {
+			continue
+		}
+		consumers := child.ConsumeTriggers()
+		for i, consumer := range consumers {
+			if consumer.Guards.Contains(nonce) && !consumer.GuardMatched {
+				consumers[i].GuardMatched = true
+			}
+		}
+		matchGuardFieldSubtree(child, nonce)
+	}
+}
+
+// bindReturnFieldsToContext binds returned struct fields to their summary. Error-returning
+// functions contribute fields only when the error is definitely nil; unknown errors stay silent.
 func (r *RootAssertionNode) bindReturnFieldsToContext(node *ast.ReturnStmt) {
 	sig := r.FuncObj().Type().(*types.Signature)
 	if len(node.Results) != sig.Results().Len() {
@@ -449,8 +483,7 @@ func (r *RootAssertionNode) bindReturnFieldsToContext(node *ast.ReturnStmt) {
 	}
 	if typeshelper.FuncIsErrReturning(sig) {
 		errExpr := node.Results[sig.Results().Len()-1]
-		// We are not attaching a consumer when we are sure that the the err is definitely non-nil
-		if _, definitelyNonNil := r.getShallowExprNilabilityProducer(errExpr).(*annotation.ProduceTriggerNever); definitelyNonNil {
+		if !isErrorReturnNil(r, errExpr) {
 			return
 		}
 	}

--- a/assertion/function/assertiontree/structinitv2.go
+++ b/assertion/function/assertiontree/structinitv2.go
@@ -378,6 +378,18 @@ func (r *RootAssertionNode) addFieldProducers(structType *types.Struct, fieldIni
 		fieldVal := asthelper.GetFieldVal(fieldInits, field.Name(), numFields, i)
 		nilable := !typeshelper.TypeBarsNilness(field.Type())
 
+		// Locals lack boundary annotations, so move the field subtree to the initializer and let
+		// backpropagation find its current value. Boundary-rooted values keep static snapshots.
+		if fieldVal != nil && r.isLocalRootedValue(fieldVal) {
+			if srcPath, _ := r.ParseExprAsProducer(fieldVal, false); srcPath != nil {
+				dstPath, _ := r.ParseExprAsProducer(fieldSel, false)
+				if lifted, ok := r.LiftFromPath(dstPath); ok && lifted != nil {
+					r.LandAtPath(srcPath, lifted)
+				}
+				continue
+			}
+		}
+
 		switch {
 		case fieldVal != nil:
 			if innerType, innerInits, ok := r.asStructAllocation(fieldVal); ok {
@@ -644,6 +656,18 @@ func (r *RootAssertionNode) bindAllocationFieldsToContext(structType *types.Stru
 		site := &annotation.StructFieldContextSite{
 			FuncObj: funcObj, Kind: kind, Index: index, Path: path,
 		}
+		// Park trackable initializers so backpropagation resolves their value at this return. Formal
+		// parameter flows stay out of shared return sites and resolve through call-scoped sources.
+		if fieldVal != nil {
+			if trackable, _ := r.ParseExprAsProducer(fieldVal, false); trackable != nil {
+				r.AddConsumption(&annotation.ConsumeTrigger{
+					Annotation: &annotation.StructFieldToContext{TriggerIfNonNil: &annotation.TriggerIfNonNil{Ann: site}},
+					Expr:       fieldVal,
+					Guards:     guard.NoGuards(),
+				})
+				continue
+			}
+		}
 		r.AddNewTriggers(annotation.FullTrigger{
 			Producer: &annotation.ProduceTrigger{Annotation: r.getFieldInitNilabilityProducer(structType, fieldInits, i), Expr: valExpr},
 			Consumer: &annotation.ConsumeTrigger{
@@ -692,6 +716,27 @@ func (r *RootAssertionNode) getParamIndex(v *types.Var) (int, bool) {
 	return 0, false
 }
 
+// dropSharedReturnFieldConsumers keeps formal parameters and receivers out of shared return-field
+// sites. Their supported return flows are supplied from each caller's arguments instead.
+func (r *RootAssertionNode) dropSharedReturnFieldConsumers(node AssertionNode) {
+	consumers := node.ConsumeTriggers()
+	kept := consumers[:0]
+	for _, consumer := range consumers {
+		toContext, ok := consumer.Annotation.(*annotation.StructFieldToContext)
+		if ok {
+			if site, ok := toContext.Ann.(*annotation.StructFieldContextSite); ok &&
+				site.FuncObj == r.FuncObj() && site.Kind == annotation.StructFieldReturnContext && !site.Location.IsValid() {
+				continue
+			}
+		}
+		kept = append(kept, consumer)
+	}
+	node.SetConsumeTriggers(kept)
+	for _, child := range node.Children() {
+		r.dropSharedReturnFieldConsumers(child)
+	}
+}
+
 // addParamFieldProducers attaches, at function entry, producers making each nilable field of
 // a struct-typed parameter/receiver nil iff the corresponding parameter context site is inferred
 // nilable.
@@ -708,12 +753,13 @@ func (r *RootAssertionNode) addParamFieldProducers(builtExpr ast.Expr) {
 	if !ok {
 		return
 	}
-	if typeshelper.AsDeeplyStruct(v.Type()) == nil {
-		return
-	}
 	path, _ := r.ParseExprAsProducer(builtExpr, false)
 	node, _ := r.lookupPath(path)
 	if node == nil {
+		return
+	}
+	r.dropSharedReturnFieldConsumers(node)
+	if typeshelper.AsDeeplyStruct(v.Type()) == nil {
 		return
 	}
 	var paths []accessedFieldPath

--- a/assertion/function/structfieldeffects/collector.go
+++ b/assertion/function/structfieldeffects/collector.go
@@ -253,11 +253,17 @@ func (fc *functionCollector) collectReturnSites() {
 	statements := returnStatements(fc.fd.Body)
 	allowParamForwarding := len(statements) == 1
 	directSourceSites := make([]int, fc.sig.Results().Len())
+	sourceSiteCount := len(statements)
 	for _, stmt := range statements {
 		// A bare spreading return such as `return f()` is one expression that yields every
 		// result, so len(stmt.Results) is 1 while the signature may have many; we bail out
 		// rather than try to split it, so such multi-result call returns are unsupported.
 		if len(stmt.Results) != fc.sig.Results().Len() {
+			continue
+		}
+		// Error paths do not describe the value observed by a checked caller.
+		if typeshelper.FuncIsErrReturning(fc.sig) && !fc.pass.IsNil(stmt.Results[len(stmt.Results)-1]) {
+			sourceSiteCount--
 			continue
 		}
 		for resultIdx, resultExpr := range stmt.Results {
@@ -279,7 +285,7 @@ func (fc *functionCollector) collectReturnSites() {
 	}
 	for resultIdx, sourceSites := range directSourceSites {
 		if typeshelper.AsDeeplyStruct(fc.sig.Results().At(resultIdx).Type()) == nil ||
-			sourceSites == len(statements) {
+			sourceSites == sourceSiteCount {
 			continue
 		}
 		if fc.collected.resultsWithConstructSite[fc.funcObj][resultIdx] {

--- a/assertion/function/structfieldeffects/collector.go
+++ b/assertion/function/structfieldeffects/collector.go
@@ -250,7 +250,10 @@ func (fc *functionCollector) collectReturnSites() {
 	fc.stableVars = fc.collectStableStructVars()
 	fc.unstableParams = fc.collectUnstableParamVars()
 
-	for _, stmt := range returnStatements(fc.fd.Body) {
+	statements := returnStatements(fc.fd.Body)
+	allowParamForwarding := len(statements) == 1
+	directSourceSites := make([]int, fc.sig.Results().Len())
+	for _, stmt := range statements {
 		// A bare spreading return such as `return f()` is one expression that yields every
 		// result, so len(stmt.Results) is 1 while the signature may have many; we bail out
 		// rather than try to split it, so such multi-result call returns are unsupported.
@@ -261,9 +264,29 @@ func (fc *functionCollector) collectReturnSites() {
 			if typeshelper.AsDeeplyStruct(fc.sig.Results().At(resultIdx).Type()) == nil {
 				continue
 			}
-			fc.collectReturnSiteEffect(resultIdx, resultExpr)
-			fc.collectWholeResultParamSource(resultIdx, resultExpr)
+			fc.collectReturnSiteEffect(resultIdx, resultExpr, allowParamForwarding)
+			if fc.collectWholeResultParamSource(resultIdx, resultExpr) {
+				directSourceSites[resultIdx]++
+			}
 		}
+	}
+
+	// A forwarding edge is sound only when the result has a single return site. With several
+	// sites, keep direct sources only when every path has one; otherwise the recorded sources do
+	// not describe the result on every path and are dropped as a deliberate under-report.
+	if allowParamForwarding {
+		return
+	}
+	for resultIdx, sourceSites := range directSourceSites {
+		if typeshelper.AsDeeplyStruct(fc.sig.Results().At(resultIdx).Type()) == nil ||
+			sourceSites == len(statements) {
+			continue
+		}
+		if fc.collected.resultsWithConstructSite[fc.funcObj][resultIdx] {
+			// Constructed results are reconciled by dropMixedResultParamSources.
+			continue
+		}
+		fc.collected.dropWholeResultParamSources(fc.funcObj, resultIdx)
 	}
 }
 
@@ -505,8 +528,9 @@ func (fc *functionCollector) collectStableStructVars() map[*types.Var]bool {
 // collectReturnSiteEffect records what one struct-shaped return operand contributes to the
 // effects summary: a construction (direct or through a stable local) enumerates its nil fields
 // and marks the result index as constructed (see markResultWithConstructSite); a direct return of a
-// static call result — or of a stable local bound to one — adds a return forwarding edge.
-func (fc *functionCollector) collectReturnSiteEffect(resultIdx int, resultExpr ast.Expr) {
+// static call result — or of a stable local bound to one — adds a return forwarding edge. A direct
+// call can retain parameter forwarding only when this result has a single return site.
+func (fc *functionCollector) collectReturnSiteEffect(resultIdx int, resultExpr ast.Expr, allowParamForwarding bool) {
 	if source, ok := staticStructAllocation(fc.pass, resultExpr); ok {
 		fc.collected.markResultWithConstructSite(fc.funcObj, resultIdx)
 		fc.enumerateConcreteReturnEffects(resultIdx, source.structType, source.fieldInits, annotation.FieldPath{})
@@ -515,7 +539,11 @@ func (fc *functionCollector) collectReturnSiteEffect(resultIdx int, resultExpr a
 	if call, ok := ast.Unparen(resultExpr).(*ast.CallExpr); ok {
 		target, ok := typeshelper.ResolveStaticCallTarget(fc.pass.TypesInfo, call)
 		if ok && target.Signature.Results().Len() == 1 {
-			fc.addReturnEdge(resultIdx, target, 0)
+			var paramForwardingEdges []paramFieldForwardEdge
+			if allowParamForwarding {
+				paramForwardingEdges = fc.returnCallParamForwardingEdges(call, target)
+			}
+			fc.addReturnEdge(resultIdx, target, 0, paramForwardingEdges)
 		}
 		return
 	}
@@ -533,13 +561,18 @@ func (fc *functionCollector) collectReturnSiteEffect(resultIdx int, resultExpr a
 		return
 	}
 	if source, ok := fc.resultVars[v]; ok {
-		fc.addReturnEdge(resultIdx, source.callee, source.idx)
+		fc.addReturnEdge(resultIdx, source.callee, source.idx, nil)
 	}
 }
 
 // addReturnEdge records a return forwarding edge when the callee resolves to an origin and its
 // forwarded result is struct-shaped.
-func (fc *functionCollector) addReturnEdge(callerResultIdx int, target typeshelper.StaticCallTarget, calleeResultIdx int) {
+func (fc *functionCollector) addReturnEdge(
+	callerResultIdx int,
+	target typeshelper.StaticCallTarget,
+	calleeResultIdx int,
+	paramForwardingEdges []paramFieldForwardEdge,
+) {
 	if target.Origin == nil {
 		return
 	}
@@ -548,9 +581,10 @@ func (fc *functionCollector) addReturnEdge(callerResultIdx int, target typeshelp
 		return
 	}
 	fc.collected.addReturnForwardEdge(fc.funcObj, returnForwardEdge{
-		callerResultIdx: callerResultIdx,
-		callee:          target.Origin,
-		calleeResultIdx: calleeResultIdx,
+		callerResultIdx:      callerResultIdx,
+		callee:               target.Origin,
+		calleeResultIdx:      calleeResultIdx,
+		paramForwardingEdges: paramForwardingEdges,
 	})
 }
 

--- a/assertion/function/structfieldeffects/effects.go
+++ b/assertion/function/structfieldeffects/effects.go
@@ -100,6 +100,7 @@ func (c *collectedFieldEffects) close() *BoundaryFieldEffects {
 	closeParamFieldSets(c.summary.paramReads, c.paramForwardingEdges)
 	closeReturnEffects(c.summary.returnEffects, c.returnForwardingEdges)
 	c.dropMixedResultParamSources()
+	closeReturnParamSources(c.summary.returnParamSources, c.returnForwardingEdges)
 	return c.summary
 }
 
@@ -174,11 +175,14 @@ type paramFieldForwardEdge struct {
 	calleeParamIdx int
 }
 
-// returnForwardEdge records that one result directly returns a callee result.
+// returnForwardEdge records that one result directly returns a callee result. A direct returned
+// call also retains its parameter-forwarding edges when every call input is a stable parameter of
+// the caller; call-backed locals leave paramForwardingEdges empty.
 type returnForwardEdge struct {
-	callerResultIdx int
-	callee          *types.Func
-	calleeResultIdx int
+	callerResultIdx      int
+	callee               *types.Func
+	calleeResultIdx      int
+	paramForwardingEdges []paramFieldForwardEdge
 }
 
 // closeParamFieldSets extends a field-effect set to a fixpoint over the forwarding edges:

--- a/assertion/function/structfieldeffects/return_contracts.go
+++ b/assertion/function/structfieldeffects/return_contracts.go
@@ -29,6 +29,7 @@ import (
 
 	"go.uber.org/nilaway/annotation"
 	"go.uber.org/nilaway/util/asthelper"
+	"go.uber.org/nilaway/util/typeshelper"
 )
 
 // ReturnParamSource records a result (or result field) whose value is the caller's own argument:
@@ -63,12 +64,17 @@ func (s ReturnParamSource) paramPathFromResultPath(resultIdx int, resultPath ann
 // returnParamSourceSet maps each function to its set of return param sources.
 type returnParamSourceSet map[*types.Func]map[ReturnParamSource]bool
 
-// add records source for funcObj, allocating the inner set on first use.
-func (s returnParamSourceSet) add(funcObj *types.Func, source ReturnParamSource) {
+// add records source for funcObj, allocating the inner set on first use. It reports whether
+// the source was newly added.
+func (s returnParamSourceSet) add(funcObj *types.Func, source ReturnParamSource) bool {
 	if s[funcObj] == nil {
 		s[funcObj] = make(map[ReturnParamSource]bool)
 	}
+	if s[funcObj][source] {
+		return false
+	}
 	s[funcObj][source] = true
+	return true
 }
 
 // sortedSources returns funcObj's return param sources in a deterministic order. The sources come
@@ -133,22 +139,124 @@ func (s ReturnParamSources) ParamPathFromResultPath(resultIdx int, resultPath an
 	return param, found
 }
 
-// collectWholeResultParamSource records the whole-result param source of one return operand: a
-// returned parameter or parameter field chain (`return p`, `return p.x`, receiver variants).
-// Disagreeing sources for the same result (a different parameter per return site) are all kept —
-// consumers refuse to answer when sources disagree, which keeps the collected set deterministic. A
-// result index that both constructs in-package and carries a whole-result source is ambiguous and
-// dropped in close(); field-level sources of constructed results are recorded by
-// recordFieldParamSource instead.
-func (fc *functionCollector) collectWholeResultParamSource(resultIdx int, expr ast.Expr) {
-	source, ok := fc.resolveReturnParamSource(expr)
-	if !ok {
-		return
+// collectWholeResultParamSource records a direct parameter source. Forwarded call sources compose
+// through the parameter edges retained on their return forwarding edge.
+func (fc *functionCollector) collectWholeResultParamSource(resultIdx int, expr ast.Expr) bool {
+	if source, ok := fc.resolveReturnParamSource(expr); ok {
+		fc.collected.addReturnParamSource(fc.funcObj, ReturnParamSource{
+			Result: IndexedFieldPath{Idx: resultIdx},
+			Param:  source,
+		})
+		return true
 	}
-	fc.collected.addReturnParamSource(fc.funcObj, ReturnParamSource{
-		Result: IndexedFieldPath{Idx: resultIdx},
-		Param:  source,
-	})
+	return false
+}
+
+// returnCallParamForwardingEdges maps every supported call input to a stable parameter of the
+// caller. Unsupported call shapes return no edges rather than risk relating the result to the
+// wrong caller value.
+func (fc *functionCollector) returnCallParamForwardingEdges(
+	call *ast.CallExpr,
+	target typeshelper.StaticCallTarget,
+) []paramFieldForwardEdge {
+	if target.Origin == nil || target.Signature.Variadic() {
+		return nil
+	}
+	var receiver ast.Expr
+	if sel, ok := ast.Unparen(call.Fun).(*ast.SelectorExpr); ok {
+		if selection := fc.pass.TypesInfo.Selections[sel]; selection != nil {
+			if selection.Kind() != types.MethodVal || len(selection.Index()) != 1 {
+				return nil
+			}
+			receiver = sel.X
+		}
+	}
+	var edges []paramFieldForwardEdge
+	add := func(idx int, expr ast.Expr) bool {
+		source, ok := fc.resolveReturnParamSource(expr)
+		if !ok {
+			return false
+		}
+		edges = append(edges, paramFieldForwardEdge{
+			callerParamIdx: source.Idx,
+			callerPrefix:   source.Path,
+			callee:         target.Origin,
+			calleeParamIdx: idx,
+		})
+		return true
+	}
+	if recv := target.Origin.Signature().Recv(); recv != nil {
+		if receiver == nil {
+			return nil
+		}
+		if _, isInterface := recv.Type().Underlying().(*types.Interface); isInterface {
+			return nil
+		}
+		if !add(annotation.ReceiverParamIndex, receiver) {
+			return nil
+		}
+	}
+	for i, arg := range call.Args {
+		if i >= target.Signature.Params().Len() {
+			break
+		}
+		if _, isInterface := target.Signature.Params().At(i).Type().Underlying().(*types.Interface); isInterface {
+			return nil
+		}
+		if !add(i, arg) {
+			return nil
+		}
+	}
+	return edges
+}
+
+// closeReturnParamSources composes callee sources through return forwarding edges until a fixpoint.
+// Edges form chains (`return f()` inside `return g()`), so newly composed wrapper sources must feed
+// back in for callers of the wrapper to resolve. Conflicting sources remain in the set so lookups
+// reject them as ambiguous.
+func closeReturnParamSources(sources returnParamSourceSet, edges map[*types.Func][]returnForwardEdge) {
+	changed := true
+	for changed {
+		changed = false
+		for fn, es := range edges {
+			for _, edge := range es {
+				if composeReturnParamSources(sources, fn, edge) {
+					changed = true
+				}
+			}
+		}
+	}
+}
+
+// composeReturnParamSources re-roots every composable source of edge's callee onto fn through
+// the matching parameter forwarding edge, reporting whether any source was newly added.
+func composeReturnParamSources(sources returnParamSourceSet, fn *types.Func, edge returnForwardEdge) bool {
+	if len(edge.paramForwardingEdges) == 0 {
+		return false
+	}
+	changed := false
+	for source := range sources[edge.callee] {
+		if source.Result.Idx != edge.calleeResultIdx {
+			continue
+		}
+		for _, paramEdge := range edge.paramForwardingEdges {
+			if paramEdge.calleeParamIdx != source.Param.Idx {
+				continue
+			}
+			paramPath := paramEdge.callerPrefix.Join(source.Param.Path)
+			if !paramPath.IsRoot() && !paramFieldPathIsAcyclic(fn, paramEdge.callerParamIdx, paramPath) {
+				break
+			}
+			if sources.add(fn, ReturnParamSource{
+				Result: IndexedFieldPath{Idx: edge.callerResultIdx, Path: source.Result.Path},
+				Param:  IndexedFieldPath{Idx: paramEdge.callerParamIdx, Path: paramPath},
+			}) {
+				changed = true
+			}
+			break
+		}
+	}
+	return changed
 }
 
 // recordFieldParamSource records the param source of one construction field: a field at path
@@ -171,10 +279,8 @@ func (fc *functionCollector) recordFieldParamSource(resultIdx int, path annotati
 	})
 }
 
-// dropMixedResultParamSources removes every param source of a result index that has an in-package
-// construction return site alongside a whole-result source. Such a result sometimes carries the
-// parameter and sometimes a fresh object, so no context-insensitive source is sound for it;
-// dropping is a deliberate under-report.
+// dropMixedResultParamSources drops sources for results that are both constructed and forwarded.
+// It runs before closure so the ambiguity cannot propagate into wrappers.
 func (c *collectedFieldEffects) dropMixedResultParamSources() {
 	for fn, results := range c.resultsWithConstructSite {
 		for idx := range results {
@@ -185,8 +291,23 @@ func (c *collectedFieldEffects) dropMixedResultParamSources() {
 					break
 				}
 			}
+			if !mixed {
+				for _, edge := range c.returnForwardingEdges[fn] {
+					if edge.callerResultIdx == idx && len(edge.paramForwardingEdges) > 0 {
+						mixed = true
+						break
+					}
+				}
+			}
 			if mixed {
 				c.dropReturnParamSources(fn, idx)
+				edges := c.returnForwardingEdges[fn]
+				for i := range edges {
+					if edges[i].callerResultIdx == idx {
+						edges[i].paramForwardingEdges = nil
+					}
+				}
+				c.returnForwardingEdges[fn] = edges
 			}
 		}
 	}
@@ -195,6 +316,14 @@ func (c *collectedFieldEffects) dropMixedResultParamSources() {
 func (c *collectedFieldEffects) dropReturnParamSources(fn *types.Func, result int) {
 	for key := range c.summary.returnParamSources[fn] {
 		if key.Result.Idx == result {
+			delete(c.summary.returnParamSources[fn], key)
+		}
+	}
+}
+
+func (c *collectedFieldEffects) dropWholeResultParamSources(fn *types.Func, result int) {
+	for key := range c.summary.returnParamSources[fn] {
+		if key.Result.Idx == result && key.Result.Path.IsRoot() {
 			delete(c.summary.returnParamSources[fn], key)
 		}
 	}

--- a/assertion/function/structfieldeffects/testdata/src/go.uber.org/returneffects/paramdependent.go
+++ b/assertion/function/structfieldeffects/testdata/src/go.uber.org/returneffects/paramdependent.go
@@ -115,3 +115,86 @@ func closureReassignedParam(y *Outer, z *Outer) *Outer { // expect_effects:
 func spreadReturn(y *Outer) (*Outer, error) { // expect_effects:
 	return forwardWithErr(y)
 }
+
+// A forwarded return call composes the callee's param sources onto the wrapper.
+func forwardViaCall(y *Outer) *Outer { // expect_effects: return_param_source:0::0:
+	return forwardParam(y)
+}
+
+// Composition re-roots the callee's parameter path under the forwarded parameter's field prefix.
+func forwardProjectionViaCall(y *Outer) *Node { // expect_effects: return_param_source:0::0:Mid param_reads:0:Mid
+	return forwardParamProjection(y)
+}
+
+// Field-level sources compose unchanged on the result side.
+func newPairViaCall(existing, requested *Leaf) *Pair { // expect_effects: return_param_source:0:Existing:0: return_param_source:0:Requested:1:
+	return newPair(existing, requested)
+}
+
+// Multi-return wrappers do not compose forwarding edges.
+func walkRec(r *Rec) *Rec { // expect_effects: param_reads:0:Self param_reads:0:Ptr
+	if r.Ptr == nil {
+		return r
+	}
+	return walkRec(r.Self)
+}
+
+// A forwarded call with a non-parameter argument composes nothing: the wrapper's result is not
+// supplied by the wrapper's own caller.
+func forwardWithLocalArg(y *Outer) *Pair { // expect_effects:
+	return newPair(nil, &Leaf{})
+}
+
+func newOuter() *Outer { // expect_effects: return_effects:0:Mid return_effects:0:Value.Child
+	return &Outer{}
+}
+
+// A non-source branch makes a multi-return wrapper unsupported.
+func forwardOrNew(y *Outer, pick bool) *Outer { // expect_effects: return_effects:0:Mid return_effects:0:Value.Child
+	if pick {
+		return forwardParam(y)
+	}
+	return newOuter()
+}
+
+func (o *Outer) selfParam() *Outer { // expect_effects: return_param_source:0::-1:
+	return o
+}
+
+func forwardMethodValue(y *Outer) *Outer { // expect_effects: return_param_source:0::0:
+	return y.selfParam()
+}
+
+// Method expressions do not compose because the receiver is an explicit argument.
+func forwardMethodExpr(y *Outer) *Outer { // expect_effects:
+	return (*Outer).selfParam(y)
+}
+
+type outerHolder struct{ *Outer }
+
+// Promoted methods do not compose because the receiver includes an implicit field path.
+func forwardPromotedMethod(h *outerHolder) *Outer { // expect_effects:
+	return h.selfParam()
+}
+
+type outerSlice struct{ Values []*Outer }
+
+func packOuter(values ...*Outer) *outerSlice { // expect_effects: return_param_source:0:Values:0:
+	return &outerSlice{Values: values}
+}
+
+// Variadic calls do not provide one expression for the variadic parameter.
+func forwardVariadic(y, z *Outer) *outerSlice { // expect_effects:
+	return packOuter(y, z)
+}
+
+type anyBox struct{ Value any }
+
+func packAny(value any) *anyBox { // expect_effects: return_param_source:0:Value:0:
+	return &anyBox{Value: value}
+}
+
+// Interface boxing can change shallow nilability, so it does not compose.
+func forwardInterface(y *Outer) *anyBox { // expect_effects:
+	return packAny(y)
+}

--- a/nilaway_test.go
+++ b/nilaway_test.go
@@ -132,6 +132,7 @@ func TestStructInitV2(t *testing.T) { //nolint:paralleltest
 	testdata := analysistest.TestData()
 	analysistest.Run(t, testdata, Analyzer,
 		"structinitv2/local",
+		"structinitv2/returnerr",
 		"structinitv2/defaultfield",
 		"structinitv2/deep",
 		"structinitv2/crosspkg/app",

--- a/testdata/src/grouping/errormessage/errormessage-assignment-flow.go
+++ b/testdata/src/grouping/errormessage/errormessage-assignment-flow.go
@@ -115,7 +115,7 @@ func test11(s []*int) {
 	print(*y)
 }
 
-func test12(mp map[int]S, i int) {
+func test12(mp map[int]*S, i int) {
 	x := mp[i] // unrelated assignment, should not be printed in the error message
 	_ = x
 
@@ -123,11 +123,23 @@ func test12(mp map[int]S, i int) {
 	_ = y
 
 	s := mp[i] // relevant assignment, should be printed in the error message
-	consumeS(&s)
+	consumeS(s)
 }
 
 func consumeS(s *S) {
 	print(s.f) //want "`mp\\[i\\]` to `s`"
+}
+
+func test12ValueMapRead(mp map[int]S, i int) {
+	s := mp[i]
+	consumeS(&s)
+}
+
+type test12ValueMap map[int]S
+
+func test12NamedValueMapRead(mp test12ValueMap, i int) {
+	s := mp[i]
+	consumeS(&s)
 }
 
 func retErr() error {

--- a/testdata/src/structinitv2/deep/deep.go
+++ b/testdata/src/structinitv2/deep/deep.go
@@ -98,11 +98,14 @@ func useReturnVarDeclNil() {
 	print(b.aptr.aptr.ptr) //want "uninitialized field `aptr`"
 }
 
-// Multi-return assignments bind the struct result by result index.
+// Multi-return assignments bind fields by result index after an ok check.
 func giveNilWithFlag() (*A, bool) { return &A{aptr: &A2{}}, false }
 
 func useMultiReturnNil() {
-	b, _ := giveNilWithFlag()
+	b, ok := giveNilWithFlag()
+	if !ok {
+		return
+	}
 	print(b.aptr.aptr.ptr) //want "uninitialized field `aptr`"
 }
 

--- a/testdata/src/structinitv2/limitations/flow_only_return.go
+++ b/testdata/src/structinitv2/limitations/flow_only_return.go
@@ -1,0 +1,45 @@
+//  Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package limitations
+
+// Flow-only parameter sources remain unsupported. The collector does not follow values through
+// local snapshots, so both callers remain silent until flow-aware collection is added.
+
+type flowLeaf struct {
+	Ptr *int
+}
+
+type flowDiff struct {
+	Value *int
+}
+
+func newFlowDiff(l *flowLeaf) *flowDiff {
+	value := l.Ptr
+	l.Ptr = nil
+	return &flowDiff{Value: value}
+}
+
+func flowOnlySafeCaller() {
+	ptr := 1
+	leaf := &flowLeaf{Ptr: &ptr}
+	diff := newFlowDiff(leaf)
+	print(*diff.Value)
+}
+
+func flowOnlyBadCaller() {
+	leaf := &flowLeaf{}
+	diff := newFlowDiff(leaf)
+	print(*diff.Value)
+}

--- a/testdata/src/structinitv2/returnerr/funcreturnwitherrors.go
+++ b/testdata/src/structinitv2/returnerr/funcreturnwitherrors.go
@@ -233,3 +233,49 @@ func m13errVarUnchecked() *int {
 	t, _ := giveACompositeOrErrVar()
 	return t.aptr.ptr //want "accessed field `ptr`"
 }
+
+// Parameter sources on an error path must not affect the checked success result.
+func paramFieldOnlyOnError(p *leaf) (*A11, error) {
+	if dummy() {
+		return &A11{aptr: p}, errors.New("boom")
+	}
+	return &A11{aptr: new(leaf)}, nil
+}
+
+func checkedParamFieldErrorPath() *int {
+	t, err := paramFieldOnlyOnError(nil)
+	if err != nil {
+		return new(int)
+	}
+	return t.aptr.ptr
+}
+
+func returnParamWithErr(p *A11) (*A11, error) { return p, nil }
+
+func uncheckedParamResult() {
+	t, _ := returnParamWithErr(&A11{})
+	_ = *t //want "lacking guarding"
+}
+
+func checkedParamResult() {
+	t, err := returnParamWithErr(&A11{})
+	if err != nil {
+		return
+	}
+	_ = *t
+}
+
+func returnParamOnSuccess(p *A11) (*A11, error) {
+	if dummy() {
+		return &A11{}, errors.New("boom")
+	}
+	return p, nil
+}
+
+func checkedNilParamResult() {
+	t, err := returnParamOnSuccess(nil)
+	if err != nil {
+		return
+	}
+	_ = *t //want "nilable value reaches result 0"
+}

--- a/testdata/src/structinitv2/returnshape/app/app.go
+++ b/testdata/src/structinitv2/returnshape/app/app.go
@@ -56,14 +56,14 @@ func useForwardParamProjection() {
 	print(b.Child.Ptr) //want "field `Child` of result 0 of `ForwardParamProjection`"
 }
 
-// Transitive parameter sources are not resolved.
+// Transitive forwarding resolves against this caller's argument.
 func useForwardParamTransitive() {
 	t := &lib.Outer{Mid: &lib.Node{}}
 	b := lib.ForwardParamTransitive(t)
-	print(b.Mid.Child.Ptr)
+	print(b.Mid.Child.Ptr) //want "field `Mid.Child` of result 0 of `ForwardParamTransitive`"
 }
 
-// The transitive tie carries t's real (non-nil) shape; no flag.
+// A safe caller does not inherit another call's nil argument.
 func useForwardParamTransitiveSafe() {
 	t := &lib.Outer{Mid: &lib.Node{Child: &lib.Leaf{}}}
 	b := lib.ForwardParamTransitive(t)
@@ -78,11 +78,11 @@ func useForwardParamAmbiguous() {
 	print(b.Mid.Child.Ptr)
 }
 
-// Cross-package transitive parameter sources are not resolved.
+// Cross-package forwarding resolves against this caller's argument.
 func useForwardParamCrossPkg() {
 	t := &lib.Outer{Mid: &lib.Node{}}
 	b := mid.ForwardParamCrossPkg(t)
-	print(b.Mid.Child.Ptr)
+	print(b.Mid.Child.Ptr) //want "field `Mid.Child` of result 0 of `ForwardParamCrossPkg`"
 }
 
 // Mixed construct/forward results retain concrete effects but no parameter source.
@@ -172,4 +172,63 @@ func useIdenticalCallsStayDistinct() {
 	t.In = &lib.Inner{Child: &lib.Leaf{}}
 	second := t.ReceiverProjection()
 	print(second.Child.Ptr)
+}
+
+// A whole-value projection remains caller-sensitive through a forwarding call.
+func useForwardProjectionTransitiveNil() {
+	t := &lib.Wrap{}
+	print(lib.ForwardProjectionTransitive(t).Child.Ptr) //want "uninitialized field `In`"
+}
+
+func useForwardProjectionTransitiveSafe() {
+	t := &lib.Wrap{In: &lib.Inner{Child: &lib.Leaf{}}}
+	print(lib.ForwardProjectionTransitive(t).Child.Ptr)
+}
+
+// The shallow projection source also survives a cross-package forwarding hop.
+func useForwardProjectionCrossPkgNil() {
+	t := &lib.Wrap{}
+	print(mid.ForwardProjectionCrossPkg(t).Child.Ptr) //want "uninitialized field `In`"
+}
+
+func useForwardProjectionCrossPkgSafe() {
+	t := &lib.Wrap{In: &lib.Inner{Child: &lib.Leaf{}}}
+	print(mid.ForwardProjectionCrossPkg(t).Child.Ptr)
+}
+
+// The no-poison guarantee survives transitive composition through `return g(args)`.
+func usePairViaCallNoPoison() {
+	ptr := 1
+	requested := &lib.Leaf{Ptr: &ptr}
+	create := lib.NewPairViaCall(nil, requested)
+	print(*create.Requested.Ptr)
+	existing := &lib.Leaf{Ptr: &ptr}
+	update := lib.NewPairViaCall(existing, requested)
+	print(*update.Existing.Ptr)
+}
+
+// The composed field-level source keeps the true positive at its own call site.
+func usePairViaCallBad() {
+	ptr := 1
+	requested := &lib.Leaf{Ptr: &ptr}
+	bad := lib.NewPairViaCall(nil, requested)
+	print(*bad.Existing.Ptr) //want "field `Existing` of result 0"
+}
+
+// The no-poison guarantee also survives a cross-package forwarding hop.
+func useForwardPairNoPoison() {
+	ptr := 1
+	requested := &lib.Leaf{Ptr: &ptr}
+	create := mid.ForwardPair(nil, requested)
+	print(*create.Requested.Ptr)
+	existing := &lib.Leaf{Ptr: &ptr}
+	update := mid.ForwardPair(existing, requested)
+	print(*update.Existing.Ptr)
+}
+
+// Cross-package field sources keep the bad call visible.
+func useForwardPairBad() {
+	requested := &lib.Leaf{}
+	bad := mid.ForwardPair(nil, requested)
+	print(*bad.Existing.Ptr) //want "field `Existing` of result 0"
 }

--- a/testdata/src/structinitv2/returnshape/lib/lib.go
+++ b/testdata/src/structinitv2/returnshape/lib/lib.go
@@ -77,6 +77,11 @@ func ForwardParamTransitive(y *Outer) *Outer {
 	return ForwardParam(y)
 }
 
+// ForwardProjectionTransitive forwards a projected parameter field through another call.
+func ForwardProjectionTransitive(y *Wrap) *Inner {
+	return ForwardParamProjection(y)
+}
+
 // ForwardParamAmbiguous forwards a different parameter on each return site. Because the result could
 // be either parameter, the caller-side tie bails — a documented under-report.
 func ForwardParamAmbiguous(y *Outer, z *Outer, pick bool) *Outer {
@@ -133,4 +138,10 @@ func NewPair(existing, requested *Leaf) *Pair {
 func NewPairAfterNil(existing, requested *Leaf) *Pair {
 	existing.Ptr = nil
 	return &Pair{Existing: existing, Requested: requested}
+}
+
+// NewPairViaCall pins transitive composition of field-level param forwarding through
+// `return g(args)`.
+func NewPairViaCall(existing, requested *Leaf) *Pair {
+	return NewPair(existing, requested)
 }

--- a/testdata/src/structinitv2/returnshape/mid/mid.go
+++ b/testdata/src/structinitv2/returnshape/mid/mid.go
@@ -25,3 +25,13 @@ import "structinitv2/returnshape/lib"
 func ForwardParamCrossPkg(y *lib.Outer) *lib.Outer {
 	return lib.ForwardParam(y)
 }
+
+// ForwardProjectionCrossPkg forwards a shallow parameter projection across a package boundary.
+func ForwardProjectionCrossPkg(y *lib.Wrap) *lib.Inner {
+	return lib.ForwardParamProjection(y)
+}
+
+// ForwardPair forwards caller-dependent fields across a package boundary.
+func ForwardPair(existing, requested *lib.Leaf) *lib.Pair {
+	return lib.NewPair(existing, requested)
+}

--- a/util/typeshelper/typeshelper.go
+++ b/util/typeshelper/typeshelper.go
@@ -108,6 +108,18 @@ func IsDeeplyType[T types.Type](t types.Type) bool {
 	})
 }
 
+// IsDeeplyTypeWithNilableElement is like IsDeeplyType, but additionally requires the element type
+// of T to admit nil.
+func IsDeeplyTypeWithNilableElement[T interface {
+	types.Type
+	Elem() types.Type
+}](t types.Type) bool {
+	return underlyingAlwaysSatisfies(t, func(u types.Type) bool {
+		outer, ok := u.(T)
+		return ok && !TypeBarsNilness(outer.Elem())
+	})
+}
+
 // IsDeeplyArrayOrArrayPtr is like IsDeeplyType[*types.Array], but additionally accepts pointers to arrays
 // (again resolving named types, aliases, and type parameters). Slice expressions and range
 // statements auto-dereference pointers to arrays, so for them an operand of either type

--- a/util/typeshelper/typeshelper_test.go
+++ b/util/typeshelper/typeshelper_test.go
@@ -111,6 +111,40 @@ func Generic[A ~[8]int, E ArrayConstraint, U ~[8]int | ~[16]int, X ~[8]int | ~[]
 	}
 }
 
+func TestIsDeeplyTypeWithNilableElement(t *testing.T) {
+	t.Parallel()
+
+	intType := types.Typ[types.Int]
+	ptrType := types.NewPointer(intType)
+	namedMap := types.NewNamed(
+		types.NewTypeName(token.NoPos, types.NewPackage("testpkg", "testpkg"), "NamedMap", nil),
+		types.NewMap(intType, ptrType),
+		nil,
+	)
+
+	tests := []struct {
+		name      string
+		typ       types.Type
+		wantMap   bool
+		wantSlice bool
+	}{
+		{name: "Nil", typ: nil},
+		{name: "MapWithNonNilableElement", typ: types.NewMap(intType, intType)},
+		{name: "MapWithNilableElement", typ: types.NewMap(intType, ptrType), wantMap: true},
+		{name: "NamedMapWithNilableElement", typ: namedMap, wantMap: true},
+		{name: "SliceWithNonNilableElement", typ: types.NewSlice(intType)},
+		{name: "SliceWithNilableElement", typ: types.NewSlice(ptrType), wantSlice: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.wantMap, IsDeeplyTypeWithNilableElement[*types.Map](tt.typ))
+			require.Equal(t, tt.wantSlice, IsDeeplyTypeWithNilableElement[*types.Slice](tt.typ))
+		})
+	}
+}
+
 func TestResolveStaticCallTarget(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Avoid requiring missing-key guards for maps whose element type cannot be nil.

Changes
- Add generic `IsDeeplyTypeWithNilableElement[T]` for named, aliased, and constrained types.
- Use it at deep map producers so value-typed map reads do not emit false positives.
- Keep grouping coverage guard-sensitive and cover map and slice instantiations.