### PR TITLE
perf(annotation): compare cheap discriminators before annotation equality

### DIFF
--- a/annotation/consume_trigger.go
+++ b/annotation/consume_trigger.go
@@ -2039,11 +2039,12 @@ type ConsumeTrigger struct {
 
 // equals compares two ConsumeTrigger pointers for equality
 func (c *ConsumeTrigger) equals(c2 *ConsumeTrigger) bool {
-	return c.Annotation.equals(c2.Annotation) &&
-		c.Expr == c2.Expr &&
-		c.Guards.Eq(c2.Guards) &&
-		c.GuardMatched == c2.GuardMatched
-
+	// Expr identity and GuardMatched are the cheap, selective discriminators; the annotation and
+	// guard-set comparisons only run for the (rare) pairs that agree on them.
+	return c.Expr == c2.Expr &&
+		c.GuardMatched == c2.GuardMatched &&
+		c.Annotation.equals(c2.Annotation) &&
+		c.Guards.Eq(c2.Guards)
 }
 
 // Copy returns a deep copy of the ConsumeTrigger
@@ -2071,8 +2072,10 @@ func MergeConsumeTriggerSlices(left, right []*ConsumeTrigger) []*ConsumeTrigger 
 
 	addToOut := func(trigger *ConsumeTrigger) {
 		for i, outTrigger := range out {
-			if outTrigger.Annotation.equals(trigger.Annotation) &&
-				outTrigger.Expr == trigger.Expr {
+			// Expr identity is the cheap, selective discriminator; the annotation comparison
+			// only runs for the (rare) same-expression pairs.
+			if outTrigger.Expr == trigger.Expr &&
+				outTrigger.Annotation.equals(trigger.Annotation) {
 				// intersect guard sets - if a guard isn't present in both branches it can't
 				// be considered present before the branch
 				out[i] = &ConsumeTrigger{

--- a/annotation/full_trigger.go
+++ b/annotation/full_trigger.go
@@ -67,17 +67,19 @@ func (t *FullTrigger) truncatedProducerPos(pass *analysishelper.EnhancedPass) to
 
 // equals returns true if the two passed FullTriggers are equal, and false otherwise.
 func (t *FullTrigger) equals(other FullTrigger) bool {
-	return t.Producer.Annotation.equals(other.Producer.Annotation) &&
-		t.Consumer.Annotation.equals(other.Consumer.Annotation) &&
-		t.Consumer.Expr == other.Consumer.Expr &&
-		t.Consumer.GuardMatched == other.Consumer.GuardMatched
+	// Consumer Expr identity and GuardMatched are the cheap, selective discriminators; the
+	// annotation comparisons only run for the (rare) pairs that agree on them.
+	return t.Consumer.Expr == other.Consumer.Expr &&
+		t.Consumer.GuardMatched == other.Consumer.GuardMatched &&
+		t.Producer.Annotation.equals(other.Producer.Annotation) &&
+		t.Consumer.Annotation.equals(other.Consumer.Annotation)
 }
 
 // equalsModuloGuardMatched returns true if the two passed FullTriggers (modulo the GuardMatched field) are equal, and false otherwise.
 func (t *FullTrigger) equalsModuloGuardMatched(other FullTrigger) bool {
-	return t.Producer.Annotation.equals(other.Producer.Annotation) &&
-		t.Consumer.Annotation.equals(other.Consumer.Annotation) &&
-		t.Consumer.Expr == other.Consumer.Expr
+	return t.Consumer.Expr == other.Consumer.Expr &&
+		t.Producer.Annotation.equals(other.Producer.Annotation) &&
+		t.Consumer.Annotation.equals(other.Consumer.Annotation)
 }
 
 // A LocatedRepr wraps another fmt.Stringer with a `token.Position` - for formatting with that position

--- a/annotation/structinitv2.go
+++ b/annotation/structinitv2.go
@@ -116,7 +116,10 @@ func (s *StructFieldContextSite) Object() types.Object { return s.FuncObj }
 
 func (s *StructFieldContextSite) equals(other Key) bool {
 	if other, ok := other.(*StructFieldContextSite); ok {
-		return *s == *other
+		// Order the value comparison so the cheap, selective scalar fields (Kind, Index, FuncObj
+		// identity) run before the Path string and Location compares.
+		return s.Kind == other.Kind && s.Index == other.Index && s.FuncObj == other.FuncObj &&
+			s.Path == other.Path && s.Location == other.Location
 	}
 	return false
 }


### PR DESCRIPTION
Annotation equality repeatedly compares rich metadata while triggers are collected and deduplicated, inflating struct-init-v2 analysis time for pairs that differ in simpler fields. Compare expression identity, guard state, and scalar site fields first so expensive annotation and path comparisons run only for candidate matches; diagnostics remain unchanged.

Performance
- Scoped benchmark total: 10.72s to 9.91s (7.6% faster).
- Whole-closure benchmark total: 24.13s to 23.14s (4.1% faster).
- `go/types` whole-closure: 3.12s to 2.37s (24.0% faster).
