### PR TITLE
test(struct-init-v2): activate limitations coverage

### DIFF
--- a/nilaway_test.go
+++ b/nilaway_test.go
@@ -133,6 +133,7 @@ func TestStructInitV2(t *testing.T) { //nolint:paralleltest
 	analysistest.Run(t, testdata, Analyzer,
 		"structinitv2/local",
 		"structinitv2/returnerr",
+		"structinitv2/limitations",
 		"structinitv2/defaultfield",
 		"structinitv2/deep",
 		"structinitv2/crosspkg/app",


### PR DESCRIPTION
Activate the existing `structinitv2/limitations` package now that its regression cases pass as a whole.

This pins documented false-positive and false-negative boundaries alongside restored map-read, error-return, field-initializer, deep-write, and aliasing coverage.