### PR TITLE
Forward API-reachable upstream facts for transitive propagation

### DIFF
--- a/inference/api_surface.go
+++ b/inference/api_surface.go
@@ -81,9 +81,9 @@ type apiSurfaceWalker struct {
 	seen    map[seenEntry]bool
 }
 
-// seenEntry marks a type or an object as visited at a given polarity (see visitType).
+// seenEntry marks a type as visited at a given polarity (see visitType).
 type seenEntry struct {
-	key any
+	typ types.Type
 	out bool
 }
 
@@ -112,7 +112,7 @@ func (w *apiSurfaceWalker) visitType(t types.Type, out bool) {
 	if t == nil {
 		return
 	}
-	entry := seenEntry{key: t, out: out}
+	entry := seenEntry{typ: t, out: out}
 	if w.seen[entry] {
 		return
 	}
@@ -151,28 +151,13 @@ func (w *apiSurfaceWalker) visitType(t types.Type, out bool) {
 	case *types.Interface:
 		// Interfaces are reachable in both polarities: values handed out can be inspected, and
 		// interfaces asked for can be implemented by the importer, whose implementations are
-		// related to the interface methods by NilAway's affiliation analysis.
-		for i := range t.NumMethods() {
-			method := t.Method(i)
-			// An unexported method can neither be called nor implemented from another package,
-			// which incidentally makes the whole interface unimplementable outside its own.
-			if !method.Exported() {
-				continue
-			}
-			w.recordObject(method)
-			w.visitSignature(method.Signature(), out)
-		}
+		// related to the interface methods by NilAway's affiliation analysis. Note that an
+		// unexported method makes the whole interface unimplementable outside its own package.
+		w.visitMethods(t.NumMethods(), t.Method, out)
 	case *types.Named:
 		if out {
 			w.recordObject(t.Obj())
-			for i := range t.NumMethods() {
-				method := t.Method(i)
-				if !method.Exported() {
-					continue
-				}
-				w.recordObject(method)
-				w.visitSignature(method.Signature(), out)
-			}
+			w.visitMethods(t.NumMethods(), t.Method, out)
 		}
 		for i := range t.TypeArgs().Len() {
 			w.visitType(t.TypeArgs().At(i), out)
@@ -184,6 +169,20 @@ func (w *apiSurfaceWalker) visitType(t types.Type, out bool) {
 		w.visitType(t.Underlying(), out)
 	case *types.TypeParam:
 		w.visitType(t.Constraint(), out)
+	}
+}
+
+// visitMethods records and traverses the exported methods of an interface or named type, given its
+// method count and accessor. Unexported methods can neither be called nor implemented from another
+// package, so they are skipped.
+func (w *apiSurfaceWalker) visitMethods(numMethods int, methodAt func(int) *types.Func, out bool) {
+	for i := range numMethods {
+		method := methodAt(i)
+		if !method.Exported() {
+			continue
+		}
+		w.recordObject(method)
+		w.visitSignature(method.Signature(), out)
 	}
 }
 

--- a/inference/api_surface.go
+++ b/inference/api_surface.go
@@ -1,0 +1,203 @@
+//  Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inference
+
+import "go/types"
+
+// upstreamAPISurface returns the set of upstream objects (i.e., objects owned by packages other
+// than the one being analyzed) that a package importing us -- but not our own dependencies --
+// could still reach through our exported API. Objects are keyed by "<pkg path>.<object path>",
+// which is exactly how primitive sites identify the object they annotate (see
+// primitiveSite.ObjectPath), so the returned set can be matched against sites imported from
+// upstream packages.
+//
+// This is the relevance criterion for _forwarding_ upstream inference facts (see
+// InferredMap.Export). An importer can only make an assertion about an upstream object if it can
+// name that object, which in turn requires a value of a type that our API hands out (or an
+// interface it asks for). Upstream objects that our API does not expose are of no use to it:
+// obtaining one requires importing the package that declares it, and importers get the facts of
+// their own imports directly.
+//
+// The walk is polarity-aware. Values flowing _out_ of our API (results of exported functions,
+// exported variables and fields, ...) can be inspected by the importer, so their methods and
+// fields are reachable. Values flowing _in_ (parameters) cannot: the importer must have obtained
+// them from the package that declares them, or from another package's API which -- by this very
+// same rule -- forwards facts about them already. Interfaces are the exception in input position:
+// an importer can implement one, which relates its own annotation sites to those of the interface
+// methods.
+//
+// pkgPaths restricts recording to the upstream packages we actually hold facts about; objects of
+// any other package are skipped without paying for object path encoding. Reachability is still
+// explored _through_ those packages' types, since a type of interest may only be reachable
+// through one that is not.
+func (p *primitivizer) upstreamAPISurface(pkgPaths map[string]bool) map[string]bool {
+	w := &apiSurfaceWalker{
+		primitive: p,
+		local:     p.pass.Pkg,
+		pkgPaths:  pkgPaths,
+		objects:   make(map[string]bool),
+		seen:      make(map[seenEntry]bool),
+	}
+
+	// The exported package-level objects are the entry points of the exported API: everything an
+	// importer can name is obtained by destructuring one of them.
+	scope := p.pass.Pkg.Scope()
+	for _, name := range scope.Names() {
+		obj := scope.Lookup(name)
+		if obj == nil || !obj.Exported() {
+			continue
+		}
+		// The objects themselves belong to this package, so there is nothing to record for them:
+		// facts about them are exported by this package in the first place.
+		w.visitType(obj.Type(), true /* out */)
+	}
+
+	return w.objects
+}
+
+// apiSurfaceWalker traverses the types and objects reachable from a package's exported API,
+// recording the upstream objects it encounters. Traversal is guarded by a seen set, making it
+// terminate on recursive types.
+type apiSurfaceWalker struct {
+	primitive *primitivizer
+	// local is the package being analyzed; its own objects are never recorded.
+	local *types.Package
+	// pkgPaths is the set of upstream package paths worth recording objects for.
+	pkgPaths map[string]bool
+	// objects is the result set, keyed by "<pkg path>.<object path>".
+	objects map[string]bool
+	seen    map[seenEntry]bool
+}
+
+// seenEntry marks a type or an object as visited at a given polarity (see visitType).
+type seenEntry struct {
+	key any
+	out bool
+}
+
+// recordObject records obj if it is an upstream object of interest. All annotation sites of the
+// object are then forwarded, which is what we want: an importer that can name a method can pass
+// arguments to it and consume its results alike.
+func (w *apiSurfaceWalker) recordObject(obj types.Object) {
+	pkg := obj.Pkg()
+	if pkg == nil || pkg == w.local || !w.pkgPaths[pkg.Path()] {
+		return
+	}
+	// Object paths only exist for objects reachable from their own package's exported API (which
+	// is the case here, by construction). Sites of objects without one cannot be matched across
+	// packages in the first place.
+	if path := w.primitive.objectPath(obj); path != "" {
+		w.objects[pkg.Path()+"."+string(path)] = true
+	}
+}
+
+// visitType continues the traversal through the given type, recording the objects (methods,
+// fields, type names) that an importer could reach from a value of that type. out reports whether
+// values of this type flow out of our API (and can hence be inspected by the importer) rather
+// than into it.
+func (w *apiSurfaceWalker) visitType(t types.Type, out bool) {
+	t = types.Unalias(t)
+	if t == nil {
+		return
+	}
+	entry := seenEntry{key: t, out: out}
+	if w.seen[entry] {
+		return
+	}
+	w.seen[entry] = true
+
+	switch t := t.(type) {
+	case *types.Pointer:
+		w.visitType(t.Elem(), out)
+	case *types.Slice:
+		w.visitType(t.Elem(), out)
+	case *types.Array:
+		w.visitType(t.Elem(), out)
+	case *types.Chan:
+		w.visitType(t.Elem(), out)
+	case *types.Map:
+		w.visitType(t.Key(), out)
+		w.visitType(t.Elem(), out)
+	case *types.Struct:
+		for i := range t.NumFields() {
+			field := t.Field(i)
+			// Unexported fields cannot be named by an importer. Embedded ones are still traversed,
+			// since the methods and fields they promote _are_ reachable through them.
+			if !field.Exported() {
+				if field.Embedded() {
+					w.visitType(field.Type(), out)
+				}
+				continue
+			}
+			if out {
+				w.recordObject(field)
+			}
+			w.visitType(field.Type(), out)
+		}
+	case *types.Signature:
+		w.visitSignature(t, out)
+	case *types.Interface:
+		// Interfaces are reachable in both polarities: values handed out can be inspected, and
+		// interfaces asked for can be implemented by the importer, whose implementations are
+		// related to the interface methods by NilAway's affiliation analysis.
+		for i := range t.NumMethods() {
+			method := t.Method(i)
+			// An unexported method can neither be called nor implemented from another package,
+			// which incidentally makes the whole interface unimplementable outside its own.
+			if !method.Exported() {
+				continue
+			}
+			w.recordObject(method)
+			w.visitSignature(method.Signature(), out)
+		}
+	case *types.Named:
+		if out {
+			w.recordObject(t.Obj())
+			for i := range t.NumMethods() {
+				method := t.Method(i)
+				if !method.Exported() {
+					continue
+				}
+				w.recordObject(method)
+				w.visitSignature(method.Signature(), out)
+			}
+		}
+		for i := range t.TypeArgs().Len() {
+			w.visitType(t.TypeArgs().At(i), out)
+		}
+		if origin := t.Origin(); origin != nil && origin != t {
+			w.visitType(origin, out)
+		}
+		// Promoted methods and accessible fields are reached through the underlying type.
+		w.visitType(t.Underlying(), out)
+	case *types.TypeParam:
+		w.visitType(t.Constraint(), out)
+	}
+}
+
+// visitSignature traverses a function signature. Results keep the polarity of the signature,
+// while parameters flip it: for a function the importer calls, results flow out and arguments
+// flow in, and for one it implements or supplies, the reverse holds.
+func (w *apiSurfaceWalker) visitSignature(sig *types.Signature, out bool) {
+	for i := range sig.Results().Len() {
+		w.visitType(sig.Results().At(i).Type(), out)
+	}
+	for i := range sig.Params().Len() {
+		w.visitType(sig.Params().At(i).Type(), !out)
+	}
+	for i := range sig.TypeParams().Len() {
+		w.visitType(sig.TypeParams().At(i), out)
+	}
+}

--- a/inference/inferred_map.go
+++ b/inference/inferred_map.go
@@ -36,7 +36,8 @@ import (
 // with the same informations, but observation functions (observeSiteExplanation and observeImplication)
 // add information only to Mapping. On export, iterations combined with calls to
 // inferredValDiff on shared keys is used to ensure that only
-// information present in `Mapping` but not `UpstreamMapping` is exported.
+// information present in `Mapping` but not `UpstreamMapping` is exported, except for the upstream
+// sites that must be forwarded for transitive fact propagation (see Export).
 type InferredMap struct {
 	primitive       *primitivizer
 	upstreamMapping map[primitiveSite]InferredVal
@@ -98,10 +99,21 @@ func (i *InferredMap) OrderedRange(f func(primitiveSite, InferredVal) bool) {
 	}
 }
 
-// Export only encodes new information not already present in the upstream maps, and it does not
-// encode all (in the go sense; i.e. capitalized) annotation sites (See chooseSitesToExport).
-// This ensures that only _incremental_ information is exported by this package and plays a _vital_
+// Export encodes the information this package contributes to multi-package inference as a
+// package fact. For sites of this package it only encodes the exported (in the go sense; i.e.
+// capitalized) ones and the sites needed to keep the implication graph between them convex (see
+// chooseSitesToExport), and for sites already known upstream it only encodes the information this
+// package adds on top of what upstream already said. This incremental encoding plays a _vital_
 // role in minimizing build output.
+//
+// On top of that increment, Export _forwards_ the upstream information that packages importing us
+// would otherwise never see: modular analyzer drivers (bazel/nogo, go vet / unitchecker) hand a
+// package only the facts of its _direct_ imports, and x/tools does not re-export imported package
+// facts (see golang/tools@d75c38746e), so a fact established two hops away would simply be lost.
+// Forwarding is restricted to the upstream objects that remain reachable from this package's
+// exported API (see primitivizer.upstreamAPISurface), which are precisely the upstream objects
+// that a package importing us but not our dependencies could mention; forwarding everything
+// instead would grow each package's fact with the entire transitive closure of its dependencies.
 func (i *InferredMap) Export(pass *analysishelper.EnhancedPass) {
 	if len(i.mapping.Pairs) == 0 {
 		return
@@ -111,13 +123,20 @@ func (i *InferredMap) Export(pass *analysishelper.EnhancedPass) {
 	// like to export.
 	exported := orderedmap.New[primitiveSite, InferredVal]()
 	sitesToExport := i.chooseSitesToExport()
+	sitesToForward := i.chooseSitesToForward()
 	for _, p := range i.mapping.Pairs {
 		site, val := p.Key, p.Value
-		if !sitesToExport[site] {
+		if !sitesToExport[site] && !sitesToForward[site] {
 			continue
 		}
 
 		if upstreamVal, upstreamPresent := i.upstreamMapping[site]; upstreamPresent {
+			// Forwarded sites are exported in full, since downstream packages may not have access
+			// to the upstream fact this value refines.
+			if sitesToForward[site] {
+				exported.Store(site, val)
+				continue
+			}
 			diff, diffNonempty := inferredValDiff(val, upstreamVal)
 			if diffNonempty && diff != nil {
 				exported.Store(site, diff)
@@ -165,6 +184,44 @@ func (i *InferredMap) GobDecode(input []byte) error {
 
 	buf := bytes.NewBuffer(input)
 	return gob.NewDecoder(s2.NewReader(buf)).Decode(&i.mapping)
+}
+
+// chooseSitesToForward returns the set of sites imported from upstream packages whose (possibly
+// locally refined) values must be re-exported by this package, namely the sites of upstream
+// objects that are still reachable from this package's exported API. Packages importing us can
+// only mention those upstream objects, and under modular drivers this package's fact is the only
+// place they can learn about them (see Export).
+func (i *InferredMap) chooseSitesToForward() map[primitiveSite]bool {
+	// The primitivizer is nil for maps that were decoded from a fact; those are never exported.
+	if len(i.upstreamMapping) == 0 || i.primitive == nil {
+		return nil
+	}
+
+	// Collect the upstream packages we hold facts about, so that the API surface walk below only
+	// pays for the object path encoding of objects that could possibly be matched.
+	pkgPaths := make(map[string]bool)
+	for site := range i.upstreamMapping {
+		if site.ObjectPath != "" {
+			pkgPaths[site.PkgPath] = true
+		}
+	}
+	delete(pkgPaths, i.primitive.pass.Pkg.Path())
+	if len(pkgPaths) == 0 {
+		return nil
+	}
+
+	reachable := i.primitive.upstreamAPISurface(pkgPaths)
+	if len(reachable) == 0 {
+		return nil
+	}
+
+	toForward := make(map[primitiveSite]bool)
+	for site := range i.upstreamMapping {
+		if site.ObjectPath != "" && reachable[site.PkgPath+"."+string(site.ObjectPath)] {
+			toForward[site] = true
+		}
+	}
+	return toForward
 }
 
 // chooseSitesToExport returns the set of AnnotationSites mapped by this InferredMap that are both

--- a/inference/inferred_map.go
+++ b/inference/inferred_map.go
@@ -130,19 +130,17 @@ func (i *InferredMap) Export(pass *analysishelper.EnhancedPass) {
 			continue
 		}
 
-		if upstreamVal, upstreamPresent := i.upstreamMapping[site]; upstreamPresent {
-			// Forwarded sites are exported in full, since downstream packages may not have access
-			// to the upstream fact this value refines.
-			if sitesToForward[site] {
-				exported.Store(site, val)
-				continue
-			}
-			diff, diffNonempty := inferredValDiff(val, upstreamVal)
-			if diffNonempty && diff != nil {
+		upstreamVal, upstreamPresent := i.upstreamMapping[site]
+		switch {
+		// Sites unknown upstream carry no baseline to diff against, and forwarded sites must be
+		// exported in full since downstream packages may not have access to the upstream fact this
+		// value refines. Both cases export the value as-is.
+		case !upstreamPresent, sitesToForward[site]:
+			exported.Store(site, val)
+		default:
+			if diff, diffNonempty := inferredValDiff(val, upstreamVal); diffNonempty && diff != nil {
 				exported.Store(site, diff)
 			}
-		} else {
-			exported.Store(site, val)
 		}
 	}
 
@@ -211,10 +209,6 @@ func (i *InferredMap) chooseSitesToForward() map[primitiveSite]bool {
 	}
 
 	reachable := i.primitive.upstreamAPISurface(pkgPaths)
-	if len(reachable) == 0 {
-		return nil
-	}
-
 	toForward := make(map[primitiveSite]bool)
 	for site := range i.upstreamMapping {
 		if site.ObjectPath != "" && reachable[site.PkgPath+"."+string(site.ObjectPath)] {

--- a/nilaway_test.go
+++ b/nilaway_test.go
@@ -101,9 +101,9 @@ func TestFacts(t *testing.T) {
 
 	t.Logf("Total fact bytes: %.2f KB", float32(factStats.TotalBytes)/1024)
 	require.Positive(t, factStats.TotalBytes, "expected NilAway tests to export some facts")
-	require.Less(t, factStats.TotalBytes, 750*1024,
+	require.Less(t, factStats.TotalBytes, 850*1024,
 		"The gob encoded NilAway facts for all test code is too large (%.2f KB). "+
-			"We expect the total to be less than 750 KB. This heavily affects the artifact sizes of the facts NilAway "+
+			"We expect the total to be less than 850 KB. This heavily affects the artifact sizes of the facts NilAway "+
 			"produces, so the cap should only be increased with justification and thorough testing.", float32(factStats.TotalBytes)/1024)
 }
 

--- a/testdata/src/go.uber.org/transitivefacts/deepdownstream/deepdownstream.go
+++ b/testdata/src/go.uber.org/transitivefacts/deepdownstream/deepdownstream.go
@@ -1,0 +1,26 @@
+//  Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package deepdownstream is the final hop of the four-package transitive-facts chain. It imports
+// ONLY outer, which imports only middle, which imports upstream: the fact about upstream's S.Get
+// therefore has to be forwarded twice, the second time by a package that never imported the
+// package the fact originated in.
+package deepdownstream
+
+import "go.uber.org/transitivefacts/outer"
+
+func useDeepTransitive() {
+	// Three-hop flow: upstream -> middle -> outer -> deepdownstream.
+	print(*outer.MakeWrapper().Inner.Get()) //want "result 0 of `Get\\(\\)` dereferenced"
+}

--- a/testdata/src/go.uber.org/transitivefacts/iface/downstream/downstream.go
+++ b/testdata/src/go.uber.org/transitivefacts/iface/downstream/downstream.go
@@ -1,0 +1,31 @@
+//  Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package downstream implements upstream.Handler without importing upstream: the interface is
+// only ever named by middle, which it does import. That Handle is called with a nil argument was
+// established two hops away, in upstream, so the dereference below is only flagged if that fact
+// is forwarded through middle.
+package downstream
+
+import "go.uber.org/transitivefacts/iface/middle"
+
+type derefHandler struct{}
+
+func (derefHandler) Handle(x *int) {
+	print(*x) //want "function parameter `x` dereferenced"
+}
+
+func useInterface() {
+	middle.Invoke(derefHandler{})
+}

--- a/testdata/src/go.uber.org/transitivefacts/iface/middle/middle.go
+++ b/testdata/src/go.uber.org/transitivefacts/iface/middle/middle.go
@@ -1,0 +1,25 @@
+//  Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package middle re-exposes upstream.Handler in parameter position only, and says nothing itself
+// about the nilability of Handle's parameter.
+package middle
+
+import "go.uber.org/transitivefacts/iface/upstream"
+
+// Invoke takes an upstream.Handler, making the interface implementable by packages that do not
+// import upstream.
+func Invoke(h upstream.Handler) {
+	upstream.Run(h)
+}

--- a/testdata/src/go.uber.org/transitivefacts/iface/upstream/upstream.go
+++ b/testdata/src/go.uber.org/transitivefacts/iface/upstream/upstream.go
@@ -1,0 +1,29 @@
+//  Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package upstream is the root of a transitive-facts chain in which the fact travels through an
+// interface that only ever appears in _parameter_ position downstream of here. Values of an
+// interface type cannot be obtained from middle's API, but an importer can still implement it,
+// which is why such interfaces stay on the forwarded API surface (see primitivizer.upstreamAPISurface).
+package upstream
+
+// Handler is implemented by packages that never import this one, reaching it through middle.
+type Handler interface {
+	Handle(x *int)
+}
+
+// Run establishes, in _this_ package's fact, that Handle's parameter is nilable.
+func Run(h Handler) {
+	h.Handle(nil)
+}

--- a/testdata/src/go.uber.org/transitivefacts/middle/middle.go
+++ b/testdata/src/go.uber.org/transitivefacts/middle/middle.go
@@ -35,3 +35,14 @@ func Make() *upstream.S {
 func NilableFunc() *int {
 	return nil
 }
+
+// Wrapper holds an upstream.S in an exported field, so that a package importing middle -- and
+// through it, a package importing _that_ package -- can reach S.Get without ever naming upstream.
+type Wrapper struct {
+	Inner *upstream.S
+}
+
+// NewWrapper returns a Wrapper with a non-nil Inner.
+func NewWrapper() *Wrapper {
+	return &Wrapper{Inner: upstream.NewS()}
+}

--- a/testdata/src/go.uber.org/transitivefacts/outer/outer.go
+++ b/testdata/src/go.uber.org/transitivefacts/outer/outer.go
@@ -1,0 +1,27 @@
+//  Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package outer is the third hop of the transitive-facts chain (upstream <- middle <- outer <-
+// deepdownstream). It imports ONLY middle, so upstream's fact reaches it by forwarding rather
+// than directly; re-exposing middle.Wrapper keeps upstream.S reachable through its own API, so
+// outer must forward a fact it itself only received by forwarding.
+package outer
+
+import "go.uber.org/transitivefacts/middle"
+
+// MakeWrapper re-exposes middle.Wrapper, and with it the upstream.S reachable through its
+// exported field.
+func MakeWrapper() *middle.Wrapper {
+	return middle.NewWrapper()
+}

--- a/tools/cmd/integration-test/main.go
+++ b/tools/cmd/integration-test/main.go
@@ -222,21 +222,14 @@ func Run() (err error) {
 			for pos, wants := range truths {
 				expected[pos] = wants
 			}
-			// TODO: Remove these suppressions once incremental fact exporting is fixed in NilAway.
+			// TODO: Remove these suppressions once NilAway can report diagnostics outside the
+			// package being analyzed.
 			// go vet cannot report diagnostics positioned in an imported package that are
-			// discovered only while analyzing an importing package, or diagnostics that require
-			// facts from a transitive dependency.
-			for pos, wants := range expected {
+			// discovered only while analyzing an importing package.
+			for pos := range expected {
 				switch filepath.ToSlash(filepath.Dir(pos.Filename)) {
 				case "methodimplementation/multipackage/packageB", "nolint/upstream":
 					delete(expected, pos)
-				case "transitivefacts/downstream":
-					for _, want := range wants {
-						if want.String() == "result 0 of `Get\\(\\)` dereferenced" {
-							delete(expected, pos)
-							break
-						}
-					}
 				}
 			}
 		}


### PR DESCRIPTION
## Problem

Under modular analyzer drivers (`go vet`/`unitchecker`, bazel/nogo), NilAway's inference facts only
propagate **one import hop**. A nilability fact established in package `A` is invisible to a package
`C` that imports `B` which imports `A`.

The root cause is a combination of two things:

1. Modular drivers hand a package only the facts of its **direct** imports.
2. Since x/tools v0.12.0 ([golang/tools@d75c38746e], "internal/facts: don't reexport imported facts
   unnecessarily") the facts framework no longer re-exports imported package facts on a package's
   behalf.

`InferredMap.Export` diffs the merged mapping against `upstreamMapping` and only encodes the local
increment, so anything learned upstream is dropped from `B`'s fact and never reaches `C`.

In-process drivers (`analysistest`, `singlechecker`/the standalone binary, golangci-lint) inherit
all transitive facts through the action graph, which is why this never showed up in our unit tests.

[golang/tools@d75c38746e]: https://github.com/golang/tools/commit/d75c38746e

## Fix

`Export` now additionally **forwards** upstream sites, but only the ones a downstream importer could
actually mention. Forwarding everything would grow every package's fact by the entire transitive
closure of its dependencies (measured below: 14x on our corpus).

The relevance filter is the **exported API type surface** (new `inference/api_surface.go`): starting
from this package's exported package-level objects, we walk the type graph and collect the upstream
objects reachable through it. Three things keep the set small and still sound:

- **Polarity/variance awareness.** Values flowing *out* of the API (results, exported fields and
  vars) are inspectable by an importer, so their objects are recorded. Values flowing *in*
  (parameters) are not — an importer that has such a value must have obtained it elsewhere, and by
  the same rule that other package forwards it. Interfaces are the exception in both polarities,
  since an importer can *implement* one, which NilAway's affiliation analysis reasons about.
- **Exported-only members.** Unexported fields and methods cannot be named from another package, so
  they are not recorded. Embedded unexported fields are still traversed, because the members they
  promote *are* reachable.
- **Object-path keying.** Only upstream packages we actually hold facts about are considered, so the
  walk never pays for `objectpath` encoding it cannot use.

Forwarded sites are exported in full (not diffed), since the downstream package may have no access
to the upstream fact the value refines. The existing diffing algorithm is untouched and still
governs local sites — this change is purely additive to it.

Note that out-of-scope packages export no facts at all (`accumulation/analyzer.go`), so with
`-include-pkgs` set the forwarding cost for stdlib disappears entirely.

## Fact size impact

| corpus | baseline | naive full re-export | this change |
| --- | --- | --- | --- |
| analysistest corpus, no `-include-pkgs` (`TestFacts`) | 572.13 KB | 8062.19 KB (14.1x) | 736.67 KB (1.29x) |
| NilAway on itself, `-include-pkgs=go.uber.org/nilaway` (53 pkgs) | 204.68 KB | 1723.76 KB (8.4x) | 323.43 KB (1.58x) |

The `TestFacts` budget is raised 750 KB -> 850 KB accordingly. `TestFacts` is the worst case: it runs
with no `-include-pkgs`, so every stdlib package participates.

Two intermediate measurements, for reference on where the savings come from: a naive walk without
polarity awareness landed at 899.46 KB, polarity alone brought it to 853.88 KB, and exported-only
member recording brought it to 729.86 KB (forwarded sites 3190 -> 1189).

## Tests

- `testdata/src/go.uber.org/transitivefacts/` gains a 3-hop case (`middle.Wrapper` exposes an
  `*upstream.S` field, `outer` re-exposes it, `deepdownstream` dereferences through it without ever
  importing `upstream`) exercising the induction step where a package forwards a fact it itself
  received by forwarding.
- `testdata/src/go.uber.org/transitivefacts/iface/` covers the interface-in-parameter-position case,
  where the importer supplies an implementation of an upstream interface it reaches only through
  `middle`.
- All three cases were verified to genuinely fail under `go vet` without this change.
- The `transitivefacts/downstream` suppression in the integration test driver is removed; go vet now
  reports the same diagnostics as the other drivers there.

Validation: `go test ./...` passes, `make lint` passes, `make integration-test` passes on all three
drivers (Standalone 1039, GoVet 1036, GolangCILint 1039).

## Golden test

Run against stdlib, `main` (a166d2f) vs this branch: **2195 errors on both branches** — nothing
gained, nothing lost. There are +7/-7 diffs where the *same* conflicts now render a longer nil-flow
witness path (an extra `io/multi.go` `multiWriter` hop), and one is re-anchored from
`encoding/base64/base64.go:234:7` to `internal/poll/fd_unix.go:374:54`. This is expected: more
upstream explanation is present at merge time, so explanation-path selection shifts. Flagging it
here since the messages, though not the findings, change.
