### PR TITLE
feat(struct-init-v2): resolve inline allocation argument projections

### DIFF
--- a/assertion/function/assertiontree/structinitv2.go
+++ b/assertion/function/assertiontree/structinitv2.go
@@ -325,10 +325,78 @@ func (r *RootAssertionNode) bindExprNilabilityToContext(expr ast.Expr, site anno
 		r.AddConsumption(consumer)
 		return
 	}
+	if producer, ok := r.inlineAllocationFieldProducer(expr); ok {
+		r.AddNewTriggers(annotation.FullTrigger{
+			Producer: &annotation.ProduceTrigger{Annotation: producer, Expr: expr},
+			Consumer: consumer,
+		})
+		return
+	}
 	r.AddNewTriggers(annotation.FullTrigger{
 		Producer: &annotation.ProduceTrigger{Annotation: r.getShallowExprNilabilityProducer(expr), Expr: expr},
 		Consumer: consumer,
 	})
+}
+
+// inlineAllocationFieldProducer resolves an inline allocation's selected field initializer.
+func (r *RootAssertionNode) inlineAllocationFieldProducer(expr ast.Expr) (annotation.ProducingAnnotationTrigger, bool) {
+	var fields []*types.Var
+	base := ast.Unparen(expr)
+	for {
+		sel, ok := ast.Unparen(base).(*ast.SelectorExpr)
+		if !ok {
+			break
+		}
+		field, ok := r.ObjectOf(sel.Sel).(*types.Var)
+		if !ok {
+			return nil, false
+		}
+		fields = append(fields, field)
+		base = sel.X
+	}
+	if len(fields) == 0 {
+		return nil, false
+	}
+	slices.Reverse(fields)
+
+	structType, fieldInits, ok := r.asStructAllocation(base)
+	if !ok {
+		return nil, false
+	}
+	for i, field := range fields {
+		fieldIdx := -1
+		for j := range structType.NumFields() {
+			if structType.Field(j) == field {
+				fieldIdx = j
+				break
+			}
+		}
+		if fieldIdx < 0 {
+			return nil, false
+		}
+		fieldVal := asthelper.GetFieldVal(fieldInits, field.Name(), structType.NumFields(), fieldIdx)
+		if fieldVal == nil {
+			if !typeshelper.TypeBarsNilness(field.Type()) {
+				return &annotation.StructFieldNil{
+					ProduceTriggerTautology: &annotation.ProduceTriggerTautology{},
+					FieldName:               field.Name(),
+				}, true
+			}
+			structType = typeshelper.AsDeeplyStruct(field.Type())
+			fieldInits = nil
+		} else if i == len(fields)-1 {
+			return r.getShallowExprNilabilityProducer(fieldVal), true
+		} else {
+			structType, fieldInits, ok = r.asStructAllocation(fieldVal)
+			if !ok {
+				return nil, false
+			}
+		}
+		if structType == nil && i != len(fields)-1 {
+			return nil, false
+		}
+	}
+	return &annotation.ProduceTriggerNever{}, true
 }
 
 // getShallowExprNilabilityProducer returns the producer encoding the nilability of the value of expr: an

--- a/testdata/src/structinitv2/returnshape/app/app.go
+++ b/testdata/src/structinitv2/returnshape/app/app.go
@@ -153,6 +153,14 @@ func useForwardParamProjectionShallowSafe() {
 	print(lib.ForwardParamProjection(t).Child.Ptr)
 }
 
+func useForwardParamProjectionInlineNil() {
+	print(lib.ForwardParamProjection(&lib.Wrap{}).Child.Ptr) //want "uninitialized field `In`"
+}
+
+func useForwardParamProjectionInlineSafe() {
+	print(lib.ForwardParamProjection(&lib.Wrap{In: &lib.Inner{Child: &lib.Leaf{}}}).Child.Ptr)
+}
+
 // Receiver field projections use the same shallow result binding.
 func useReceiverProjectionNil() {
 	t := &lib.Wrap{}
@@ -162,6 +170,14 @@ func useReceiverProjectionNil() {
 func useReceiverProjectionSafe() {
 	t := &lib.Wrap{In: &lib.Inner{Child: &lib.Leaf{}}}
 	print(t.ReceiverProjection().Child.Ptr)
+}
+
+func useReceiverProjectionInlineNil() {
+	print((&lib.Wrap{}).ReceiverProjection().Child.Ptr) //want "uninitialized field `In`"
+}
+
+func useReceiverProjectionInlineSafe() {
+	print((&lib.Wrap{In: &lib.Inner{Child: &lib.Leaf{}}}).ReceiverProjection().Child.Ptr)
 }
 
 // Calls at different locations use distinct sites even when otherwise identical.
@@ -183,6 +199,14 @@ func useForwardProjectionTransitiveNil() {
 func useForwardProjectionTransitiveSafe() {
 	t := &lib.Wrap{In: &lib.Inner{Child: &lib.Leaf{}}}
 	print(lib.ForwardProjectionTransitive(t).Child.Ptr)
+}
+
+func useForwardProjectionTransitiveInlineNil() {
+	print(lib.ForwardProjectionTransitive(&lib.Wrap{}).Child.Ptr) //want "uninitialized field `In`"
+}
+
+func useForwardProjectionTransitiveInlineSafe() {
+	print(lib.ForwardProjectionTransitive(&lib.Wrap{In: &lib.Inner{Child: &lib.Leaf{}}}).Child.Ptr)
 }
 
 // The shallow projection source also survives a cross-package forwarding hop.


### PR DESCRIPTION
Parameter-sourced projections from inline struct allocations have no assertion-tree path, so their call-scoped result sites lose omitted or explicit field nilability. Resolve selector chains from allocation initializers so nil projections report without affecting non-nil inline arguments.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>