### PR TITLE
fix(struct-init-v2): drop concrete effects of mixed construct/forward results

### DIFF
--- a/assertion/function/structfieldeffects/effects.go
+++ b/assertion/function/structfieldeffects/effects.go
@@ -99,8 +99,8 @@ func (c *collectedFieldEffects) close() *BoundaryFieldEffects {
 	closeParamFieldSets(c.summary.paramWrites, c.paramForwardingEdges)
 	closeParamFieldSets(c.summary.paramReads, c.paramForwardingEdges)
 	closeReturnEffects(c.summary.returnEffects, c.returnForwardingEdges)
-	c.dropMixedResultParamSources()
 	closeReturnParamSources(c.summary.returnParamSources, c.returnForwardingEdges)
+	c.dropMixedResultParamSources()
 	return c.summary
 }
 

--- a/assertion/function/structfieldeffects/return_contracts.go
+++ b/assertion/function/structfieldeffects/return_contracts.go
@@ -279,10 +279,27 @@ func (fc *functionCollector) recordFieldParamSource(resultIdx int, path annotati
 	})
 }
 
-// dropMixedResultParamSources drops sources for results that are both constructed and forwarded.
-// It runs before closure so the ambiguity cannot propagate into wrappers.
+// dropMixedResultParamSources removes both summaries when a result is constructed and wholly
+// parameter-sourced. It runs after closure so wrappers inherit the mixed state before the drop.
 func (c *collectedFieldEffects) dropMixedResultParamSources() {
+	constructed := make(map[*types.Func]map[int]bool, len(c.resultsWithConstructSite))
+	markConstructed := func(fn *types.Func, idx int) {
+		if constructed[fn] == nil {
+			constructed[fn] = make(map[int]bool)
+		}
+		constructed[fn][idx] = true
+	}
 	for fn, results := range c.resultsWithConstructSite {
+		for idx := range results {
+			markConstructed(fn, idx)
+		}
+	}
+	for fn, effects := range c.summary.returnEffects {
+		for key := range effects {
+			markConstructed(fn, key.Idx)
+		}
+	}
+	for fn, results := range constructed {
 		for idx := range results {
 			mixed := false
 			for source := range c.summary.returnParamSources[fn] {
@@ -291,23 +308,9 @@ func (c *collectedFieldEffects) dropMixedResultParamSources() {
 					break
 				}
 			}
-			if !mixed {
-				for _, edge := range c.returnForwardingEdges[fn] {
-					if edge.callerResultIdx == idx && len(edge.paramForwardingEdges) > 0 {
-						mixed = true
-						break
-					}
-				}
-			}
 			if mixed {
 				c.dropReturnParamSources(fn, idx)
-				edges := c.returnForwardingEdges[fn]
-				for i := range edges {
-					if edges[i].callerResultIdx == idx {
-						edges[i].paramForwardingEdges = nil
-					}
-				}
-				c.returnForwardingEdges[fn] = edges
+				c.dropReturnEffects(fn, idx)
 			}
 		}
 	}
@@ -325,6 +328,15 @@ func (c *collectedFieldEffects) dropWholeResultParamSources(fn *types.Func, resu
 	for key := range c.summary.returnParamSources[fn] {
 		if key.Result.Idx == result && key.Result.Path.IsRoot() {
 			delete(c.summary.returnParamSources[fn], key)
+		}
+	}
+}
+
+// dropReturnEffects deletes every concrete return effect of fn's result index.
+func (c *collectedFieldEffects) dropReturnEffects(fn *types.Func, result int) {
+	for key := range c.summary.returnEffects[fn] {
+		if key.Idx == result {
+			delete(c.summary.returnEffects[fn], key)
 		}
 	}
 }

--- a/assertion/function/structfieldeffects/testdata/src/go.uber.org/returneffects/paramdependent.go
+++ b/assertion/function/structfieldeffects/testdata/src/go.uber.org/returneffects/paramdependent.go
@@ -73,10 +73,11 @@ func copyValueField(src *Outer) *Outer { // expect_effects: return_param_source:
 	return &Outer{Value: src.Value}
 }
 
-// A result that sometimes constructs and sometimes forwards its parameter carries no sound source;
-// the whole-result source is dropped in close(). (The construct branch's concrete effects remain —
-// their interaction with mixed results is owned by a later fix revision.)
-func mixedConstructOrForward(y *Outer, pick bool) *Outer { // expect_effects: return_effects:0:Mid return_effects:0:Value.Child
+// A result that sometimes constructs and sometimes forwards its parameter carries no sound
+// source and no sound construction shape: the whole-result source AND the construct branch's
+// concrete effects are both dropped after the closures (see dropMixedResultParamSources) —
+// recording either side would mis-attribute the other branch's values.
+func mixedConstructOrForward(y *Outer, pick bool) *Outer { // expect_effects:
 	if pick {
 		return &Outer{}
 	}


### PR DESCRIPTION
A result index that both constructs in-package and wholly forwards a parameter kept its construction branch's concrete nil effects after the mixed drop discarded the param sources. That is the mirror-image false positive: a caller of the forwarding branch sees the construction's omitted fields as nil. Drop every return summary of a mixed result — param sources and concrete effects — a deliberate under-report; field-level sources describe part of a construction and do not conflict.

Detection also moves from "any forwarding edge" to "a closed whole-result source exists", running after both return closures: an edge whose ties can never compose (an argument-less forward) no longer discards sound concrete effects, and a wrapper forwarding a mixed function inherits the conflicting source and effects through the closures, so the per-function drop prunes the wrapper too.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>